### PR TITLE
 Allow specifying amount of boundary condition test points 

### DIFF
--- a/docs/demos/pinn_forward/Kovasznay.flow.rst
+++ b/docs/demos/pinn_forward/Kovasznay.flow.rst
@@ -110,7 +110,7 @@ Now, we have specified the geometry, PDE residual, and boundary condition. We th
         [boundary_condition_u, boundary_condition_v, boundary_condition_right_p],
         num_domain=2601,
         num_boundary=400,
-        num_test=100000,
+        num_test_domain=100000,
     )
     
 The training residual points imside the domain is 2601, and the number of training points sampled on the boundary is 400. 100000 test points were used in the ``PDE``.

--- a/docs/demos/pinn_forward/diffusion.1d.exactBC.rst
+++ b/docs/demos/pinn_forward/diffusion.1d.exactBC.rst
@@ -67,7 +67,7 @@ Now, we have specified the geometry and the PDE residual. However, in order to a
 
 .. code-block:: python
 
-    data = dde.data.TimePDE(geomtime, pde, [], num_domain=40, solution=func, num_test=10000)
+    data = dde.data.TimePDE(geomtime, pde, [], num_domain=40, solution=func, num_test_domain=10000)
 
 The number 40 is the number of training residual points sampled inside the domain. 10000 points for testing the PDE residual.
 

--- a/docs/demos/pinn_forward/diffusion.1d.resample.rst
+++ b/docs/demos/pinn_forward/diffusion.1d.resample.rst
@@ -83,7 +83,7 @@ Now, we have specified the geometry, the PDE residual and the boundary/initial c
         num_initial=10,
         train_distribution="pseudo",
         solution=func,
-        num_test=10000,
+        num_test_domain=10000,
     )
 
 The number 40 is the number of training residual points sampled inside the domain, and the number 20 is the number of training points sampled on the boundary (the left and right endpoints of the interval). We also include 10 initial residual points for the initial conditions and 10000 points for testing the PDE residual. The argument ``train_distribution="pseudo"`` means that the sample training points follows a pseudo-random distribution.

--- a/docs/demos/pinn_forward/diffusion.1d.rst
+++ b/docs/demos/pinn_forward/diffusion.1d.rst
@@ -82,7 +82,7 @@ Now, we have specified the geometry, the PDE residual and the boundary/initial c
         num_boundary=20,
         num_initial=10,
         solution=func,
-        num_test=10000,
+        num_test_domain=10000,
     )
 
 The number 40 is the number of training residual points sampled inside the domain, and the number 20 is the number of training points sampled on the boundary (the left and right endpoints of the interval). We also include 10 initial residual points for the initial conditions and 10000 points for testing the PDE residual.

--- a/docs/demos/pinn_forward/diffusion.reaction.rst
+++ b/docs/demos/pinn_forward/diffusion.reaction.rst
@@ -108,7 +108,7 @@ Now, we have specified the geometry and the PDE residual. We then define the ``T
 .. code-block:: python
 
     data = dde.data.TimePDE(
-        geomtime, pde, [], num_domain=320, solution=func, num_test=80000
+        geomtime, pde, [], num_domain=320, solution=func, num_test_domain=80000
     )
 
 The number 320 is the number of training residual points sampled inside the domain, and the number 80000 is the number of points sampled inside

--- a/docs/demos/pinn_forward/eulerbeam.rst
+++ b/docs/demos/pinn_forward/eulerbeam.rst
@@ -109,7 +109,7 @@ Now, we have specified the geometry, PDE residual and boundary conditions. We th
         num_domain=10,
         num_boundary=2,
         solution=func,
-        num_test=100,
+        num_test_domain=100,
     )
 
 The number 10 is the number of training residual points sampled inside the domain, and the number 2 is the number of training points sampled on the boundary. The argument ``solution=func`` is the reference solution to compute the error of our solution, and can be ignored if we don't have a reference solution. We use 100 residual points for testing the PDE residual.

--- a/docs/demos/pinn_forward/heat.resample.rst
+++ b/docs/demos/pinn_forward/heat.resample.rst
@@ -82,7 +82,7 @@ Now, we have specified the geometry, PDE residual, and boundary/initial conditio
         num_domain=2540,
         num_boundary=80,
         num_initial=160,
-        num_test=2540,
+        num_test_domain=2540,
     )
 
 The number 2540 is the number of training residual points sampled inside the domain, and the number 80 is the number of training points sampled on the boundary. We also include 160 initial residual points for the initial conditions.

--- a/docs/demos/pinn_forward/heat.rst
+++ b/docs/demos/pinn_forward/heat.rst
@@ -82,7 +82,7 @@ Now, we have specified the geometry, PDE residual, and boundary/initial conditio
         num_domain=2540,
         num_boundary=80,
         num_initial=160,
-        num_test=2540,
+        num_test_domain=2540,
     )
 
 The number 2540 is the number of training residual points sampled inside the domain, and the number 80 is the number of training points sampled on the boundary. We also include 160 initial residual points for the initial conditions.

--- a/docs/demos/pinn_forward/helmholtz.2d.dirichlet.rst
+++ b/docs/demos/pinn_forward/helmholtz.2d.dirichlet.rst
@@ -124,7 +124,7 @@ Next, we generate the training and testing points.
       num_domain=nx_train ** 2,
       num_boundary=4 * nx_train,
       solution=func,
-      num_test=nx_test ** 2,
+      num_test_domain=nx_test ** 2,
   )
 
 Next, we choose the network. Here, we use a fully connected neural network of depth 4 (i.e., 3 hidden layers) and width 150. Besides, we choose sin as activation function and Glorot uniform as initializer :

--- a/docs/demos/pinn_forward/helmholtz.2d.neumann.hole.rst
+++ b/docs/demos/pinn_forward/helmholtz.2d.neumann.hole.rst
@@ -160,7 +160,7 @@ Next, we generate the data points, the net, the model, and the weights for the l
       num_domain=nx_train**2,
       num_boundary=16 * nx_train,
       solution=func,
-      num_test=nx_test**2,
+      num_test_domain=nx_test**2,
   )
 
   net = dde.nn.FNN(

--- a/docs/demos/pinn_forward/helmholtz.2d.sound.hard.abc.rst
+++ b/docs/demos/pinn_forward/helmholtz.2d.sound.hard.abc.rst
@@ -191,7 +191,7 @@ Next, we define the weights for the loss function and generate the training and 
       bcs,
       num_domain=nx**2,
       num_boundary=8 * nx,
-      num_test=5 * nx **2,
+      num_test_domain=5 * nx **2,
       solution=sol
   )
 

--- a/docs/demos/pinn_forward/klein.gordon.rst
+++ b/docs/demos/pinn_forward/klein.gordon.rst
@@ -96,7 +96,7 @@ Now, we have specified the geometry, PDE residual, and the boundary/initial cond
         num_boundary=1500,
         num_initial=1500,
         solution=func,
-        num_test=6000, 
+        num_test_domain=6000, 
     )
 
 The number 30000 is the number of training residual points sampled inside of the domain, and the number 1500 is the number of training residual points sampled on the boundary. We also include 1500 initial residual points for the initial conditions and 6000 points for testing the PDE residual. 

--- a/docs/demos/pinn_forward/lotka.volterra.rst
+++ b/docs/demos/pinn_forward/lotka.volterra.rst
@@ -69,7 +69,7 @@ Now, we define the ODE problem as
 
 .. code-block:: python 
 
-    data = dde.data.PDE(geom, ode_system, [], 3000, 2, num_test = 3000)
+    data = dde.data.PDE(geom, ode_system, [], 3000, 2, num_test_domain = 3000)
 
 Note that when solving this equation, we want to have hard constraints on the initial conditions, so we define this later when creating the network rather than as part of the PDE.
 

--- a/docs/demos/pinn_forward/ode.2nd.rst
+++ b/docs/demos/pinn_forward/ode.2nd.rst
@@ -70,11 +70,11 @@ Then, the initial condition is defined by
 
     ic2 = dde.icbc.OperatorBC(geom, error_2, boundary_l)
 
-Now, we have specified the geometry, PDE residual, and the initial conditions. We then define the PDE problem. Note: If you use `X` in `func`, then do not set ``num_test`` when you define ``dde.data.PDE`` or ``dde.data.TimePDE``, otherwise DeepXDE would throw an error. In this case, the training points will be used for testing, and this will not affect the network training and training loss. This is a bug of DeepXDE, which cannot be fixed in an easy way for all backends.
+Now, we have specified the geometry, PDE residual, and the initial conditions. We then define the PDE problem. Note: If you use `X` in `func`, then do not set ``num_test_domain`` when you define ``dde.data.PDE`` or ``dde.data.TimePDE``, otherwise DeepXDE would throw an error. In this case, the training points will be used for testing, and this will not affect the network training and training loss. This is a bug of DeepXDE, which cannot be fixed in an easy way for all backends.
 
 .. code-block:: python
 
-    data = dde.data.TimePDE(geom, ode, [ic1, ic2], 16, 2, solution=func, num_test=500)
+    data = dde.data.TimePDE(geom, ode, [ic1, ic2], 16, 2, solution=func, num_test_domain=500)
 
 The number 16 is the number of training residual points sampled inside the domain, and the number 2 is the number of training points sampled on the boundary. The argument ``solution=func`` is the reference solution to compute the error of our solution, and can be ignored if we don't have a reference solution. We use 500 residual points for testing the PDE residual.
 

--- a/docs/demos/pinn_forward/ode.system.rst
+++ b/docs/demos/pinn_forward/ode.system.rst
@@ -70,7 +70,7 @@ Now, we have specified the geometry, ODEs, and initial conditions. Since ``PDE``
 
 .. code-block:: python
 
-    data = dde.data.PDE(geom, ode_system, [ic1, ic2], 35, 2, solution=func, num_test=100)
+    data = dde.data.PDE(geom, ode_system, [ic1, ic2], 35, 2, solution=func, num_test_domain=100)
 
 The number 35 is the number of training residual points sampled inside the domain, and the number 2 is the number of training points sampled on the boundary (the left and right endpoints of the time domain in this case). We use 100 points for testing the ODE residual. The argument  ``solution=func`` is the reference solution to compute the error of our solution, and we define it as follows:
 

--- a/docs/demos/pinn_forward/poisson.1d.dirichlet.rst
+++ b/docs/demos/pinn_forward/poisson.1d.dirichlet.rst
@@ -80,7 +80,7 @@ Now, we have specified the geometry, PDE residual, and Dirichlet boundary condit
 
 .. code-block:: python
 
-    data = dde.data.PDE(geom, pde, bc, 16, 2, solution=func, num_test=100)    
+    data = dde.data.PDE(geom, pde, bc, 16, 2, solution=func, num_test_domain=100)    
 
 The number 16 is the number of training residual points sampled inside the domain, and the number 2 is the number of training points sampled on the boundary. The argument ``solution=func`` is the reference solution to compute the error of our solution, and can be ignored if we don't have a reference solution. We use 100 residual points for testing the PDE residual.
 

--- a/docs/demos/pinn_forward/poisson.1d.dirichletperiodic.rst
+++ b/docs/demos/pinn_forward/poisson.1d.dirichletperiodic.rst
@@ -89,7 +89,7 @@ Now, we have specified the geometry, PDE residual, Dirichlet boundary condition 
 
 .. code-block:: python
 
-    data = dde.data.PDE(geom, pde, [bc1, bc2], 16, 2, solution=func, num_test=100)
+    data = dde.data.PDE(geom, pde, [bc1, bc2], 16, 2, solution=func, num_test_domain=100)
 
 The number 16 is the number of training residual points sampled inside the domain, and the number 2 is the number of training points sampled on the boundary. The argument ``solution=func`` is the reference solution to compute the error of our solution, and can be ignored if we don't have a reference solution. We use 100 residual points for testing the PDE residual.
 

--- a/docs/demos/pinn_forward/poisson.1d.dirichletrobin.rst
+++ b/docs/demos/pinn_forward/poisson.1d.dirichletrobin.rst
@@ -87,7 +87,7 @@ Now, we have specified the geometry, PDE residual, Dirichlet boundary condition 
 
 .. code-block:: python
 
-    data = dde.data.PDE(geom, pde, [bc_l, bc_r], 16, 2, solution=func, num_test=100)
+    data = dde.data.PDE(geom, pde, [bc_l, bc_r], 16, 2, solution=func, num_test_domain=100)
 
 The number 16 is the number of training residual points sampled inside the domain, and the number 2 is the number of training points sampled on the boundary. The argument ``solution=func`` is the reference solution to compute the error of our solution, and can be ignored if we don't have a reference solution. We use 100 residual points for testing the PDE residual.
 

--- a/docs/demos/pinn_forward/poisson.1d.multiscaleFourier.rst
+++ b/docs/demos/pinn_forward/poisson.1d.multiscaleFourier.rst
@@ -80,7 +80,7 @@ Now, we have specified the geometry, PDE residual and Dirichlet boundary conditi
         2,
         train_distribution="pseudo",
         solution=func,
-        num_test=10000,
+        num_test_domain=10000,
     )
 
 The number 1280 is the number of training residual points sampled inside the domain, and the number 2 is the number of training points sampled on the boundary. The argument ``train_distribution = 'pseudo'`` means that the sample training points follows a pseudo-random distribution.  The argument ``solution=func`` is the reference solution to compute the error of our solution, and can be ignored if we don't have a reference solution. We use 10000 residual points for testing the PDE residual.

--- a/docs/demos/pinn_forward/poisson.1d.neumanndirichlet.rst
+++ b/docs/demos/pinn_forward/poisson.1d.neumanndirichlet.rst
@@ -93,7 +93,7 @@ Now, we have specified the geometry, PDE residual, Dirichlet boundary condition 
 
 .. code-block:: python
 
-    data = dde.data.PDE(geom, pde, [bc_l, bc_r], 16, 2, solution=func, num_test=100)
+    data = dde.data.PDE(geom, pde, [bc_l, bc_r], 16, 2, solution=func, num_test_domain=100)
 
 The number 16 is the number of training residual points sampled inside the domain, and the number 2 is the number of training points sampled on the boundary. The argument ``solution=func`` is the reference solution to compute the error of our solution, and can be ignored if we don't have a reference solution. We use 100 residual points for testing the PDE residual.
 

--- a/docs/demos/pinn_forward/poisson.1d.pointsetoperator.rst
+++ b/docs/demos/pinn_forward/poisson.1d.pointsetoperator.rst
@@ -96,7 +96,7 @@ Now, we have specified the geometry, PDE residual, Dirichlet boundary condition 
 
 .. code-block:: python
 
-    data = dde.data.PDE(geom, pde, [bc_l, bc_r], 16, 2, solution=func, num_test=100)
+    data = dde.data.PDE(geom, pde, [bc_l, bc_r], 16, 2, solution=func, num_test_domain=100)
 
 The number 16 is the number of training residual points sampled inside the domain, and the number 2 is the number of training points sampled on the boundary. The argument ``solution=func`` is the reference solution to compute the error of our solution, and can be ignored if we don't have a reference solution. We use 100 residual points for testing the PDE residual.
 

--- a/docs/demos/pinn_forward/poisson.Lshape.rst
+++ b/docs/demos/pinn_forward/poisson.Lshape.rst
@@ -59,7 +59,7 @@ Now, we have specified the geometry, PDE residual, and Dirichlet boundary condit
 
 .. code-block:: python
 
-    data = dde.data.PDE(geom, pde, bc, num_domain=1200, num_boundary=120, num_test=1500)
+    data = dde.data.PDE(geom, pde, bc, num_domain=1200, num_boundary=120, num_test_domain=1500)
 The number 1200 is the number of training residual points sampled inside the domain, and the number 120 is the number of training points sampled on the boundary. We use 1500 residual points for testing the PDE residual.
 
 Next, we choose the network. Here, we use a fully connected neural network of depth 5 (i.e., 4 hidden layers) and width 50. Besides, we choose ``tanh`` as activation function and ``Glorot uniform`` as initializer :

--- a/docs/demos/pinn_forward/poisson.dirichlet.1d.exactbc.rst
+++ b/docs/demos/pinn_forward/poisson.dirichlet.1d.exactbc.rst
@@ -54,7 +54,7 @@ Now, we have specified the geometry and PDE residual. We then define the PDE pro
 
 .. code-block:: python
 
-    data = dde.data.PDE(geom, pde, [], num_domain=64, solution=func, num_test=400)
+    data = dde.data.PDE(geom, pde, [], num_domain=64, solution=func, num_test_domain=400)
     
 The number 64 is the number of training residual points sampled inside the domain. The argument ``solution=func`` is the reference solution to compute the error of our solution, and can be ignored if we don’t have a reference solution. We use 400 residual points for testing the PDE residual.
 

--- a/docs/demos/pinn_inverse/diffusion.1d.inverse.rst
+++ b/docs/demos/pinn_inverse/diffusion.1d.inverse.rst
@@ -95,7 +95,7 @@ Now, we have specified the geometry, PDE residual, boundary/initial condition, a
         num_initial=10,
         anchors=observe_x,
         solution=func,
-        num_test=10000,
+        num_test_domain=10000,
     )
 
 The number 40 is the number of training residual points sampled inside the domain, and the number 20 is the number of training points sampled on the boundary (the left and right endpoints of the interval). We also include 10 initial residual points for the initial conditions and 10000 points for testing the PDE residual. The argument ``anchors`` is the above described training points in addition to the ``num_domain``, ``num_initial``, and ``num_boundary`` sampled points.

--- a/docs/demos/pinn_inverse/elliptic.inverse.field.rst
+++ b/docs/demos/pinn_inverse/elliptic.inverse.field.rst
@@ -88,7 +88,7 @@ Now that the problem is fully setup, we define the PDE as:
         num_domain=200,
         num_boundary=2,
         anchors=ob_x,
-        num_test=1000,
+        num_test_domain=1000,
     )
  
 where ``num_domain`` is the number of points inside the domain, and ``num_boundary`` is the number of points on the boundary. ``anchors`` are extra points beyond ``num_domain`` and ``num_boundary`` used for training.

--- a/docs/demos/pinn_inverse/reaction.inverse.rst
+++ b/docs/demos/pinn_inverse/reaction.inverse.rst
@@ -124,7 +124,7 @@ Now, we can define the ``TimePDE`` problem as follows:
         num_boundary=100,
         num_initial=100,
         anchors=observe_x,
-        num_test=50000,
+        num_test_domain=50000,
     )
 
 We have 2000 training residual points in the domain, 100 points on the boundary, 100 points for the initial conditions, and 50000 to test the PDE residual. ``anchors`` specifies the training points as well.

--- a/examples/pinn_forward/Beltrami_flow.py
+++ b/examples/pinn_forward/Beltrami_flow.py
@@ -158,7 +158,7 @@ data = dde.data.TimePDE(
     num_domain=50000,
     num_boundary=5000,
     num_initial=5000,
-    num_test=10000,
+    num_test_domain=10000,
 )
 
 net = dde.nn.FNN([4] + 4 * [50] + [4], "tanh", "Glorot normal")

--- a/examples/pinn_forward/Euler_beam.py
+++ b/examples/pinn_forward/Euler_beam.py
@@ -43,7 +43,7 @@ data = dde.data.PDE(
     num_domain=10,
     num_boundary=2,
     solution=func,
-    num_test=100,
+    num_test_domain=100,
 )
 layer_size = [1] + [20] * 3 + [1]
 activation = "tanh"

--- a/examples/pinn_forward/Helmholtz_Dirichlet_2d.py
+++ b/examples/pinn_forward/Helmholtz_Dirichlet_2d.py
@@ -68,7 +68,7 @@ data = dde.data.PDE(
     num_domain=nx_train ** 2,
     num_boundary=4 * nx_train,
     solution=func,
-    num_test=nx_test ** 2,
+    num_test_domain=nx_test ** 2,
 )
 
 net = dde.nn.FNN(

--- a/examples/pinn_forward/Helmholtz_Neumann_2d_hole.py
+++ b/examples/pinn_forward/Helmholtz_Neumann_2d_hole.py
@@ -97,7 +97,7 @@ data = dde.data.PDE(
     num_domain=nx_train**2,
     num_boundary=16 * nx_train,
     solution=func,
-    num_test=nx_test**2,
+    num_test_domain=nx_test**2,
 )
 
 net = dde.nn.FNN(

--- a/examples/pinn_forward/Helmholtz_Sound_hard_ABC_2d.py
+++ b/examples/pinn_forward/Helmholtz_Sound_hard_ABC_2d.py
@@ -122,7 +122,7 @@ data = dde.data.PDE(
     bcs,
     num_domain=nx**2,
     num_boundary=8 * nx,
-    num_test=5 * nx**2,
+    num_test_domain=5 * nx**2,
     solution=sol,
 )
 net = dde.maps.FNN(

--- a/examples/pinn_forward/Klein_Gordon.py
+++ b/examples/pinn_forward/Klein_Gordon.py
@@ -55,7 +55,7 @@ data = dde.data.TimePDE(
     num_boundary=1500,
     num_initial=1500,
     solution=func,
-    num_test=6000,
+    num_test_domain=6000,
 )
 
 layer_size = [2] + [40] * 2 + [1]

--- a/examples/pinn_forward/Kovasznay_flow.py
+++ b/examples/pinn_forward/Kovasznay_flow.py
@@ -68,7 +68,7 @@ data = dde.data.PDE(
     [boundary_condition_u, boundary_condition_v, boundary_condition_right_p],
     num_domain=2601,
     num_boundary=400,
-    num_test=100000,
+    num_test_domain=100000,
 )
 
 net = dde.nn.FNN([2] + 4 * [50] + [3], "tanh", "Glorot normal")

--- a/examples/pinn_forward/Lotka_Volterra.py
+++ b/examples/pinn_forward/Lotka_Volterra.py
@@ -44,7 +44,7 @@ def ode_system(x, y):
 
 
 geom = dde.geometry.TimeDomain(0.0, 1.0)
-data = dde.data.PDE(geom, ode_system, [], 3000, 2, num_test=3000)
+data = dde.data.PDE(geom, ode_system, [], 3000, 2, num_test_domain=3000)
 
 layer_size = [1] + [64] * 6 + [2]
 activation = "tanh"

--- a/examples/pinn_forward/Poisson_Dirichlet_1d.py
+++ b/examples/pinn_forward/Poisson_Dirichlet_1d.py
@@ -30,7 +30,7 @@ def func(x):
 
 geom = dde.geometry.Interval(-1, 1)
 bc = dde.icbc.DirichletBC(geom, func, boundary)
-data = dde.data.PDE(geom, pde, bc, 16, 2, solution=func, num_test=100)
+data = dde.data.PDE(geom, pde, bc, 16, 2, solution=func, num_test_domain=100)
 
 layer_size = [1] + [50] * 3 + [1]
 activation = "tanh"

--- a/examples/pinn_forward/Poisson_Dirichlet_1d_exactBC.py
+++ b/examples/pinn_forward/Poisson_Dirichlet_1d_exactBC.py
@@ -25,7 +25,7 @@ def func(x):
     summation = sum([np.sin(i * x) / i for i in range(1, 5)])
     return x + summation + np.sin(8 * x) / 8
 
-data = dde.data.PDE(geom, pde, [], num_domain=64, solution=func, num_test=400)
+data = dde.data.PDE(geom, pde, [], num_domain=64, solution=func, num_test_domain=400)
 
 layer_size = [1] + [50] * 3 + [1]
 activation = 'tanh'

--- a/examples/pinn_forward/Poisson_Lshape.py
+++ b/examples/pinn_forward/Poisson_Lshape.py
@@ -19,7 +19,7 @@ def boundary(_, on_boundary):
 geom = dde.geometry.Polygon([[0, 0], [1, 0], [1, -1], [-1, -1], [-1, 1], [0, 1]])
 bc = dde.icbc.DirichletBC(geom, lambda x: 0, boundary)
 
-data = dde.data.PDE(geom, pde, bc, num_domain=1200, num_boundary=120, num_test=1500)
+data = dde.data.PDE(geom, pde, bc, num_domain=1200, num_boundary=120, num_test_domain=1500)
 net = dde.nn.FNN([2] + [50] * 4 + [1], "tanh", "Glorot uniform")
 model = dde.Model(data, net)
 

--- a/examples/pinn_forward/Poisson_Neumann_1d.py
+++ b/examples/pinn_forward/Poisson_Neumann_1d.py
@@ -23,7 +23,7 @@ def func(x):
 geom = dde.geometry.Interval(-1, 1)
 bc_l = dde.icbc.DirichletBC(geom, func, boundary_l)
 bc_r = dde.icbc.NeumannBC(geom, lambda X: 2 * (X + 1), boundary_r)
-data = dde.data.PDE(geom, pde, [bc_l, bc_r], 16, 2, solution=func, num_test=100)
+data = dde.data.PDE(geom, pde, [bc_l, bc_r], 16, 2, solution=func, num_test_domain=100)
 
 layer_size = [1] + [50] * 3 + [1]
 activation = "tanh"

--- a/examples/pinn_forward/Poisson_PointSetOperator_1d.py
+++ b/examples/pinn_forward/Poisson_PointSetOperator_1d.py
@@ -32,7 +32,7 @@ r_boundary_pts = boundary_pts[np.isclose(boundary_pts, 1)].reshape(-1, 1)
 bc_r = dde.icbc.PointSetOperatorBC(r_boundary_pts, d_func(r_boundary_pts), dy_x)
 
 data = dde.data.PDE(
-    geom, pde, [bc_l, bc_r], num_domain=16, num_boundary=2, solution=func, num_test=100
+    geom, pde, [bc_l, bc_r], num_domain=16, num_boundary=2, solution=func, num_test_domain=100
 )
 
 layer_size = [1] + [50] * 3 + [1]

--- a/examples/pinn_forward/Poisson_Robin_1d.py
+++ b/examples/pinn_forward/Poisson_Robin_1d.py
@@ -23,7 +23,7 @@ def func(x):
 geom = dde.geometry.Interval(-1, 1)
 bc_l = dde.icbc.DirichletBC(geom, func, boundary_l)
 bc_r = dde.icbc.RobinBC(geom, lambda X, y: y, boundary_r)
-data = dde.data.PDE(geom, pde, [bc_l, bc_r], 16, 2, solution=func, num_test=100)
+data = dde.data.PDE(geom, pde, [bc_l, bc_r], 16, 2, solution=func, num_test_domain=100)
 
 layer_size = [1] + [50] * 3 + [1]
 activation = "tanh"

--- a/examples/pinn_forward/Poisson_multiscale_1d.py
+++ b/examples/pinn_forward/Poisson_multiscale_1d.py
@@ -45,7 +45,7 @@ data = dde.data.PDE(
     2,
     train_distribution="pseudo",
     solution=func,
-    num_test=10000,
+    num_test_domain=10000,
 )
 
 layer_size = [1] + [100] * 3 + [1]

--- a/examples/pinn_forward/Poisson_periodic_1d.py
+++ b/examples/pinn_forward/Poisson_periodic_1d.py
@@ -34,7 +34,7 @@ def func(x):
 geom = dde.geometry.Interval(-1, 1)
 bc1 = dde.icbc.DirichletBC(geom, func, boundary_l)
 bc2 = dde.icbc.PeriodicBC(geom, 0, boundary_r)
-data = dde.data.PDE(geom, pde, [bc1, bc2], 16, 2, solution=func, num_test=100)
+data = dde.data.PDE(geom, pde, [bc1, bc2], 16, 2, solution=func, num_test_domain=100)
 
 layer_size = [1] + [50] * 3 + [1]
 activation = "tanh"

--- a/examples/pinn_forward/diffusion_1d.py
+++ b/examples/pinn_forward/diffusion_1d.py
@@ -53,7 +53,7 @@ data = dde.data.TimePDE(
     num_boundary=20,
     num_initial=10,
     solution=func,
-    num_test=10000,
+    num_test_domain=10000,
 )
 
 layer_size = [2] + [32] * 3 + [1]

--- a/examples/pinn_forward/diffusion_1d_exactBC.py
+++ b/examples/pinn_forward/diffusion_1d_exactBC.py
@@ -43,7 +43,7 @@ geom = dde.geometry.Interval(-1, 1)
 timedomain = dde.geometry.TimeDomain(0, 1)
 geomtime = dde.geometry.GeometryXTime(geom, timedomain)
 
-data = dde.data.TimePDE(geomtime, pde, [], num_domain=40, solution=func, num_test=10000)
+data = dde.data.TimePDE(geomtime, pde, [], num_domain=40, solution=func, num_test_domain=10000)
 
 layer_size = [2] + [32] * 3 + [1]
 activation = "tanh"

--- a/examples/pinn_forward/diffusion_1d_resample.py
+++ b/examples/pinn_forward/diffusion_1d_resample.py
@@ -54,7 +54,7 @@ data = dde.data.TimePDE(
     num_initial=10,
     train_distribution="pseudo",
     solution=func,
-    num_test=10000,
+    num_test_domain=10000,
 )
 
 layer_size = [2] + [32] * 3 + [1]

--- a/examples/pinn_forward/diffusion_reaction.py
+++ b/examples/pinn_forward/diffusion_reaction.py
@@ -64,7 +64,7 @@ timedomain = dde.geometry.TimeDomain(0, 1)
 geomtime = dde.geometry.GeometryXTime(geom, timedomain)
 
 data = dde.data.TimePDE(
-    geomtime, pde, [], num_domain=320, solution=func, num_test=80000
+    geomtime, pde, [], num_domain=320, solution=func, num_test_domain=80000
 )
 
 layer_size = [2] + [30] * 6 + [1]

--- a/examples/pinn_forward/fractional_Poisson_1d.py
+++ b/examples/pinn_forward/fractional_Poisson_1d.py
@@ -59,7 +59,7 @@ bc = dde.icbc.DirichletBC(geom, func, lambda _, on_boundary: on_boundary)
 data = dde.data.FPDE(geom, fpde, alpha, bc, [101], meshtype="static", solution=func)
 # Dynamic auxiliary points
 # data = dde.data.FPDE(
-#     geom, fpde, alpha, bc, [100], meshtype="dynamic", num_domain=20, num_boundary=2, solution=func, num_test=100
+#     geom, fpde, alpha, bc, [100], meshtype="dynamic", num_domain=20, num_boundary=2, solution=func, num_test_domain=100
 # )
 
 net = dde.nn.FNN([1] + [20] * 4 + [1], "tanh", "Glorot normal")

--- a/examples/pinn_forward/fractional_diffusion_1d.py
+++ b/examples/pinn_forward/fractional_diffusion_1d.py
@@ -84,7 +84,7 @@ data = dde.data.TimeFPDE(
 #     num_boundary=1,
 #     num_initial=1,
 #     solution=func,
-#     num_test=50,
+#     num_test_domain=50,
 # )
 
 net = dde.nn.FNN([2] + [20] * 4 + [1], "tanh", "Glorot normal")

--- a/examples/pinn_forward/heat.py
+++ b/examples/pinn_forward/heat.py
@@ -87,7 +87,7 @@ data = dde.data.TimePDE(
     num_domain=2540,
     num_boundary=80,
     num_initial=160,
-    num_test=2540,
+    num_test_domain=2540,
 )
 net = dde.nn.FNN([2] + [20] * 3 + [1], "tanh", "Glorot normal")
 model = dde.Model(data, net)

--- a/examples/pinn_forward/heat_resample.py
+++ b/examples/pinn_forward/heat_resample.py
@@ -90,7 +90,7 @@ data = dde.data.TimePDE(
     num_domain=2540,
     num_boundary=80,
     num_initial=160,
-    num_test=2540,
+    num_test_domain=2540,
 )
 net = dde.nn.FNN([2] + [20] * 3 + [1], "tanh", "Glorot normal")
 model = dde.Model(data, net)

--- a/examples/pinn_forward/ode_2nd.py
+++ b/examples/pinn_forward/ode_2nd.py
@@ -31,7 +31,7 @@ def bc_func2(inputs, outputs, X):
 ic1 = dde.icbc.IC(geom, lambda x: -1, lambda _, on_initial: on_initial)
 ic2 = dde.icbc.OperatorBC(geom, bc_func2, boundary_l)
 
-data = dde.data.TimePDE(geom, ode, [ic1, ic2], 16, 2, solution=func, num_test=500)
+data = dde.data.TimePDE(geom, ode, [ic1, ic2], 16, 2, solution=func, num_test_domain=500)
 layer_size = [1] + [50] * 3 + [1]
 activation = "tanh"
 initializer = "Glorot uniform"

--- a/examples/pinn_forward/ode_system.py
+++ b/examples/pinn_forward/ode_system.py
@@ -35,7 +35,7 @@ def func(x):
 geom = dde.geometry.TimeDomain(0, 10)
 ic1 = dde.icbc.IC(geom, lambda x: 0, boundary, component=0)
 ic2 = dde.icbc.IC(geom, lambda x: 1, boundary, component=1)
-data = dde.data.PDE(geom, ode_system, [ic1, ic2], 35, 2, solution=func, num_test=100)
+data = dde.data.PDE(geom, ode_system, [ic1, ic2], 35, 2, solution=func, num_test_domain=100)
 
 layer_size = [1] + [50] * 3 + [2]
 activation = "tanh"

--- a/examples/pinn_forward/wave_1d.py
+++ b/examples/pinn_forward/wave_1d.py
@@ -51,7 +51,7 @@ data = dde.data.TimePDE(
     num_boundary=360,
     num_initial=360,
     solution=func,
-    num_test=10000,
+    num_test_domain=10000,
 )
 
 layer_size = [2] + [100] * 3 + [1]

--- a/examples/pinn_inverse/brinkman_forchheimer.py
+++ b/examples/pinn_inverse/brinkman_forchheimer.py
@@ -49,7 +49,7 @@ data = dde.data.PDE(
     num_domain=100,
     num_boundary=0,
     train_distribution="uniform",
-    num_test=500,
+    num_test_domain=500,
 )
 
 net = dde.nn.FNN([1] + [20] * 3 + [1], "tanh", "Glorot uniform")

--- a/examples/pinn_inverse/diffusion_1d_inverse.py
+++ b/examples/pinn_inverse/diffusion_1d_inverse.py
@@ -61,7 +61,7 @@ data = dde.data.TimePDE(
     num_initial=10,
     anchors=observe_x,
     solution=func,
-    num_test=10000,
+    num_test_domain=10000,
 )
 
 layer_size = [2] + [32] * 3 + [1]

--- a/examples/pinn_inverse/diffusion_reaction_rate.py
+++ b/examples/pinn_inverse/diffusion_reaction_rate.py
@@ -57,7 +57,7 @@ data = dde.data.PDE(
     num_domain=50,
     num_boundary=8,
     train_distribution="uniform",
-    num_test=1000,
+    num_test_domain=1000,
 )
 
 net = dde.nn.PFNN([1, [20, 20], [20, 20], 2], "tanh", "Glorot uniform")

--- a/examples/pinn_inverse/elliptic_inverse_field.py
+++ b/examples/pinn_inverse/elliptic_inverse_field.py
@@ -35,7 +35,7 @@ data = dde.data.PDE(
     num_domain=200,
     num_boundary=2,
     anchors=ob_x,
-    num_test=1000,
+    num_test_domain=1000,
 )
 
 net = dde.nn.PFNN([1, [20, 20], [20, 20], [20, 20], 2], "tanh", "Glorot uniform")

--- a/examples/pinn_inverse/elliptic_inverse_field_batch.py
+++ b/examples/pinn_inverse/elliptic_inverse_field_batch.py
@@ -35,7 +35,7 @@ data = dde.data.PDE(
     [bc, observe_u],
     num_domain=200,
     num_boundary=2,
-    num_test=1000,
+    num_test_domain=1000,
 )
 
 net = dde.nn.PFNN([1, [20, 20], [20, 20], [20, 20], 2], "tanh", "Glorot uniform")

--- a/examples/pinn_inverse/fractional_Poisson_1d_inverse.py
+++ b/examples/pinn_inverse/fractional_Poisson_1d_inverse.py
@@ -68,7 +68,7 @@ data = dde.data.FPDE(
     num_domain=20,
     anchors=observe_x,
     solution=func,
-    num_test=100,
+    num_test_domain=100,
 )
 
 net = dde.nn.FNN([1] + [20] * 4 + [1], "tanh", "Glorot normal")

--- a/examples/pinn_inverse/reaction_inverse.py
+++ b/examples/pinn_inverse/reaction_inverse.py
@@ -62,7 +62,7 @@ data = dde.data.TimePDE(
     num_boundary=100,
     num_initial=100,
     anchors=observe_x,
-    num_test=50000,
+    num_test_domain=50000,
 )
 net = dde.nn.FNN([2] + [20] * 3 + [2], "tanh", "Glorot uniform")
 


### PR DESCRIPTION
Something similar can be done in `data/pde_operator.py` and I may do this in a future pull request.

Should I add `num_test_boundary` to the examples? I'm not sure if this is a problem in the real-world. It seems to me that doing this would prevent (or at least detect) overfitting to the boundary conditions selected.

I also fixed a trivial TODO in `pde.py` (rename `train_x_all` to `train_x_pde`). Let me know if you want me to split this into a seperate PR.