### PR TITLE
stop training if nan in loss_train or loss_test

### DIFF
--- a/deepxde/model.py
+++ b/deepxde/model.py
@@ -384,6 +384,9 @@ class Model(object):
             self.train_state.epoch += 1
             self.train_state.step += 1
             if self.train_state.step % display_every == 0 or i + 1 == epochs:
+                if (np.isnan(self.train_state.loss_train).any()) or (np.isnan(self.train_state.loss_test).any()):
+                    self.stop_training = True
+                    break
                 self._test()
 
             self.callbacks.on_batch_end()

--- a/deepxde/model.py
+++ b/deepxde/model.py
@@ -384,12 +384,6 @@ class Model(object):
             self.train_state.epoch += 1
             self.train_state.step += 1
             if self.train_state.step % display_every == 0 or i + 1 == epochs:
-                if (
-                    np.isnan(self.train_state.loss_train).any()
-                    or np.isnan(self.train_state.loss_test).any()
-                ):
-                    self.stop_training = True
-                    break
                 self._test()
 
             self.callbacks.on_batch_end()
@@ -516,6 +510,12 @@ class Model(object):
             self.train_state.loss_test,
             self.train_state.metrics_test,
         )
+
+        if (
+            np.isnan(self.train_state.loss_train).any()
+            or np.isnan(self.train_state.loss_test).any()
+        ):
+            self.stop_training = True
         display.training_display(self.train_state)
 
     def predict(self, x, operator=None, callbacks=None):

--- a/deepxde/model.py
+++ b/deepxde/model.py
@@ -384,7 +384,10 @@ class Model(object):
             self.train_state.epoch += 1
             self.train_state.step += 1
             if self.train_state.step % display_every == 0 or i + 1 == epochs:
-                if (np.isnan(self.train_state.loss_train).any()) or (np.isnan(self.train_state.loss_test).any()):
+                if (
+                    np.isnan(self.train_state.loss_train).any()
+                    or np.isnan(self.train_state.loss_test).any()
+                ):
                     self.stop_training = True
                     break
                 self._test()


### PR DESCRIPTION
Hi, it happens sometimes (e.g. when using single precision GPUs) that the loss returns nan values during training.
I added these lines to check for each "display_every" whether there are nans in loss_train or loss_test, in order stop training the model directly.
Are you ok with this procedure? 
Paul
