### PR TITLE
Remove redundant code from pde.py

### DIFF
--- a/deepxde/data/pde.py
+++ b/deepxde/data/pde.py
@@ -193,15 +193,7 @@ class PDE(Data):
             self.anchors = anchors
         else:
             self.anchors = np.vstack((anchors, self.anchors))
-        self.train_x_all = np.vstack((anchors, self.train_x_all))
-        self.train_x = self.bc_points()
-        if self.pde is not None:
-            self.train_x = np.vstack((self.train_x, self.train_x_all))
-        self.train_y = self.soln(self.train_x) if self.soln else None
-        if self.auxiliary_var_fn is not None:
-            self.train_aux_vars = self.auxiliary_var_fn(self.train_x).astype(
-                config.real(np)
-            )
+        self.train_next_batch()
 
     def train_points(self):
         X = np.empty((0, self.geom.dim), dtype=config.real(np))


### PR DESCRIPTION
We don't need to update train points in `add_anchor` since we do it in `train_next_batch`, just like what we did in `__init__`