### PR TITLE
Changing `Pointset` to `PointSetBC` for training using exact solution.

### DIFF
--- a/deepxde/__init__.py
+++ b/deepxde/__init__.py
@@ -12,6 +12,7 @@ from .boundary_conditions import NeumannBC
 from .boundary_conditions import OperatorBC
 from .boundary_conditions import PeriodicBC
 from .boundary_conditions import RobinBC
+from .boundary_conditions import PointSetBC
 from .initial_condition import IC
 from .model import Model
 from .postprocessing import saveplot
@@ -31,6 +32,7 @@ __all__ = [
     "OperatorBC",
     "PeriodicBC",
     "RobinBC",
+    "PointSetBC",
     "IC",
     "Model",
     "saveplot",

--- a/deepxde/boundary_conditions.py
+++ b/deepxde/boundary_conditions.py
@@ -159,7 +159,7 @@ class PointSet(object):
 
 
 class PointSetBC(object):
-    """Boundary Condition for a set of points.
+    """Dirichlet boundary condition for a set of points.
     Compare the output (that associates with `points`) with `values` (target data).
 
     Args:
@@ -168,13 +168,13 @@ class PointSetBC(object):
         component: The output component satisfying this BC.
     """
 
-    def __init__(self, points, values, component):
+    def __init__(self, points, values, component=0):
         self.points = np.array(points)
         if not isinstance(values, numbers.Number) and values.shape[1] != 1:
             raise RuntimeError(
                 "PointSetBC should output 1D values. Use argument 'component' for different components."
             )
-        self.values = np.array(values)
+        self.values = values
         self.component = component
 
     def collocation_points(self, X):

--- a/deepxde/boundary_conditions.py
+++ b/deepxde/boundary_conditions.py
@@ -136,6 +136,28 @@ class OperatorBC(BC):
         return self.func(inputs, outputs, X)[beg:end]
 
 
+class PointSet(object):
+    """A set of points.
+    """
+
+    def __init__(self, points):
+        self.points = np.array(points)
+
+    def inside(self, x):
+        return np.any(np.all(np.isclose(x, self.points), axis=1))
+
+    def values_to_func(self, values):
+        zero = np.zeros(len(values[0]))
+
+        def func(x):
+            if not self.inside(x):
+                return zero
+            idx = np.argwhere(np.all(np.isclose(x, self.points), axis=1))[0, 0]
+            return values[idx]
+
+        return lambda X: np.array(list(map(func, X)))
+
+
 class PointSetBC(object):
     """Boundary Condition for a set of points.
     Compare the output (that associates with `points`) with `values` (target data).

--- a/deepxde/boundary_conditions.py
+++ b/deepxde/boundary_conditions.py
@@ -139,6 +139,11 @@ class OperatorBC(BC):
 class PointSetBC(object):
     """Boundary Condition for a set of points.
     Compare the output (that associates with `points`) with `values` (target data).
+
+    Args:
+        points: An array of points where the corresponding target values are known and used for training.
+        values: An array of values that gives the exact solution of the problem.
+        component: The output component satisfying this BC.
     """
 
     def __init__(self, points, values, component):

--- a/examples/Lorenz_inverse.py
+++ b/examples/Lorenz_inverse.py
@@ -46,9 +46,9 @@ def main():
 
     # Get the train data
     observe_t, ob_y = gen_traindata()
-    observe_y0 = dde.bc.PointSetBC(observe_t, ob_y[:, 0:1], component=0)
-    observe_y1 = dde.bc.PointSetBC(observe_t, ob_y[:, 1:2], component=1)
-    observe_y2 = dde.bc.PointSetBC(observe_t, ob_y[:, 2:3], component=2)
+    observe_y0 = dde.PointSetBC(observe_t, ob_y[:, 0:1], component=0)
+    observe_y1 = dde.PointSetBC(observe_t, ob_y[:, 1:2], component=1)
+    observe_y2 = dde.PointSetBC(observe_t, ob_y[:, 2:3], component=2)
 
     data = dde.data.PDE(
         geom,
@@ -56,6 +56,7 @@ def main():
         [ic1, ic2, ic3, observe_y0, observe_y1, observe_y2],
         num_domain=400,
         num_boundary=2,
+        anchors=observe_t,
     )
 
     net = dde.maps.FNN([1] + [40] * 3 + [3], "tanh", "Glorot uniform")

--- a/examples/Lorenz_inverse.py
+++ b/examples/Lorenz_inverse.py
@@ -46,17 +46,9 @@ def main():
 
     # Get the train data
     observe_t, ob_y = gen_traindata()
-    ptset = dde.bc.PointSet(observe_t)
-    inside = lambda x, _: ptset.inside(x)
-    observe_y0 = dde.DirichletBC(
-        geom, ptset.values_to_func(ob_y[:, 0:1]), inside, component=0
-    )
-    observe_y1 = dde.DirichletBC(
-        geom, ptset.values_to_func(ob_y[:, 1:2]), inside, component=1
-    )
-    observe_y2 = dde.DirichletBC(
-        geom, ptset.values_to_func(ob_y[:, 2:3]), inside, component=2
-    )
+    observe_y0 = dde.bc.PointSetBC(observe_t, ob_y[:, 0:1], component=0)
+    observe_y1 = dde.bc.PointSetBC(observe_t, ob_y[:, 1:2], component=1)
+    observe_y2 = dde.bc.PointSetBC(observe_t, ob_y[:, 2:3], component=2)
 
     data = dde.data.PDE(
         geom,
@@ -64,7 +56,6 @@ def main():
         [ic1, ic2, ic3, observe_y0, observe_y1, observe_y2],
         num_domain=400,
         num_boundary=2,
-        anchors=observe_t,
     )
 
     net = dde.maps.FNN([1] + [40] * 3 + [3], "tanh", "Glorot uniform")

--- a/examples/diffusion_1d_inverse.py
+++ b/examples/diffusion_1d_inverse.py
@@ -32,7 +32,7 @@ def main():
     ic = dde.IC(geomtime, func, lambda _, on_initial: on_initial)
 
     observe_x = np.vstack((np.linspace(-1, 1, num=10), np.full((10), 1))).T
-    observe_y = dde.bc.PointSetBC(observe_x, func(observe_x), component=0)
+    observe_y = dde.PointSetBC(observe_x, func(observe_x), component=0)
 
     data = dde.data.TimePDE(
         geomtime,
@@ -41,6 +41,7 @@ def main():
         num_domain=40,
         num_boundary=20,
         num_initial=10,
+        anchors=observe_x,
         solution=func,
         num_test=10000,
     )

--- a/examples/diffusion_1d_inverse.py
+++ b/examples/diffusion_1d_inverse.py
@@ -32,10 +32,7 @@ def main():
     ic = dde.IC(geomtime, func, lambda _, on_initial: on_initial)
 
     observe_x = np.vstack((np.linspace(-1, 1, num=10), np.full((10), 1))).T
-    ptset = dde.bc.PointSet(observe_x)
-    observe_y = dde.DirichletBC(
-        geomtime, ptset.values_to_func(func(observe_x)), lambda x, _: ptset.inside(x)
-    )
+    observe_y = dde.bc.PointSetBC(observe_x, func(observe_x), component=0)
 
     data = dde.data.TimePDE(
         geomtime,
@@ -44,7 +41,6 @@ def main():
         num_domain=40,
         num_boundary=20,
         num_initial=10,
-        anchors=observe_x,
         solution=func,
         num_test=10000,
     )

--- a/examples/reaction_inverse.py
+++ b/examples/reaction_inverse.py
@@ -53,13 +53,8 @@ def main():
     ic2 = dde.IC(geomtime, fun_init, lambda _, on_initial: on_initial, component=1)
 
     observe_x, Ca, Cb = gen_traindata()
-    ptset = dde.bc.PointSet(observe_x)
-    observe_y1 = dde.DirichletBC(
-        geomtime, ptset.values_to_func(Ca), lambda x, _: ptset.inside(x), component=0
-    )
-    observe_y2 = dde.DirichletBC(
-        geomtime, ptset.values_to_func(Cb), lambda x, _: ptset.inside(x), component=1
-    )
+    observe_y1 = dde.bc.PointSetBC(observe_x, Ca, component=0)
+    observe_y2 = dde.bc.PointSetBC(observe_x, Cb, component=1)
 
     data = dde.data.TimePDE(
         geomtime,
@@ -68,7 +63,6 @@ def main():
         num_domain=2000,
         num_boundary=100,
         num_initial=100,
-        anchors=observe_x,
         num_test=50000,
     )
     net = dde.maps.FNN([2] + [20] * 3 + [2], "tanh", "Glorot uniform")

--- a/examples/reaction_inverse.py
+++ b/examples/reaction_inverse.py
@@ -53,8 +53,8 @@ def main():
     ic2 = dde.IC(geomtime, fun_init, lambda _, on_initial: on_initial, component=1)
 
     observe_x, Ca, Cb = gen_traindata()
-    observe_y1 = dde.bc.PointSetBC(observe_x, Ca, component=0)
-    observe_y2 = dde.bc.PointSetBC(observe_x, Cb, component=1)
+    observe_y1 = dde.PointSetBC(observe_x, Ca, component=0)
+    observe_y2 = dde.PointSetBC(observe_x, Cb, component=1)
 
     data = dde.data.TimePDE(
         geomtime,
@@ -63,6 +63,7 @@ def main():
         num_domain=2000,
         num_boundary=100,
         num_initial=100,
+        anchors=observe_x,
         num_test=50000,
     )
     net = dde.maps.FNN([2] + [20] * 3 + [2], "tanh", "Glorot uniform")


### PR DESCRIPTION
## Aim
This modification is aim to improve the execution speed of problems that need training data (ground truth, exact solution, numerical solution, `y_train`).

## Background
For the original implementation, take `examples/diffusion_1d_inverse.py` for example, for lines https://github.com/lululxvi/deepxde/blob/3d1edd0529486409fec2c2dadf8775b6684d9bd0/examples/diffusion_1d_inverse.py#L34-L38
`deepxde.boundary_conditions.PointSet` computes the loss by comparing outputs with ground truth, when doing so, since the ground true typically only known on some `x`, the code match each `x` used for training with a list of points where ground truth is known, this maybe slow when number of points is large.

## Modification
The modification improve the code by directly compute loss using ordered (one-to-one match) pairs of outputs and ground truth.

P.S. I am not familiar with `deepxde.data.fpde.FPDE` and how to use git version control with jupyter notebook, so I leave them for the author to update.