### PR TITLE
[Bug fix] use bkd.stack instead of bkd.concat in convert_to_array function

### DIFF
--- a/deepxde/backend/backend.py
+++ b/deepxde/backend/backend.py
@@ -204,6 +204,18 @@ def concat(values, axis):
     """
 
 
+def stack(values, axis):
+    """Returns the stack of the input tensors along the given dim.
+
+    Args:
+        values (list or tuple of Tensor). The input tensors in list or tuple.
+        axis (int). The stacking dim.
+
+    Returns:
+        Tensor: Stacked tensor.
+    """
+
+
 def expand_dims(tensor, axis):
     """Expand dim for tensor along given axis.
 

--- a/deepxde/backend/paddle/tensor.py
+++ b/deepxde/backend/paddle/tensor.py
@@ -90,6 +90,10 @@ def concat(values, axis):
     return paddle.concat(values, axis=axis)
 
 
+def stack(values, axis):
+    return paddle.stack(values, axis=axis)
+
+
 def expand_dims(tensor, axis):
     return paddle.unsqueeze(tensor, axis=axis)
 

--- a/deepxde/backend/pytorch/tensor.py
+++ b/deepxde/backend/pytorch/tensor.py
@@ -98,6 +98,10 @@ def concat(values, axis):
     return torch.cat(values, axis)
 
 
+def stack(values, axis):
+    return torch.stack(values, axis)
+
+
 def expand_dims(tensor, axis):
     return torch.unsqueeze(tensor, axis)
 

--- a/deepxde/backend/tensorflow_compat_v1/tensor.py
+++ b/deepxde/backend/tensorflow_compat_v1/tensor.py
@@ -108,6 +108,10 @@ def concat(values, axis):
     return tf.concat(values, axis)
 
 
+def stack(values, axis):
+    return tf.stack(values, axis)
+
+
 def expand_dims(tensor, axis):
     return tf.expand_dims(tensor, axis)
 

--- a/deepxde/utils/array_ops_compat.py
+++ b/deepxde/utils/array_ops_compat.py
@@ -14,7 +14,11 @@ def istensorlist(values):
 def convert_to_array(value):
     """Convert a list of numpy arrays or tensors to a numpy array or a tensor."""
     if istensorlist(value):
-        return bkd.concat(value, axis=0)
+        # TODO: use concat instead of stack as paddle now use shape [1,]
+        # for 0-D tensor, it will be solved soon.
+        if bkd.backend_name == "paddle":
+            return bkd.concat(value, axis=0)
+        return bkd.stack(value, axis=0)
     value = np.array(value)
     if value.dtype != config.real(np):
         return value.astype(config.real(np))


### PR DESCRIPTION
1. change `bkd.concat` to `bkd.stack` for other backend, because paddle now is using shape `[1]` for 0-D tensor, and other backend use shape `[]` for 0-Dtensor, and 0-D tensor can not be concatenated, or will raise an error like `tensorflow.python.framework.errors_impl.InvalidArgumentError: Can't concatenate scalars ` in tensorflow.compat.v1
