### PR TITLE
Hard constraint on BC: simplify the code and output

### DIFF
--- a/deepxde/data/pde.py
+++ b/deepxde/data/pde.py
@@ -134,7 +134,7 @@ class PDE(Data):
     def bc_points(self):
         x_bcs = [bc.collocation_points(self.train_x) for bc in self.bcs]
         self.num_bcs = list(map(len, x_bcs))
-        return np.vstack(x_bcs)
+        return np.vstack(x_bcs) if x_bcs else np.empty([0, self.train_x.shape[-1]])
 
     def test_points(self):
         return self.geom.uniform_points(self.num_test, True)

--- a/examples/diffusion_1d_exactBC.py
+++ b/examples/diffusion_1d_exactBC.py
@@ -27,15 +27,11 @@ def main():
     timedomain = dde.geometry.TimeDomain(0, 1)
     geomtime = dde.geometry.GeometryXTime(geom, timedomain)
 
-    bc = dde.DirichletBC(geomtime, func, lambda _, on_boundary: on_boundary)
-    ic = dde.IC(geomtime, func, lambda _, on_initial: on_initial)
     data = dde.data.TimePDE(
         geomtime,
         pde,
-        [bc, ic],
+        [],
         num_domain=40,
-        num_boundary=1,
-        num_initial=1,
         solution=func,
         num_test=10000,
     )


### PR DESCRIPTION
Support set `deepxde.data.pde.PDE.bcs` as empty list.

Previously, even when hard constraint is applied, `num_boundary` still need to be set to above 0 and `deepxde.data.pde.PDE.bcs` still need to be specified, which might cause inconvenience and confusion. Now the code is modified so that `deepxde.data.pde.PDE.bcs` can be simply set to `[]` and `num_boundary` is not required as optional parameter.
