### PR TITLE
Feed-forward neural networks that support sub-networks

### DIFF
--- a/deepxde/maps/__init__.py
+++ b/deepxde/maps/__init__.py
@@ -6,4 +6,5 @@ from .opnn import OpNN
 from .pfnn import PFNN
 from .resnet import ResNet
 
+
 __all__ = ["FNN", "MfNN", "OpNN", "PFNN", "ResNet"]

--- a/deepxde/maps/__init__.py
+++ b/deepxde/maps/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from .fnn import FNN
 from .mfnn import MfNN
 from .opnn import OpNN
+from .pfnn import PFNN
 from .resnet import ResNet
 
-
-__all__ = ["FNN", "MfNN", "OpNN", "ResNet"]
+__all__ = ["FNN", "MfNN", "OpNN", "PFNN", "ResNet"]

--- a/deepxde/maps/pfnn.py
+++ b/deepxde/maps/pfnn.py
@@ -27,10 +27,10 @@ class PFNN(FNN):
 
         Args:
             layer_size: Accept nested list. The general structure of the list define the architecture of the neural
-                network (how the layers are connected). If layer_size[i] is int, it represent one layer shared by all the
-                outputs; if layer_size[i] is list, it represent len(layer_size[i]) sub-layers, each of which exclusively
-                used by one output. Note that len(layer_size[i]) should equal to the number of outputs. Every number
-                specify the number of neurons of that layer.
+                network (how the layers are connected). If layer_size[i] is int, it represent one layer shared by all
+                the outputs; if layer_size[i] is list, it represent len(layer_size[i]) sub-layers, each of which
+                exclusively used by one output. Note that len(layer_size[i]) should equal to the number of outputs.
+                Every number specify the number of neurons of that layer.
             activation:
             kernel_initializer:
             regularization:
@@ -74,7 +74,8 @@ class PFNN(FNN):
             if type(self.layer_size[i_layer + 1]) is list:
                 if type(y) is list:
                     # e.g. [8, 8, 8] -> [16, 16, 16]
-                    assert len(self.layer_size[i_layer + 1]) == len(self.layer_size[i_layer])
+                    if not (len(self.layer_size[i_layer + 1]) == len(self.layer_size[i_layer])):
+                        raise ValueError("number of sub-layers should be the same when feed-forwarding")
                     y = [
                         layer_map(y[i_net], self.layer_size[i_layer + 1][i_net], self)
                         for i_net in range(len(self.layer_size[i_layer + 1]))

--- a/deepxde/maps/pfnn.py
+++ b/deepxde/maps/pfnn.py
@@ -86,7 +86,11 @@ class PFNN(FNN):
                 y = layer_map(y, self.layer_size[i_layer + 1], self)
         # output layers
         if isinstance(y, (list, tuple)):
-            # e.g. [3, 3, 3] -> [3]
+            # e.g. [3, 3, 3] -> 3
+            if len(self.layer_size[-2]) != self.layer_size[-1]:
+                raise ValueError(
+                    "Number of sub-layers should be the same as number of outputs"
+                )
             y = [self.dense(y[i_net], 1) for i_net in range(len(y))]
             self.y = tf.concat(y, axis=1)
         else:

--- a/deepxde/maps/pfnn.py
+++ b/deepxde/maps/pfnn.py
@@ -1,0 +1,139 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import math
+
+from . import activations
+from . import initializers
+from . import regularizers
+from .map import Map
+from .. import config
+from ..backend import tf
+from ..utils import timing
+
+
+class PFNN(Map):
+    """Parallel Feed-forward neural networks.
+    """
+
+    def __init__(
+            self,
+            layer_size,
+            activation,
+            kernel_initializer,
+            regularization=None,
+            dropout_rate=0,
+            batch_normalization=None,
+    ):
+        super(PFNN, self).__init__()
+        self.layer_size = layer_size
+        self.activation = activations.get(activation)
+        self.kernel_initializer = initializers.get(kernel_initializer)
+        self.regularizer = regularizers.get(regularization)
+        self.dropout_rate = dropout_rate
+        self.batch_normalization = batch_normalization
+
+    @property
+    def inputs(self):
+        return self.x
+
+    @property
+    def outputs(self):
+        return self.y
+
+    @property
+    def targets(self):
+        return self.y_
+
+    @timing
+    def build(self):
+
+        def layer_map(y, layer_size, net):
+            if net.batch_normalization is None:
+                y = net.dense(y, layer_size, activation=net.activation)
+            elif net.batch_normalization == "before":
+                y = net.dense_batchnorm_v1(y, layer_size)
+            elif net.batch_normalization == "after":
+                y = net.dense_batchnorm_v2(y, layer_size)
+            else:
+                raise ValueError("batch_normalization")
+            if net.dropout_rate > 0:
+                y = tf.layers.dropout(y, rate=net.dropout_rate, training=net.dropout)
+
+            return y
+
+        print("Building feed-forward neural network...")
+        self.x = tf.placeholder(config.real(tf), [None, self.layer_size[0]])
+
+        y = self.x
+        if self._input_transform is not None:
+            y = self._input_transform(y)
+        # hidden layers
+        for i_layer in range(len(self.layer_size) - 2):
+            if type(self.layer_size[i_layer + 1]) is list:
+                if type(self.layer_size[i_layer]) is list:
+                    # e.g. [8, 8, 8] -> [16, 16, 16]
+                    assert len(self.layer_size[i_layer + 1]) == len(self.layer_size[i_layer])
+                    y = [
+                        layer_map(y[i_net], self.layer_size[i_layer + 1][i_net], self)
+                        for i_net in range(len(self.layer_size[i_layer + 1]))
+                    ]
+                else:
+                    # e.g. 64 -> [16, 16, 16]
+                    y = [
+                        layer_map(y, self.layer_size[i_layer + 1][i_net], self)
+                        for i_net in range(len(self.layer_size[i_layer + 1]))
+                    ]
+            else:
+                # e.g. 64 -> 64
+                y = layer_map(y, self.layer_size[i_layer + 1], self)
+        # output layers
+        if type(self.layer_size[-1]) is list:
+            # e.g. [3, 3, 3] -> [1, 1, 1]
+            y = [self.dense(y[i_net], self.layer_size[-1][i_net]) for i_net in range(len(self.layer_size[-1]))]
+            self.y = tf.concat(y, axis=1)
+        else:
+            self.y = self.dense(y, self.layer_size[-1])
+
+        if self._output_transform is not None:
+            self.y = self._output_transform(self.x, self.y)
+
+        self.y_ = tf.placeholder(config.real(tf), [None, self.layer_size[-1]])
+        self.built = True
+
+    def dense(self, inputs, units, activation=None, use_bias=True):
+        return tf.layers.dense(
+            inputs,
+            units,
+            activation=activation,
+            use_bias=use_bias,
+            kernel_initializer=self.kernel_initializer,
+            kernel_regularizer=self.regularizer,
+        )
+
+    @staticmethod
+    def dense_weightnorm(inputs, units, activation=None, use_bias=True):
+        shape = inputs.get_shape().as_list()
+        fan_in = shape[1]
+        W = tf.Variable(tf.random_normal([fan_in, units], stddev=math.sqrt(2 / fan_in)))
+        g = tf.Variable(tf.ones(units))
+        W = tf.nn.l2_normalize(W, axis=0) * g
+        y = tf.matmul(inputs, W)
+        if use_bias:
+            b = tf.Variable(tf.zeros(units))
+            y += b
+        if activation is not None:
+            return activation(y)
+        return y
+
+    def dense_batchnorm_v1(self, inputs, units):
+        # FC - BN - activation
+        y = self.dense(inputs, units, use_bias=False)
+        y = tf.layers.batch_normalization(y, training=self.training)
+        return self.activation(y)
+
+    def dense_batchnorm_v2(self, inputs, units):
+        # FC - activation - BN
+        y = self.dense(inputs, units, activation=self.activation)
+        return tf.layers.batch_normalization(y, training=self.training)

--- a/deepxde/maps/pfnn.py
+++ b/deepxde/maps/pfnn.py
@@ -10,6 +10,8 @@ from ..utils import timing
 
 class PFNN(FNN):
     """Parallel Feed-forward neural networks.
+
+    Feed-forward neural networks that support independent "branches" or sub-network inside the network.
     """
 
     def __init__(
@@ -21,6 +23,20 @@ class PFNN(FNN):
             dropout_rate=0,
             batch_normalization=None,
     ):
+        """
+
+        Args:
+            layer_size: Accept nested list. The general structure of the list define the architecture of the neural
+                network (how the layers are connected). If layer_size[i] is int, it represent one layer shared by all the
+                outputs; if layer_size[i] is list, it represent len(layer_size[i]) sub-layers, each of which exclusively
+                used by one output. Note that len(layer_size[i]) should equal to the number of outputs. Every number
+                specify the number of neurons of that layer.
+            activation:
+            kernel_initializer:
+            regularization:
+            dropout_rate:
+            batch_normalization:
+        """
         super(PFNN, self).__init__(
             layer_size,
             activation,

--- a/deepxde/maps/pfnn.py
+++ b/deepxde/maps/pfnn.py
@@ -70,8 +70,8 @@ class PFNN(FNN):
             y = self._input_transform(y)
         # hidden layers
         for i_layer in range(len(self.layer_size) - 2):
-            if type(self.layer_size[i_layer + 1]) is list:
-                if type(y) is list:
+            if isinstance(self.layer_size[i_layer + 1], list):
+                if isinstance(y, list):
                     # e.g. [8, 8, 8] -> [16, 16, 16]
                     if not (
                         len(self.layer_size[i_layer + 1])
@@ -94,7 +94,7 @@ class PFNN(FNN):
                 # e.g. 64 -> 64
                 y = layer_map(y, self.layer_size[i_layer + 1], self)
         # output layers
-        if type(y) is list:
+        if isinstance(y, list):
             # e.g. [3, 3, 3] -> [3]
             y = [self.dense(y[i_net], 1) for i_net in range(len(y))]
             self.y = tf.concat(y, axis=1)

--- a/deepxde/maps/pfnn.py
+++ b/deepxde/maps/pfnn.py
@@ -19,7 +19,6 @@ class PFNN(FNN):
             if `layer_size[i]` is list, it represent `len(layer_size[i])` sub-layers, each of which exclusively used by one output.
             Note that `len(layer_size[i])` should equal to the number of outputs.
             Every number specify the number of neurons of that layer.
-
     """
 
     def __init__(
@@ -66,9 +65,8 @@ class PFNN(FNN):
             if isinstance(self.layer_size[i_layer + 1], (list, tuple)):
                 if isinstance(y, (list, tuple)):
                     # e.g. [8, 8, 8] -> [16, 16, 16]
-                    if not (
-                        len(self.layer_size[i_layer + 1])
-                        == len(self.layer_size[i_layer])
+                    if len(self.layer_size[i_layer + 1]) != len(
+                        self.layer_size[i_layer]
                     ):
                         raise ValueError(
                             "Number of sub-layers should be the same when feed-forwarding"

--- a/deepxde/maps/pfnn.py
+++ b/deepxde/maps/pfnn.py
@@ -49,19 +49,19 @@ class PFNN(Map):
     @timing
     def build(self):
 
-        def layer_map(y, layer_size, net):
+        def layer_map(_y, layer_size, net):
             if net.batch_normalization is None:
-                y = net.dense(y, layer_size, activation=net.activation)
+                _y = net.dense(_y, layer_size, activation=net.activation)
             elif net.batch_normalization == "before":
-                y = net.dense_batchnorm_v1(y, layer_size)
+                _y = net.dense_batchnorm_v1(_y, layer_size)
             elif net.batch_normalization == "after":
-                y = net.dense_batchnorm_v2(y, layer_size)
+                _y = net.dense_batchnorm_v2(_y, layer_size)
             else:
                 raise ValueError("batch_normalization")
             if net.dropout_rate > 0:
-                y = tf.layers.dropout(y, rate=net.dropout_rate, training=net.dropout)
+                _y = tf.layers.dropout(_y, rate=net.dropout_rate, training=net.dropout)
 
-            return y
+            return _y
 
         print("Building feed-forward neural network...")
         self.x = tf.placeholder(config.real(tf), [None, self.layer_size[0]])
@@ -72,7 +72,7 @@ class PFNN(Map):
         # hidden layers
         for i_layer in range(len(self.layer_size) - 2):
             if type(self.layer_size[i_layer + 1]) is list:
-                if type(self.layer_size[i_layer]) is list:
+                if type(y) is list:
                     # e.g. [8, 8, 8] -> [16, 16, 16]
                     assert len(self.layer_size[i_layer + 1]) == len(self.layer_size[i_layer])
                     y = [
@@ -80,7 +80,7 @@ class PFNN(Map):
                         for i_net in range(len(self.layer_size[i_layer + 1]))
                     ]
                 else:
-                    # e.g. 64 -> [16, 16, 16]
+                    # e.g. 64 -> [8, 8, 8]
                     y = [
                         layer_map(y, self.layer_size[i_layer + 1][i_net], self)
                         for i_net in range(len(self.layer_size[i_layer + 1]))
@@ -89,9 +89,9 @@ class PFNN(Map):
                 # e.g. 64 -> 64
                 y = layer_map(y, self.layer_size[i_layer + 1], self)
         # output layers
-        if type(self.layer_size[-1]) is list:
-            # e.g. [3, 3, 3] -> [1, 1, 1]
-            y = [self.dense(y[i_net], self.layer_size[-1][i_net]) for i_net in range(len(self.layer_size[-1]))]
+        if type(y) is list:
+            # e.g. [3, 3, 3] -> [3]
+            y = [self.dense(y[i_net], 1) for i_net in range(len(y))]
             self.y = tf.concat(y, axis=1)
         else:
             self.y = self.dense(y, self.layer_size[-1])

--- a/deepxde/maps/pfnn.py
+++ b/deepxde/maps/pfnn.py
@@ -11,14 +11,15 @@ from ..utils import timing
 class PFNN(FNN):
     """Parallel Feed-forward neural networks.
 
-    Args:
-    layer_size: A nested list to define the architecture of the neural network (how the layers are connected).
-        If `layer_size[i]` is int, it represent one layer shared by all the outputs;
-        if `layer_size[i]` is list, it represent `len(layer_size[i])` sub-layers, each of which exclusively used by one output.
-        Note that `len(layer_size[i])` should equal to the number of outputs.
-        Every number specify the number of neurons of that layer.
-
     Feed-forward neural networks that support independent "branches" or sub-network inside the network.
+
+    Args:
+        layer_size: A nested list to define the architecture of the neural network (how the layers are connected).
+            If `layer_size[i]` is int, it represent one layer shared by all the outputs;
+            if `layer_size[i]` is list, it represent `len(layer_size[i])` sub-layers, each of which exclusively used by one output.
+            Note that `len(layer_size[i])` should equal to the number of outputs.
+            Every number specify the number of neurons of that layer.
+
     """
 
     def __init__(

--- a/deepxde/maps/pfnn.py
+++ b/deepxde/maps/pfnn.py
@@ -15,13 +15,13 @@ class PFNN(FNN):
     """
 
     def __init__(
-            self,
-            layer_size,
-            activation,
-            kernel_initializer,
-            regularization=None,
-            dropout_rate=0,
-            batch_normalization=None,
+        self,
+        layer_size,
+        activation,
+        kernel_initializer,
+        regularization=None,
+        dropout_rate=0,
+        batch_normalization=None,
     ):
         """
 
@@ -48,7 +48,6 @@ class PFNN(FNN):
 
     @timing
     def build(self):
-
         def layer_map(_y, layer_size, net):
             if net.batch_normalization is None:
                 _y = net.dense(_y, layer_size, activation=net.activation)
@@ -74,8 +73,13 @@ class PFNN(FNN):
             if type(self.layer_size[i_layer + 1]) is list:
                 if type(y) is list:
                     # e.g. [8, 8, 8] -> [16, 16, 16]
-                    if not (len(self.layer_size[i_layer + 1]) == len(self.layer_size[i_layer])):
-                        raise ValueError("number of sub-layers should be the same when feed-forwarding")
+                    if not (
+                        len(self.layer_size[i_layer + 1])
+                        == len(self.layer_size[i_layer])
+                    ):
+                        raise ValueError(
+                            "number of sub-layers should be the same when feed-forwarding"
+                        )
                     y = [
                         layer_map(y[i_net], self.layer_size[i_layer + 1][i_net], self)
                         for i_net in range(len(self.layer_size[i_layer + 1]))


### PR DESCRIPTION
The code was modified from @lululxvi 's deepxde/maps/fnn.py, which support users to define independent hidden layers for each unknown variables (output)

The API is the same as deepxde/maps/fnn.py, except that the `layer_size`accept nested list. The general structure of the list define the architecture of the neural network (how the layers are connected). If `layer_size[i]` is int, it represent one layer shared by all the outputs; if `layer_size[i]` is list, it represent `len(layer_size[i])` sub-layers, each of which exclusively used by one output. Note that `len(layer_size[i])` should equal to the number of outputs.  Every number specify the number of neurons of that layer.

example:
```python
        layer_size = [3] + \
                     [config.num_neurons] * config.num_common_hidden_layers + \
                     [[config.num_neurons] * 3] * config.num_independent_hidden_layers + \
                     [3]
        net = dde.maps.PFNN(layer_size, config.activation, config.initializer)
```

Might be useful for #93 