### PR TITLE
speed up construction of indices for sparse tensor

### DIFF
--- a/examples/pinn_forward/fractional_Poisson_1d.py
+++ b/examples/pinn_forward/fractional_Poisson_1d.py
@@ -32,7 +32,12 @@ def fpde(x, y, int_mat):
 #     """(D_{0+}^alpha + D_{1-}^alpha) u(x) = f(x)"""
 #     if isinstance(int_mat, (list, tuple)) and len(int_mat) == 3:
 #         indices, values, shape = int_mat
-#         int_mat = paddle.sparse.sparse_coo_tensor(list(zip(*indices)), values, shape, stop_gradient=False)
+#         int_mat = paddle.sparse.sparse_coo_tensor(
+#             [[p[0] for p in indices], [p[1] for p in indices]],
+#             values,
+#             shape,
+#             stop_gradient=False
+#         )
 #         lhs = paddle.sparse.matmul(int_mat, y)
 #     else:
 #         int_mat = paddle.to_tensor(int_mat, dde.config.real(paddle), stop_gradient=False)

--- a/examples/pinn_forward/fractional_Poisson_2d.py
+++ b/examples/pinn_forward/fractional_Poisson_2d.py
@@ -34,7 +34,12 @@ def fpde(x, y, int_mat):
 #     """\int_theta D_theta^alpha u(x)"""
 #     if isinstance(int_mat, (list, tuple)) and len(int_mat) == 3:
 #         indices, values, shape = int_mat
-#         int_mat = paddle.sparse.sparse_coo_tensor(list(zip(*indices)), values, shape, stop_gradient=False)
+#         int_mat = paddle.sparse.sparse_coo_tensor(
+#             [[p[0] for p in indices], [p[1] for p in indices]],
+#             values,
+#             shape,
+#             stop_gradient=False
+#         )
 #         lhs = paddle.sparse.matmul(int_mat, y)
 #     else:
 #         int_mat = paddle.to_tensor(int_mat, dde.config.real(paddle), stop_gradient=False)

--- a/examples/pinn_forward/fractional_Poisson_3d.py
+++ b/examples/pinn_forward/fractional_Poisson_3d.py
@@ -35,7 +35,12 @@ def fpde(x, y, int_mat):
 #     """\int_theta D_theta^alpha u(x)"""
 #     if isinstance(int_mat, (list, tuple)) and len(int_mat) == 3:
 #         indices, values, shape = int_mat
-#         int_mat = paddle.sparse.sparse_coo_tensor(list(zip(*indices)), values, shape, stop_gradient=False)
+#         int_mat = paddle.sparse.sparse_coo_tensor(
+#             [[p[0] for p in indices], [p[1] for p in indices]],
+#             values,
+#             shape,
+#             stop_gradient=False
+#         )
 #         lhs = paddle.sparse.matmul(int_mat, y)
 #     else:
 #         int_mat = paddle.to_tensor(int_mat, dde.config.real(paddle), stop_gradient=False)

--- a/examples/pinn_forward/fractional_diffusion_1d.py
+++ b/examples/pinn_forward/fractional_diffusion_1d.py
@@ -34,7 +34,12 @@ def fpde(x, y, int_mat):
 #     """du/dt + (D_{0+}^alpha + D_{1-}^alpha) u(x) = f(x)"""
 #     if isinstance(int_mat, (list, tuple)) and len(int_mat) == 3:
 #         indices, values, shape = int_mat
-#         int_mat = paddle.sparse.sparse_coo_tensor(list(zip(*indices)), values, shape, stop_gradient=False)
+#         int_mat = paddle.sparse.sparse_coo_tensor(
+#             [[p[0] for p in indices], [p[1] for p in indices]],
+#             values,
+#             shape,
+#             stop_gradient=False
+#         )
 #         lhs = -paddle.sparse.matmul(int_mat, y)
 #     else:
 #         int_mat = paddle.to_tensor(int_mat, dde.config.real(paddle), stop_gradient=False)

--- a/examples/pinn_inverse/fractional_Poisson_1d_inverse.py
+++ b/examples/pinn_inverse/fractional_Poisson_1d_inverse.py
@@ -27,7 +27,12 @@ def fpde(x, y, int_mat):
 #     """(D_{0+}^alpha + D_{1-}^alpha) u(x)"""
 #     if isinstance(int_mat, (list, tuple)) and len(int_mat) == 3:
 #         indices, values, shape = int_mat
-#         int_mat = paddle.sparse.sparse_coo_tensor(list(zip(*indices)), values, shape, stop_gradient=False)
+#         int_mat = paddle.sparse.sparse_coo_tensor(
+#             [[p[0] for p in indices], [p[1] for p in indices]],
+#             values,
+#             shape,
+#             stop_gradient=False
+#         )
 #         lhs = paddle.sparse.matmul(int_mat, y)
 #     else:
 #         lhs = paddle.mm(int_mat, y)

--- a/examples/pinn_inverse/fractional_Poisson_2d_inverse.py
+++ b/examples/pinn_inverse/fractional_Poisson_2d_inverse.py
@@ -37,7 +37,12 @@ def fpde(x, y, int_mat):
 #     r"""\int_theta D_theta^alpha u(x)"""
 #     if isinstance(int_mat, (list, tuple)) and len(int_mat) == 3:
 #         indices, values, shape = int_mat
-#         int_mat = paddle.sparse.sparse_coo_tensor(list(zip(*indices)), values, shape, stop_gradient=False)
+#         int_mat = paddle.sparse.sparse_coo_tensor(
+#             [[p[0] for p in indices], [p[1] for p in indices]],
+#             values,
+#             shape,
+#             stop_gradient=False
+#         )
 #         lhs = paddle.sparse.matmul(int_mat, y)
 #     else:
 #         lhs = paddle.mm(int_mat, y)


### PR DESCRIPTION
replace list(zip()) with nested list comprehension to speed up construction of indices for sparse tensor

python3.7 

```python
import time
import random

n = 1252319
array = [[random.randint(0, n), random.randint(0, n)] for _ in range(n)]

s = time.perf_counter()
res1 = zip(*array)
e1 = time.perf_counter()
print(f"zip(...) cost: {e1 - s}")

s = time.perf_counter()
res1 = list(res1)
e2 = time.perf_counter()
print(f"list(...) cost: {e2 - s}")

s = time.perf_counter()
res2 = [tuple([p[0] for p in array]), tuple([p[1] for p in array])]
e2 = time.perf_counter()
print(f"list comprehension cost: {e2 - s}")

print(res1 == res2)

"""
zip(...) cost: 0.6884705810807645
list(...) cost: 0.0964503069408238
list comprehension cost: 0.1501797849778086
True
"""
```