### PR TITLE
Pytorch clears gradients in output transform

### DIFF
--- a/deepxde/model.py
+++ b/deepxde/model.py
@@ -265,6 +265,8 @@ class Model:
                 else:
                     inputs = torch.as_tensor(inputs)
                     inputs.requires_grad_()
+            # Clear cached Jacobians and Hessians.
+            grad.clear()
             return self.net(inputs)
 
         def outputs_losses(training, inputs, targets, losses_fn):


### PR DESCRIPTION
Pytorch backend would not clear gradients in the output transform. This would cause OOM errors when running many output transforms in series.