### PR TITLE
rm redundant condition while testing with Paddle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
           python -c "import deepxde"
 
       - name: Test build with Paddle(MacOS)
-        if: matrix.os == 'macos-latest' && matrix.python-version != 3.11  # not available on Python 3.11
+        if: matrix.os == 'macos-latest'
         run: |
           python -m pip install paddlepaddle==0.0.0 -f https://www.paddlepaddle.org.cn/whl/mac/cpu-noavx/develop.html
           python -c "import deepxde"
@@ -73,7 +73,7 @@ jobs:
           DDE_BACKEND: paddle
 
       - name: Test build with Paddle(Linux)
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.11  # not available on Python 3.11
+        if: matrix.os == 'ubuntu-latest'
         run: |
           python -m pip install paddlepaddle==0.0.0 -f https://www.paddlepaddle.org.cn/whl/linux/cpu-mkl/develop.html
           python -c "import deepxde"
@@ -81,7 +81,7 @@ jobs:
           DDE_BACKEND: paddle
 
       - name: Test build with Paddle(Windows)
-        if: matrix.os == 'windows-latest' && matrix.python-version != 3.11  # not available on Python 3.11
+        if: matrix.os == 'windows-latest'
         run: |
           python -m pip install paddlepaddle==0.0.0 -f https://www.paddlepaddle.org.cn/whl/windows/cpu-mkl-avx/develop.html
           python -c "import deepxde"


### PR DESCRIPTION
DeepXDE is not tested on Python 3.11; hence, the Python condition is redundant here. This should not affect anything. This will only make the YAML file a bit cleaner.