### PR TITLE
add DeepONet with pytorch backend in __init__ file

### DIFF
--- a/deepxde/nn/pytorch/__init__.py
+++ b/deepxde/nn/pytorch/__init__.py
@@ -1,6 +1,7 @@
 """Package for pytorch NN modules."""
 
 __all__ = [
+    "DeepONet",
     "DeepONetCartesianProd",
     "FNN",
     "MIONetCartesianProd",
@@ -10,7 +11,7 @@ __all__ = [
     "PODMIONet",
 ]
 
-from .deeponet import DeepONetCartesianProd, PODDeepONet
+from .deeponet import DeepONet, DeepONetCartesianProd, PODDeepONet
 from .mionet import MIONetCartesianProd, PODMIONet
 from .fnn import FNN, PFNN
 from .nn import NN


### PR DESCRIPTION
I noticed that DeepONet has already been implemented but not declared in the init file. Not 100% familiar with the repo but I think adding this line make the module available for the torch backend.