### PR TITLE
remove fixed old version for imagemagick

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ COPY requirements.txt /root
 WORKDIR /root
 RUN /usr/bin/python -m pip install --upgrade pip
 RUN pip3 install -r requirements.txt 
-RUN apt-get update && apt-get install -y --no-install-recommends imagemagick=8:6.9.7.4+dfsg-16ubuntu6.12 \
+RUN apt-get update && apt-get install -y --no-install-recommends imagemagick \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 EXPOSE 8888/tcp


### PR DESCRIPTION
There was a specific version of imagemagick requested, but that version is not available anymore from the base image, resulting in the following docker build error:

```
#10 18.69 E: Version '8:6.9.7.4+dfsg-16ubuntu6.12' for 'imagemagick' was not found
------
executor failed running [/bin/bash -euo pipefail -c apt-get update && apt-get install -y --no-install-recommends imagemagick=8:6.9.7.4+dfsg-16ubuntu6.12  && apt-get clean  && rm -rf /var/lib/apt/lists/*]: exit code: 100
```

When the version is removed it builds successfully.