### PR TITLE
Fix docs by installing `torch<2.0.0`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
     python: "3.8"
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,7 @@ tensorflow>=2.7.0
 # TensorFlow 2.x
 tensorflow-probability>=0.10.0
 # PyTorch
-torch<2.0.0
+torch>=1.9.0
 # PaddlePaddle
 paddlepaddle>=2.3.0
 # JAX

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,7 @@ tensorflow>=2.7.0
 # TensorFlow 2.x
 tensorflow-probability>=0.10.0
 # PyTorch
-torch>=1.9.0
+torch<2.0.0    # build fails on RTD with torch 2.0.0
 # PaddlePaddle
 paddlepaddle>=2.3.0
 # JAX

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,7 @@ tensorflow>=2.7.0
 # TensorFlow 2.x
 tensorflow-probability>=0.10.0
 # PyTorch
-torch<2.0.0    # build fails on RTD with torch 2.0.0
+torch>=1.9.0
 # PaddlePaddle
 paddlepaddle>=2.3.0
 # JAX

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,7 @@ tensorflow>=2.7.0
 # TensorFlow 2.x
 tensorflow-probability>=0.10.0
 # PyTorch
-torch>=1.9.0 --index-url https://download.pytorch.org/whl/cpu
+torch<2.0.0
 # PaddlePaddle
 paddlepaddle>=2.3.0
 # JAX

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,7 @@ tensorflow>=2.7.0
 # TensorFlow 2.x
 tensorflow-probability>=0.10.0
 # PyTorch
-torch>=1.9.0
+torch<=2.0.0
 # PaddlePaddle
 paddlepaddle>=2.3.0
 # JAX

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,7 @@ tensorflow>=2.7.0
 # TensorFlow 2.x
 tensorflow-probability>=0.10.0
 # PyTorch
-torch>=1.9.0
+torch>=1.9.0 --index-url https://download.pytorch.org/whl/cpu
 # PaddlePaddle
 paddlepaddle>=2.3.0
 # JAX

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,7 @@ tensorflow>=2.7.0
 # TensorFlow 2.x
 tensorflow-probability>=0.10.0
 # PyTorch
-torch<2.0.0
+torch<2.0.0    # build fails on RTD with torch 2.0.0
 # PaddlePaddle
 paddlepaddle>=2.3.0
 # JAX

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,7 @@ tensorflow>=2.7.0
 # TensorFlow 2.x
 tensorflow-probability>=0.10.0
 # PyTorch
-torch<=2.0.0
+torch<2.0.0
 # PaddlePaddle
 paddlepaddle>=2.3.0
 # JAX


### PR DESCRIPTION
- Upper cap torch to `<2.0.0` to make the build work
- Bump the `Ubuntu` image version to the latest LTS version - `22.04`

For future reference, the error we are facing with the `torch` build -
```
Setting the default backend to "tensorflow.compat.v1". You can change it in the ~/.deepxde/config.json file or export the DDE_BACKEND environment variable. Valid options are: tensorflow.compat.v1, tensorflow, pytorch, jax, paddle (all lowercase)
reading sources... [ 62%] modules/deepxde.backend
reading sources... [ 64%] modules/deepxde.backend.jax
reading sources... [ 65%] modules/deepxde.backend.paddle
reading sources... [ 67%] modules/deepxde.backend.pytorch
terminate called after throwing an instance of 'std::runtime_error'
  what():  random_device could not be read
Aborted (core dumped)
```

