### PR TITLE
Add a workflow to automate the release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         run: pipx run twine check dist/*
 
   publish:
-    needs: [dist]
+    needs: [build]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,5 +41,4 @@ jobs:
       - name: Publish on PyPI
       - uses: pypa/gh-action-pypi-publish@v1.6.4
         with:
-          user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         run: pipx run build
 
       - name: Upload SDist and wheel
-      - uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3
         with:
           path: dist/*
           if-no-files-found: error
@@ -33,12 +33,12 @@ jobs:
 
     steps:
       - name: Download SDist and wheel
-      - uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist
 
       - name: Publish on PyPI
-      - uses: pypa/gh-action-pypi-publish@v1.6.4
+        uses: pypa/gh-action-pypi-publish@v1.6.4
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,4 +42,4 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@v1.6.4
         with:
           user: __token__
-          password: ${{ secrets.pypi_password }}
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: release
+
+on:
+  workflow_dispatch:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Build SDist and wheel
+        run: pipx run build
+
+      - name: Upload SDist and wheel
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*
+          if-no-files-found: error
+
+      - name: Check metadata
+        run: pipx run twine check dist/*
+
+  publish:
+    needs: [dist]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+
+    steps:
+      - name: Download SDist and wheel
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+
+      - name: Publish on PyPI
+      - uses: pypa/gh-action-pypi-publish@v1.6.4
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
XRef #1111 

Now, creating a new release on GitHub will trigger GitHub Actions to automatically build DeeoXDE and publish it to PyPI, without any manual work. One will also be able to trigger the release process manually from the Actions tab (`workflow_dispatch`).

This will require adding a new PyPI API token as a repository secret in DeepXDE's GitHub repository. This secret should be named `PYPI_API_TOKEN`.