### PR TITLE
Monitor testing loss in EarlyStopping

### DIFF
--- a/deepxde/callbacks.py
+++ b/deepxde/callbacks.py
@@ -156,7 +156,7 @@ class ModelCheckpoint(Callback):
 
 
 class EarlyStopping(Callback):
-    """Stop training when a monitored quantity (training loss or testing_loss) has stopped improving.
+    """Stop training when a monitored quantity (training or testing loss) has stopped improving.
     Only checked at validation step according to ``display_every`` in ``Model.train``.
 
     Args:
@@ -173,9 +173,7 @@ class EarlyStopping(Callback):
         Either 'loss_train' or 'loss_test'
     """
 
-    def __init__(
-        self, min_delta=0, patience=0, baseline=None, monitored_function="loss_train"
-    ):
+    def __init__(self, min_delta=0, patience=0, baseline=None, monitored_function = 'loss_train'):
         super(EarlyStopping, self).__init__()
 
         self.baseline = baseline
@@ -213,12 +211,14 @@ class EarlyStopping(Callback):
             print("Epoch {}: early stopping".format(self.stopped_epoch))
 
     def get_monitor_value(self):
-        if self.monitored_function == "loss_train":
+        if self.monitored_function == 'loss_train':
             result = sum(self.model.train_state.loss_train)
-        elif self.monitored_function == "loss_test":
+        elif self.monitored_function == 'loss_test':
             result = sum(self.model.train_state.loss_test)
         else:
-            raise ValueError("The specified monitor function is incorrect.")
+            raise ValueError(
+                    "The specified monitor function is incorrect."
+                )
 
         return result
 

--- a/deepxde/callbacks.py
+++ b/deepxde/callbacks.py
@@ -169,16 +169,14 @@ class EarlyStopping(Callback):
         baseline: Baseline value for the monitored quantity to reach.
             Training will stop if the model doesn't show improvement
             over the baseline.
-        monitored_function: The loss function that is monitored. Either 'loss_train' or 'loss_test'
+        monitor: The loss function that is monitored. Either 'loss_train' or 'loss_test'
     """
 
-    def __init__(
-        self, min_delta=0, patience=0, baseline=None, monitored_function="loss_train"
-    ):
+    def __init__(self, min_delta=0, patience=0, baseline=None, monitor="loss_train"):
         super(EarlyStopping, self).__init__()
 
         self.baseline = baseline
-        self.monitored_function = monitored_function
+        self.monitor = monitor
         self.patience = patience
         self.min_delta = min_delta
         self.wait = 0
@@ -212,9 +210,9 @@ class EarlyStopping(Callback):
             print("Epoch {}: early stopping".format(self.stopped_epoch))
 
     def get_monitor_value(self):
-        if self.monitored_function == "loss_train":
+        if self.monitor == "loss_train":
             result = sum(self.model.train_state.loss_train)
-        elif self.monitored_function == "loss_test":
+        elif self.monitor == "loss_test":
             result = sum(self.model.train_state.loss_test)
         else:
             raise ValueError("The specified monitor function is incorrect.")

--- a/deepxde/callbacks.py
+++ b/deepxde/callbacks.py
@@ -169,11 +169,12 @@ class EarlyStopping(Callback):
         baseline: Baseline value for the monitored quantity to reach.
             Training will stop if the model doesn't show improvement
             over the baseline.
-        monitored_function: The loss function that is monitored.
-        Either 'loss_train' or 'loss_test'
+        monitored_function: The loss function that is monitored. Either 'loss_train' or 'loss_test'
     """
 
-    def __init__(self, min_delta=0, patience=0, baseline=None, monitored_function = 'loss_train'):
+    def __init__(
+        self, min_delta=0, patience=0, baseline=None, monitored_function="loss_train"
+    ):
         super(EarlyStopping, self).__init__()
 
         self.baseline = baseline
@@ -211,14 +212,12 @@ class EarlyStopping(Callback):
             print("Epoch {}: early stopping".format(self.stopped_epoch))
 
     def get_monitor_value(self):
-        if self.monitored_function == 'loss_train':
+        if self.monitored_function == "loss_train":
             result = sum(self.model.train_state.loss_train)
-        elif self.monitored_function == 'loss_test':
+        elif self.monitored_function == "loss_test":
             result = sum(self.model.train_state.loss_test)
         else:
-            raise ValueError(
-                    "The specified monitor function is incorrect."
-                )
+            raise ValueError("The specified monitor function is incorrect.")
 
         return result
 

--- a/deepxde/callbacks.py
+++ b/deepxde/callbacks.py
@@ -156,7 +156,7 @@ class ModelCheckpoint(Callback):
 
 
 class EarlyStopping(Callback):
-    """Stop training when a monitored quantity (training loss) has stopped improving.
+    """Stop training when a monitored quantity (training loss or testing_loss) has stopped improving.
     Only checked at validation step according to ``display_every`` in ``Model.train``.
 
     Args:
@@ -169,12 +169,17 @@ class EarlyStopping(Callback):
         baseline: Baseline value for the monitored quantity to reach.
             Training will stop if the model doesn't show improvement
             over the baseline.
+        monitored_function: The loss function that is monitored.
+        Either 'loss_train' or 'loss_test'
     """
 
-    def __init__(self, min_delta=0, patience=0, baseline=None):
+    def __init__(
+        self, min_delta=0, patience=0, baseline=None, monitored_function="loss_train"
+    ):
         super(EarlyStopping, self).__init__()
 
         self.baseline = baseline
+        self.monitored_function = monitored_function
         self.patience = patience
         self.min_delta = min_delta
         self.wait = 0
@@ -208,7 +213,14 @@ class EarlyStopping(Callback):
             print("Epoch {}: early stopping".format(self.stopped_epoch))
 
     def get_monitor_value(self):
-        return sum(self.model.train_state.loss_train)
+        if self.monitored_function == "loss_train":
+            result = sum(self.model.train_state.loss_train)
+        elif self.monitored_function == "loss_test":
+            result = sum(self.model.train_state.loss_test)
+        else:
+            raise ValueError("The specified monitor function is incorrect.")
+
+        return result
 
 
 class Timer(Callback):


### PR DESCRIPTION
Hi, 
I modified slightly the EarlySopping to monitor either the training or testing loss. 
I noticed that it is sometimes more preferable to monitor the testing loss than the training loss, hence the changes.

Paul