### PR TITLE
A copy button added in the docs.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
+    "sphinx-copybutton",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
-    "sphinx-copybutton",
+    "sphinx_copybutton",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,8 +3,6 @@ numpy
 scikit-learn
 scikit-optimize>=0.9.0
 scipy
-docutils<0.18  # https://github.com/readthedocs/readthedocs.org/issues/8616
-sphinx-copybutton
 
 # TensorFlow 1.x
 tensorflow>=2.7.0
@@ -19,3 +17,5 @@ jax
 flax
 optax
 
+docutils<0.18  # https://github.com/readthedocs/readthedocs.org/issues/8616
+sphinx-copybutton

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,7 @@ scikit-learn
 scikit-optimize>=0.9.0
 scipy
 docutils<0.18  # https://github.com/readthedocs/readthedocs.org/issues/8616
+sphinx-copybutton
 
 # TensorFlow 1.x
 tensorflow>=2.7.0
@@ -17,4 +18,4 @@ paddlepaddle>=2.3.0
 jax
 flax
 optax
-sphinx-copybutton
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -17,3 +17,4 @@ paddlepaddle>=2.3.0
 jax
 flax
 optax
+sphinx-copybutton


### PR DESCRIPTION
Hi, I just added a copy button in the docs to copy the code with just one click. This is particularly useful when copying the full-code at the end of the examples.

Here is an example: 

![image](https://user-images.githubusercontent.com/70601302/217485776-bdbf6c01-8563-4847-90d6-c7bfede18a55.png)

This copybutton appear in each code cell. I have build the docs so you can have a quick look.

HTML build: https://deepxde-copybutton.readthedocs.io/en/latest/demos/pinn_forward/poisson.1d.dirichlet.html
 