### PR TITLE
Add `CITATION.cff`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,6 +20,6 @@ keywords:
   - "deep learning"
   - "physics-informed neural networks"
   - "scientific machine learning"
-
+version: "0.13.6"
 repository-code: "https://github.com/lululxvi/deepxde"
 title: "DeepXDE: A deep learning library for solving differential equations"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,25 @@
+cff-version: 1.1.0
+message: "If you use DeepXDE for academic research, you are encouraged to cite the following paper:"
+authors: 
+- family-names: Lu
+  given-names: Lu
+- family-names: Meng
+  given-names: Xuhui
+- family-names: Mao
+  given-names: Zhiping
+- family-names: Karniadakis
+  given-names: George Em
+
+journal: "SIAM Review"
+date-released: 2021-02-04
+doi: 10.1137/19M1274067
+keywords: 
+  - "education software"
+  - "DeepXDE"
+  - "differential equations"
+  - "deep learning"
+  - "physics-informed neural networks"
+  - "scientific machine learning"
+
+repository-code: "https://github.com/lululxvi/deepxde"
+title: "DeepXDE: A deep learning library for solving differential equations"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,28 +1,32 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
 cff-version: 1.2.0
-title: "DeepXDE: A deep learning library for solving differential equations"
-message: "If you use DeepXDE for academic research, you are encouraged to cite the following paper:"
+title: >-
+  DeepXDE: A deep learning library for solving
+  differential equations
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
 type: software
 authors:
-- family-names: Lu
-  given-names: Lu
-  orchid: "https://orcid.org/0000-0002-5476-5768"
-- family-names: Meng
-  given-names: Xuhui
-- family-names: Mao
-  given-names: Zhiping
-- family-names: Karniadakis
-  given-names: George Em
-  orchid: "https://orcid.org/0000-0002-9713-7120"
-
-journal: "SIAM Review"
-date-released: 2021-02-04
-doi: 10.1137/19M1274067
-keywords: 
-  - "education software"
-  - "DeepXDE"
-  - "differential equations"
-  - "deep learning"
-  - "physics-informed neural networks"
-  - "scientific machine learning"
-version: "0.13.6"
-repository-code: "https://github.com/lululxvi/deepxde"
+  - given-names: Lu
+    orcid: 'https://orcid.org/0000-0002-5476-5768'
+    family-names: Lu
+    affiliation: Massachusetts Institute of Technology
+  - given-names: Xuhui
+    family-names: Meng
+    affiliation: Brown University
+  - family-names: Mao
+    given-names: Zhiping
+    affiliation: Xiamen University
+  - family-names: Karniadakis
+    given-names: George Em
+    orcid: 'https://orcid.org/0000-0002-9713-7120'
+    affiliation: Brown University
+identifiers:
+  - type: doi
+    value: 10.1137/19M1274067
+repository-code: 'https://github.com/lululxvi/deepxde'
+url: 'https://deepxde.readthedocs.io'
+license: Apache-2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,14 +1,18 @@
-cff-version: 1.1.0
+cff-version: 1.2.0
+title: "DeepXDE: A deep learning library for solving differential equations"
 message: "If you use DeepXDE for academic research, you are encouraged to cite the following paper:"
-authors: 
+type: software
+authors:
 - family-names: Lu
   given-names: Lu
+  orchid: "https://orcid.org/0000-0002-5476-5768"
 - family-names: Meng
   given-names: Xuhui
 - family-names: Mao
   given-names: Zhiping
 - family-names: Karniadakis
   given-names: George Em
+  orchid: "https://orcid.org/0000-0002-9713-7120"
 
 journal: "SIAM Review"
 date-released: 2021-02-04
@@ -22,4 +26,3 @@ keywords:
   - "scientific machine learning"
 version: "0.13.6"
 repository-code: "https://github.com/lululxvi/deepxde"
-title: "DeepXDE: A deep learning library for solving differential equations"


### PR DESCRIPTION
Closes #423 

## Additions
- Added the `CITATIONS.cff` file which will render a `"Cite this repository"` dropdown menu in the `About` section of the repository.

An orcid URL can also be added for each author but I couldn't find any in the repository, I'll be happy to add them if someone can comment them down.

Apologies if I misspelled any name.

The working dropdown can be viewed [here](https://github.com/Saransh-cpp/deepxde/tree/add-citation.cff).

