### PR TITLE
optimize spase matrix initialization for FPDE

### DIFF
--- a/deepxde/data/fpde.py
+++ b/deepxde/data/fpde.py
@@ -100,7 +100,9 @@ class FPDE(PDE):
     def losses_train(self, targets, outputs, loss_fn, inputs, model, aux=None):
         bcs_start = np.cumsum([0] + self.num_bcs)
         # do not cache int_mat when alpha is a learnable parameter
-        if not is_tensor(self.alpha):
+        if is_tensor(self.alpha):
+            int_mat = self.get_int_matrix(True)
+        else:
             if self.int_mat_train is not None:
                 # use cached int_mat
                 int_mat = self.int_mat_train
@@ -108,8 +110,6 @@ class FPDE(PDE):
                 # initialize self.int_mat_train with int_mat
                 int_mat = self.get_int_matrix(True)
                 self.int_mat_train = int_mat
-        else:
-            int_mat = self.get_int_matrix(True)
 
         f = self.pde(inputs, outputs, int_mat)
         if not isinstance(f, (list, tuple)):

--- a/deepxde/data/fpde.py
+++ b/deepxde/data/fpde.py
@@ -83,7 +83,7 @@ class FPDE(PDE):
         self.alpha = alpha
         self.disc = Scheme(meshtype, resolution)
         self.frac_train, self.frac_test = None, None
-        self.int_mat = None
+        self.int_mat_train = None
 
         super().__init__(
             geometry,
@@ -101,13 +101,13 @@ class FPDE(PDE):
         bcs_start = np.cumsum([0] + self.num_bcs)
         # do not cache int_mat when alpha is a learnable parameter
         if not is_tensor(self.alpha):
-            if self.int_mat is not None:
+            if self.int_mat_train is not None:
                 # use cached int_mat
-                int_mat = self.int_mat
+                int_mat = self.int_mat_train
             else:
-                # initialize self.int_mat with int_mat
+                # initialize self.int_mat_train with int_mat
                 int_mat = self.get_int_matrix(True)
-                self.int_mat = int_mat
+                self.int_mat_train = int_mat
         else:
             int_mat = self.get_int_matrix(True)
 


### PR DESCRIPTION
Cache `int_mat` when FPDE.alpha is an unlearnable constant to speed up training process, such as `fractional_Poisson_3d.py`