### PR TITLE
Modify some examples to support paddle with an uniform format

### DIFF
--- a/examples/pinn_forward/Helmholtz_Dirichlet_2d.py
+++ b/examples/pinn_forward/Helmholtz_Dirichlet_2d.py
@@ -11,15 +11,27 @@ weights = 100  # if hard_constraint == False
 iterations = 5000
 parameters = [1e-3, 3, 150, "sin"]
 
-# Define sine function
-if dde.backend.backend_name == "pytorch":
-    sin = dde.backend.pytorch.sin
-elif dde.backend.backend_name == "paddle":
-    sin = dde.backend.paddle.sin
-else:
+# Define function
+if dde.backend.backend_name == "paddle":
+    # Backend paddle
+    import paddle
+
+    sin = paddle.sin
+elif dde.backend.backend_name == "pytorch":
+    # Backend pytorch
+    import torch
+
+    sin = torch.sin
+elif dde.backend.backend_name in ["tensorflow.compat.v1", "tensorflow"]:
+    # Backend tensorflow.compat.v1 or tensorflow
     from deepxde.backend import tf
 
     sin = tf.sin
+elif dde.backend.backend_name == "jax":
+    # Backend jax
+    import jax.numpy as jnp
+
+    sin = jnp.sin
 
 learning_rate, num_dense_layers, num_dense_nodes, activation = parameters
 
@@ -28,8 +40,8 @@ def pde(x, y):
     dy_xx = dde.grad.hessian(y, x, i=0, j=0)
     dy_yy = dde.grad.hessian(y, x, i=1, j=1)
 
-    f = k0 ** 2 * sin(k0 * x[:, 0:1]) * sin(k0 * x[:, 1:2])
-    return -dy_xx - dy_yy - k0 ** 2 * y - f
+    f = k0**2 * sin(k0 * x[:, 0:1]) * sin(k0 * x[:, 1:2])
+    return -dy_xx - dy_yy - k0**2 * y - f
 
 
 def func(x):
@@ -65,10 +77,10 @@ data = dde.data.PDE(
     geom,
     pde,
     bc,
-    num_domain=nx_train ** 2,
+    num_domain=nx_train**2,
     num_boundary=4 * nx_train,
     solution=func,
-    num_test=nx_test ** 2,
+    num_test=nx_test**2,
 )
 
 net = dde.nn.FNN(

--- a/examples/pinn_forward/Helmholtz_Dirichlet_2d_HPO.py
+++ b/examples/pinn_forward/Helmholtz_Dirichlet_2d_HPO.py
@@ -9,12 +9,27 @@ from skopt.plots import plot_convergence, plot_objective
 from skopt.space import Real, Categorical, Integer
 from skopt.utils import use_named_args
 
-if dde.backend.backend_name == "pytorch":
-    sin = dde.backend.pytorch.sin
-else:
+# Define function
+if dde.backend.backend_name == "paddle":
+    # Backend paddle
+    import paddle
+
+    sin = paddle.sin
+elif dde.backend.backend_name == "pytorch":
+    # Backend pytorch
+    import torch
+
+    sin = torch.sin
+elif dde.backend.backend_name in ["tensorflow.compat.v1", "tensorflow"]:
+    # Backend tensorflow.compat.v1 or tensorflow
     from deepxde.backend import tf
 
     sin = tf.sin
+elif dde.backend.backend_name == "jax":
+    # Backend jax
+    import jax.numpy as jnp
+
+    sin = jnp.sin
 
 # General parameters
 d = 2
@@ -110,7 +125,6 @@ default_parameters = [1e-3, 4, 50, "sin"]
 
 @use_named_args(dimensions=dimensions)
 def fitness(learning_rate, num_dense_layers, num_dense_nodes, activation):
-
     config = [learning_rate, num_dense_layers, num_dense_nodes, activation]
     global ITERATION
 

--- a/examples/pinn_forward/Helmholtz_Neumann_2d_hole.py
+++ b/examples/pinn_forward/Helmholtz_Neumann_2d_hole.py
@@ -23,7 +23,7 @@ activation = "sin"
 k0 = 2 * np.pi * n
 wave_len = 1 / n
 
-# Define sine function
+# Define function
 if dde.backend.backend_name in ["tensorflow.compat.v1", "tensorflow"]:
     from deepxde.backend import tf
 
@@ -36,6 +36,11 @@ elif dde.backend.backend_name == "paddle":
     import paddle
 
     sin = paddle.sin
+elif dde.backend.backend_name == "jax":
+    # Backend jax
+    import jax.numpy as jnp
+
+    sin = jnp.sin
 
 
 def pde(x, y):

--- a/examples/pinn_forward/Klein_Gordon.py
+++ b/examples/pinn_forward/Klein_Gordon.py
@@ -8,16 +8,22 @@ geom = dde.geometry.Interval(-1, 1)
 timedomain = dde.geometry.TimeDomain(0, 10)
 geomtime = dde.geometry.GeometryXTime(geom, timedomain)
 
-
-# Define sine function
-if dde.backend.backend_name in ["tensorflow.compat.v1", "tensorflow"]:
-    from deepxde.backend import tf
-
-    cos = tf.math.cos
-elif dde.backend.backend_name == "paddle":
+# Define function
+if dde.backend.backend_name == "paddle":
+    # Backend paddle
     import paddle
 
     cos = paddle.cos
+elif dde.backend.backend_name in ["tensorflow.compat.v1", "tensorflow"]:
+    # Backend tensorflow.compat.v1 or tensorflow
+    from deepxde.backend import tf
+
+    cos = tf.math.cos
+elif dde.backend.backend_name == "jax":
+    # Backend jax
+    import jax.numpy as jnp
+
+    cos = jnp.cos
 
 
 def pde(x, y):
@@ -29,9 +35,9 @@ def pde(x, y):
         dy_tt
         + alpha * dy_xx
         + beta * y
-        + gamma * (y ** k)
+        + gamma * (y**k)
         + x * cos(t)
-        - (x ** 2) * (cos(t) ** 2)
+        - (x**2) * (cos(t) ** 2)
     )
 
 

--- a/examples/pinn_forward/Laplace_disk.py
+++ b/examples/pinn_forward/Laplace_disk.py
@@ -1,12 +1,36 @@
 """Backend supported: tensorflow.compat.v1, tensorflow, pytorch, paddle"""
 import deepxde as dde
 import numpy as np
-# Import tf if using backend tensorflow.compat.v1 or tensorflow
-from deepxde.backend import tf
-# Import torch if using backend pytorch
-# import torch
-# Import paddle if using backend paddle
-# import paddle
+
+# Define function
+if dde.backend.backend_name == "paddle":
+    # Backend paddle
+    import paddle
+
+    sin = paddle.sin
+    cos = paddle.cos
+    concat = paddle.concat
+elif dde.backend.backend_name == "pytorch":
+    # Backend pytorch
+    import torch
+
+    sin = torch.sin
+    cos = torch.cos
+    concat = torch.cat
+elif dde.backend.backend_name in ["tensorflow.compat.v1", "tensorflow"]:
+    # Backend tensorflow.compat.v1 or tensorflow
+    from deepxde.backend import tf
+
+    sin = tf.sin
+    cos = tf.cos
+    concat = tf.concat
+elif dde.backend.backend_name == "jax":
+    # Backend jax
+    import jax.numpy as jnp
+
+    sin = jnp.sin
+    cos = jnp.cos
+    concat = jnp.concatenate
 
 
 def pde(x, y):
@@ -33,22 +57,18 @@ data = dde.data.PDE(
 
 net = dde.nn.FNN([2] + [20] * 3 + [1], "tanh", "Glorot normal")
 
+
 # Use [r*sin(theta), r*cos(theta)] as features,
 # so that the network is automatically periodic along the theta coordinate.
-# Backend tensorflow.compat.v1 or tensorflow
+# Backend tensorflow.compat.v1 or tensorflow or paddle or jax
 def feature_transform(x):
-    return tf.concat(
-        [x[:, 0:1] * tf.sin(x[:, 1:2]), x[:, 0:1] * tf.cos(x[:, 1:2])], axis=1
-    )
+    return concat([x[:, 0:1] * sin(x[:, 1:2]), x[:, 0:1] * cos(x[:, 1:2])], axis=1)
+
+
 # Backend pytorch
 # def feature_transform(x):
-#     return torch.cat(
-#         [x[:, 0:1] * torch.sin(x[:, 1:2]), x[:, 0:1] * torch.cos(x[:, 1:2])], dim=1
-#     )
-# Backend paddle
-# def feature_transform(x):
-#     return paddle.concat(
-#         [x[:, 0:1] * paddle.sin(x[:, 1:2]), x[:, 0:1] * paddle.cos(x[:, 1:2])], axis=1
+#     return cat(
+#         [x[:, 0:1] * sin(x[:, 1:2]), x[:, 0:1] * cos(x[:, 1:2])], dim=1
 #     )
 
 net.apply_feature_transform(feature_transform)

--- a/examples/pinn_forward/Poisson_Dirichlet_1d.py
+++ b/examples/pinn_forward/Poisson_Dirichlet_1d.py
@@ -2,22 +2,33 @@
 import deepxde as dde
 import matplotlib.pyplot as plt
 import numpy as np
-# Import tf if using backend tensorflow.compat.v1 or tensorflow
-from deepxde.backend import tf
-# Import torch if using backend pytorch
-# import torch
-# Import paddle if using backend paddle
-# import paddle
+
+# Define function
+if dde.backend.backend_name == "paddle":
+    # Backend paddle
+    import paddle
+
+    sin = paddle.sin
+elif dde.backend.backend_name == "pytorch":
+    # Backend pytorch
+    import torch
+
+    sin = torch.sin
+elif dde.backend.backend_name in ["tensorflow.compat.v1", "tensorflow"]:
+    # Backend tensorflow.compat.v1 or tensorflow
+    from deepxde.backend import tf
+
+    sin = tf.sin
+elif dde.backend.backend_name == "jax":
+    # Backend jax
+    import jax.numpy as jnp
+
+    sin = jnp.sin
 
 
 def pde(x, y):
     dy_xx = dde.grad.hessian(y, x)
-    # Use tf.sin for backend tensorflow.compat.v1 or tensorflow
-    return -dy_xx - np.pi ** 2 * tf.sin(np.pi * x)
-    # Use torch.sin for backend pytorch
-    # return -dy_xx - np.pi ** 2 * torch.sin(np.pi * x)
-    # Use paddle.sin for backend paddle
-    # return -dy_xx - np.pi ** 2 * paddle.sin(np.pi * x)
+    return -dy_xx - np.pi**2 * sin(np.pi * x)
 
 
 def boundary(x, on_boundary):

--- a/examples/pinn_forward/Poisson_Dirichlet_1d_exactBC.py
+++ b/examples/pinn_forward/Poisson_Dirichlet_1d_exactBC.py
@@ -4,16 +4,27 @@ import numpy as np
 
 geom = dde.geometry.Interval(0, np.pi)
 
-
-# Define sine function
-if dde.backend.backend_name in ["tensorflow.compat.v1", "tensorflow"]:
-    from deepxde.backend import tf
-
-    sin = tf.sin
-elif dde.backend.backend_name == "paddle":
+# Define function
+if dde.backend.backend_name == "paddle":
+    # Backend paddle
     import paddle
 
     sin = paddle.sin
+elif dde.backend.backend_name in ["tensorflow.compat.v1", "tensorflow"]:
+    # Backend tensorflow.compat.v1 or tensorflow
+    from deepxde.backend import tf
+
+    sin = tf.sin
+elif dde.backend.backend_name == "pytorch":
+    # Backend pytorch
+    import torch
+
+    sin = torch.sin
+elif dde.backend.backend_name == "jax":
+    # Backend jax
+    import jax.numpy as jnp
+
+    sin = jnp.sin
 
 
 def pde(x, y):
@@ -21,24 +32,30 @@ def pde(x, y):
     summation = sum([i * sin(i * x) for i in range(1, 5)])
     return -dy_xx - summation - 8 * sin(8 * x)
 
+
 def func(x):
     summation = sum([np.sin(i * x) / i for i in range(1, 5)])
     return x + summation + np.sin(8 * x) / 8
 
+
 data = dde.data.PDE(geom, pde, [], num_domain=64, solution=func, num_test=400)
 
 layer_size = [1] + [50] * 3 + [1]
-activation = 'tanh'
-initializer = 'Glorot uniform'
+activation = "tanh"
+initializer = "Glorot uniform"
 net = dde.nn.FNN(layer_size, activation, initializer)
+
 
 def output_transform(x, y):
     return x * (np.pi - x) * y + x
 
+
 net.apply_output_transform(output_transform)
 
 model = dde.Model(data, net)
-model.compile("adam", lr=1e-4, decay=("inverse time", 1000, 0.3), metrics=["l2 relative error"])
+model.compile(
+    "adam", lr=1e-4, decay=("inverse time", 1000, 0.3), metrics=["l2 relative error"]
+)
 
 losshistory, train_state = model.train(iterations=30000)
 

--- a/examples/pinn_forward/Poisson_multiscale_1d.py
+++ b/examples/pinn_forward/Poisson_multiscale_1d.py
@@ -10,16 +10,27 @@ import numpy as np
 A = 2
 B = 50
 
-
-# Define sine function
-if dde.backend.backend_name in ["tensorflow.compat.v1", "tensorflow"]:
-    from deepxde.backend import tf
-
-    sin = tf.sin
-elif dde.backend.backend_name == "paddle":
+# Define function
+if dde.backend.backend_name == "paddle":
+    # Backend paddle
     import paddle
 
     sin = paddle.sin
+elif dde.backend.backend_name in ["tensorflow.compat.v1", "tensorflow"]:
+    # Backend tensorflow.compat.v1 or tensorflow
+    from deepxde.backend import tf
+
+    sin = tf.sin
+elif dde.backend.backend_name == "pytorch":
+    # Backend pytorch
+    import torch
+
+    sin = torch.sin
+elif dde.backend.backend_name == "jax":
+    # Backend jax
+    import jax.numpy as jnp
+
+    sin = jnp.sin
 
 
 def pde(x, y):

--- a/examples/pinn_forward/Poisson_periodic_1d.py
+++ b/examples/pinn_forward/Poisson_periodic_1d.py
@@ -1,22 +1,33 @@
 """Backend supported: tensorflow.compat.v1, tensorflow, pytorch, paddle"""
 import deepxde as dde
 import numpy as np
-# Import tf if using backend tensorflow.compat.v1 or tensorflow
-from deepxde.backend import tf
-# Import torch if using backend pytorch
-# import torch
-# Import paddle if using backend paddle
-# import paddle
+
+# Define function
+if dde.backend.backend_name == "paddle":
+    # Backend paddle
+    import paddle
+
+    sin = paddle.sin
+elif dde.backend.backend_name == "pytorch":
+    # Backend pytorch
+    import torch
+
+    sin = torch.sin
+elif dde.backend.backend_name in ["tensorflow.compat.v1", "tensorflow"]:
+    # Backend tensorflow.compat.v1 or tensorflow
+    from deepxde.backend import tf
+
+    sin = tf.sin
+elif dde.backend.backend_name == "jax":
+    # Backend jax
+    import jax.numpy as jnp
+
+    sin = jnp.sin
 
 
 def pde(x, y):
     dy_xx = dde.grad.hessian(y, x)
-    # Use tf.sin for backend tensorflow.compat.v1 or tensorflow
-    return -dy_xx - np.pi ** 2 * tf.sin(np.pi * x)
-    # Use torch.sin for backend pytorch
-    # return -dy_xx - np.pi ** 2 * torch.sin(np.pi * x)
-    # Use paddle.sin for backend paddle
-    # return -dy_xx - np.pi ** 2 * paddle.sin(np.pi * x)
+    return -dy_xx - np.pi**2 * sin(np.pi * x)
 
 
 def boundary_l(x, on_boundary):

--- a/examples/pinn_forward/diffusion_1d.py
+++ b/examples/pinn_forward/diffusion_1d.py
@@ -1,12 +1,32 @@
 """Backend supported: tensorflow.compat.v1, tensorflow, pytorch, paddle"""
 import deepxde as dde
 import numpy as np
-# Backend tensorflow.compat.v1 or tensorflow
-from deepxde.backend import tf
-# Backend pytorch
-# import torch
-# Backend paddle
-# import paddle
+
+# Define function
+if dde.backend.backend_name == "paddle":
+    # Backend paddle
+    import paddle
+
+    sin = paddle.sin
+    exp = paddle.exp
+elif dde.backend.backend_name == "pytorch":
+    # Backend pytorch
+    import torch
+
+    sin = torch.sin
+    exp = torch.exp
+elif dde.backend.backend_name in ["tensorflow.compat.v1", "tensorflow"]:
+    # Backend tensorflow.compat.v1 or tensorflow
+    from deepxde.backend import tf
+
+    sin = tf.sin
+    exp = tf.exp
+elif dde.backend.backend_name == "jax":
+    # Backend jax
+    import jax.numpy as jnp
+
+    sin = jnp.sin
+    exp = jnp.exp
 
 
 def pde(x, y):
@@ -16,23 +36,9 @@ def pde(x, y):
     return (
         dy_t
         - dy_xx
-        + tf.exp(-x[:, 1:])
-        * (tf.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * tf.sin(np.pi * x[:, 0:1]))
+        + exp(-x[:, 1:])
+        * (sin(np.pi * x[:, 0:1]) - np.pi**2 * sin(np.pi * x[:, 0:1]))
     )
-    # Backend pytorch
-    # return (
-    #     dy_t
-    #     - dy_xx
-    #     + torch.exp(-x[:, 1:])
-    #     * (torch.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * torch.sin(np.pi * x[:, 0:1]))
-    # )
-    # Backend paddle
-    # return (
-    #     dy_t
-    #     - dy_xx
-    #     + paddle.exp(-x[:, 1:])
-    #     * (paddle.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * paddle.sin(np.pi * x[:, 0:1]))
-    # )
 
 
 def func(x):

--- a/examples/pinn_forward/diffusion_1d_exactBC.py
+++ b/examples/pinn_forward/diffusion_1d_exactBC.py
@@ -1,38 +1,43 @@
 """Backend supported: tensorflow.compat.v1, tensorflow, pytorch, paddle"""
 import deepxde as dde
 import numpy as np
-# Backend tensorflow.compat.v1 or tensorflow
-from deepxde.backend import tf
-# Backend pytorch
-# import torch
-# Backend paddle
-# import paddle
+
+# Define function
+if dde.backend.backend_name == "paddle":
+    # Backend paddle
+    import paddle
+
+    sin = paddle.sin
+    exp = paddle.exp
+elif dde.backend.backend_name == "pytorch":
+    # Backend pytorch
+    import torch
+
+    sin = torch.sin
+    exp = torch.exp
+elif dde.backend.backend_name in ["tensorflow.compat.v1", "tensorflow"]:
+    # Backend tensorflow.compat.v1 or tensorflow
+    from deepxde.backend import tf
+
+    sin = tf.sin
+    exp = tf.exp
+elif dde.backend.backend_name == "jax":
+    # Backend jax
+    import jax.numpy as jnp
+
+    sin = jnp.sin
+    exp = jnp.exp
 
 
 def pde(x, y):
     dy_t = dde.grad.jacobian(y, x, i=0, j=1)
     dy_xx = dde.grad.hessian(y, x, i=0, j=0)
-    # Backend tensorflow.compat.v1 or tensorflow
     return (
         dy_t
         - dy_xx
-        + tf.exp(-x[:, 1:])
-        * (tf.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * tf.sin(np.pi * x[:, 0:1]))
+        + exp(-x[:, 1:])
+        * (sin(np.pi * x[:, 0:1]) - np.pi**2 * sin(np.pi * x[:, 0:1]))
     )
-    # Backend pytorch
-    # return (
-    #     dy_t
-    #     - dy_xx
-    #     + torch.exp(-x[:, 1:])
-    #     * (torch.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * torch.sin(np.pi * x[:, 0:1]))
-    # )
-    # Backend paddle
-    # return (
-    #     dy_t
-    #     - dy_xx
-    #     + paddle.exp(-x[:, 1:])
-    #     * (paddle.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * paddle.sin(np.pi * x[:, 0:1]))
-    # )
 
 
 def func(x):
@@ -50,12 +55,7 @@ activation = "tanh"
 initializer = "Glorot uniform"
 net = dde.nn.FNN(layer_size, activation, initializer)
 net.apply_output_transform(
-    # Backend tensorflow.compat.v1 or tensorflow
-    lambda x, y: x[:, 1:2] * (1 - x[:, 0:1] ** 2) * y + tf.sin(np.pi * x[:, 0:1])
-    # Backend pytorch
-    # lambda x, y: x[:, 1:2] * (1 - x[:, 0:1] ** 2) * y + torch.sin(np.pi * x[:, 0:1])
-    # Backend paddle
-    # lambda x, y: x[:, 1:2] * (1 - x[:, 0:1] ** 2) * y + paddle.sin(np.pi * x[:, 0:1])
+    lambda x, y: x[:, 1:2] * (1 - x[:, 0:1] ** 2) * y + sin(np.pi * x[:, 0:1])
 )
 
 model = dde.Model(data, net)

--- a/examples/pinn_forward/diffusion_1d_resample.py
+++ b/examples/pinn_forward/diffusion_1d_resample.py
@@ -1,12 +1,32 @@
 """Backend supported: tensorflow.compat.v1, tensorflow, pytorch, paddle"""
 import deepxde as dde
 import numpy as np
-# Backend tensorflow.compat.v1 or tensorflow
-from deepxde.backend import tf
-# Backend pytorch
-# import torch
-# Backend paddle
-# import paddle
+
+# Define function
+if dde.backend.backend_name == "paddle":
+    # Backend paddle
+    import paddle
+
+    sin = paddle.sin
+    exp = paddle.exp
+elif dde.backend.backend_name == "pytorch":
+    # Backend pytorch
+    import torch
+
+    sin = torch.sin
+    exp = torch.exp
+elif dde.backend.backend_name in ["tensorflow.compat.v1", "tensorflow"]:
+    # Backend tensorflow.compat.v1 or tensorflow
+    from deepxde.backend import tf
+
+    sin = tf.sin
+    exp = tf.exp
+elif dde.backend.backend_name == "jax":
+    # Backend jax
+    import jax.numpy as jnp
+
+    sin = jnp.sin
+    exp = jnp.exp
 
 
 def pde(x, y):
@@ -16,23 +36,9 @@ def pde(x, y):
     return (
         dy_t
         - dy_xx
-        + tf.exp(-x[:, 1:])
-        * (tf.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * tf.sin(np.pi * x[:, 0:1]))
+        + exp(-x[:, 1:])
+        * (sin(np.pi * x[:, 0:1]) - np.pi**2 * sin(np.pi * x[:, 0:1]))
     )
-    # Backend pytorch
-    # return (
-    #     dy_t
-    #     - dy_xx
-    #     + torch.exp(-x[:, 1:])
-    #     * (torch.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * torch.sin(np.pi * x[:, 0:1]))
-    # )
-    # Backend paddle
-    # return (
-    #     dy_t
-    #     - dy_xx
-    #     + paddle.exp(-x[:, 1:])
-    #     * (paddle.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * paddle.sin(np.pi * x[:, 0:1]))
-    # )
 
 
 def func(x):

--- a/examples/pinn_forward/diffusion_reaction.py
+++ b/examples/pinn_forward/diffusion_reaction.py
@@ -1,12 +1,32 @@
 """Backend supported: tensorflow.compat.v1, tensorflow, pytorch, paddle"""
 import deepxde as dde
 import numpy as np
-# Backend tensorflow.compat.v1 or tensorflow
-from deepxde.backend import tf
-# Backend pytorch
-# import torch
-# Backend paddle
-# import paddle
+
+# Define function
+if dde.backend.backend_name == "paddle":
+    # Backend paddle
+    import paddle
+
+    sin = paddle.sin
+    exp = paddle.exp
+elif dde.backend.backend_name == "pytorch":
+    # Backend pytorch
+    import torch
+
+    sin = torch.sin
+    exp = torch.exp
+elif dde.backend.backend_name in ["tensorflow.compat.v1", "tensorflow"]:
+    # Backend tensorflow.compat.v1 or tensorflow
+    from deepxde.backend import tf
+
+    sin = tf.sin
+    exp = tf.exp
+elif dde.backend.backend_name == "jax":
+    # Backend jax
+    import jax.numpy as jnp
+
+    sin = jnp.sin
+    exp = jnp.exp
 
 
 def pde(x, y):
@@ -17,36 +37,14 @@ def pde(x, y):
     return (
         dy_t
         - d * dy_xx
-        - tf.exp(-x[:, 1:])
+        - exp(-x[:, 1:])
         * (
-            3 * tf.sin(2 * x[:, 0:1]) / 2
-            + 8 * tf.sin(3 * x[:, 0:1]) / 3
-            + 15 * tf.sin(4 * x[:, 0:1]) / 4
-            + 63 * tf.sin(8 * x[:, 0:1]) / 8
+            3 * sin(2 * x[:, 0:1]) / 2
+            + 8 * sin(3 * x[:, 0:1]) / 3
+            + 15 * sin(4 * x[:, 0:1]) / 4
+            + 63 * sin(8 * x[:, 0:1]) / 8
         )
     )
-    # Backend pytorch
-    # return (
-    #     dy_t
-    #     - d * dy_xx
-    #     - torch.exp(-x[:, 1:])
-    #     * (3 * torch.sin(2 * x[:, 0:1]) / 2
-    #        + 8 * torch.sin(3 * x[:, 0:1]) / 3
-    #        + 15 * torch.sin(4 * x[:, 0:1]) / 4
-    #        + 63 * torch.sin(8 * x[:, 0:1]) / 8
-    #     )
-    # )
-    # Backend paddle
-    # return (
-    #     dy_t
-    #     - d * dy_xx
-    #     - paddle.exp(-x[:, 1:])
-    #     * (3 * paddle.sin(2 * x[:, 0:1]) / 2
-    #        + 8 * paddle.sin(3 * x[:, 0:1]) / 3
-    #        + 15 * paddle.sin(4 * x[:, 0:1]) / 4
-    #        + 63 * paddle.sin(8 * x[:, 0:1]) / 8
-    #     )
-    # )
 
 
 def func(x):
@@ -72,36 +70,18 @@ activation = "tanh"
 initializer = "Glorot uniform"
 net = dde.nn.FNN(layer_size, activation, initializer)
 
+
 # Backend tensorflow.compat.v1 or tensorflow
 def output_transform(x, y):
     return (
-        x[:, 1:2] * (np.pi ** 2 - x[:, 0:1] ** 2) * y
-        + tf.sin(x[:, 0:1])
-        + tf.sin(2 * x[:, 0:1]) / 2
-        + tf.sin(3 * x[:, 0:1]) / 3
-        + tf.sin(4 * x[:, 0:1]) / 4
-        + tf.sin(8 * x[:, 0:1]) / 8
+        x[:, 1:2] * (np.pi**2 - x[:, 0:1] ** 2) * y
+        + sin(x[:, 0:1])
+        + sin(2 * x[:, 0:1]) / 2
+        + sin(3 * x[:, 0:1]) / 3
+        + sin(4 * x[:, 0:1]) / 4
+        + sin(8 * x[:, 0:1]) / 8
     )
-# Backend pytorch
-# def output_transform(x, y):
-#     return (
-#         x[:, 1:2] * (np.pi ** 2 - x[:, 0:1] ** 2) * y
-#         + torch.sin(x[:, 0:1])
-#         + torch.sin(2 * x[:, 0:1]) / 2
-#         + torch.sin(3 * x[:, 0:1]) / 3
-#         + torch.sin(4 * x[:, 0:1]) / 4
-#         + torch.sin(8 * x[:, 0:1]) / 8
-#    )
-# Backend paddle
-# def output_transform(x, y):
-#     return (
-#         x[:, 1:2] * (np.pi ** 2 - x[:, 0:1] ** 2) * y
-#         + paddle.sin(x[:, 0:1])
-#         + paddle.sin(2 * x[:, 0:1]) / 2
-#         + paddle.sin(3 * x[:, 0:1]) / 3
-#         + paddle.sin(4 * x[:, 0:1]) / 4
-#         + paddle.sin(8 * x[:, 0:1]) / 8
-#    )
+
 
 net.apply_output_transform(output_transform)
 

--- a/examples/pinn_inverse/diffusion_1d_inverse.py
+++ b/examples/pinn_inverse/diffusion_1d_inverse.py
@@ -1,12 +1,32 @@
 """Backend supported: tensorflow.compat.v1, tensorflow, pytorch, paddle"""
 import deepxde as dde
 import numpy as np
-# Backend tensorflow.compat.v1 or tensorflow
-from deepxde.backend import tf
-# Backend pytorch
-# import torch
-# Backend paddle
-# import paddle
+
+# Define function
+if dde.backend.backend_name == "paddle":
+    # Backend paddle
+    import paddle
+
+    sin = paddle.sin
+    exp = paddle.exp
+elif dde.backend.backend_name == "pytorch":
+    # Backend pytorch
+    import torch
+
+    sin = torch.sin
+    exp = torch.exp
+elif dde.backend.backend_name in ["tensorflow.compat.v1", "tensorflow"]:
+    # Backend tensorflow.compat.v1 or tensorflow
+    from deepxde.backend import tf
+
+    sin = tf.sin
+    exp = tf.exp
+elif dde.backend.backend_name == "jax":
+    # Backend jax
+    import jax.numpy as jnp
+
+    sin = jnp.sin
+    exp = jnp.exp
 
 
 C = dde.Variable(2.0)
@@ -19,23 +39,9 @@ def pde(x, y):
     return (
         dy_t
         - C * dy_xx
-        + tf.exp(-x[:, 1:])
-        * (tf.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * tf.sin(np.pi * x[:, 0:1]))
+        + exp(-x[:, 1:])
+        * (sin(np.pi * x[:, 0:1]) - np.pi**2 * sin(np.pi * x[:, 0:1]))
     )
-    # Backend pytorch
-    # return (
-    #     dy_t
-    #     - C * dy_xx
-    #     + torch.exp(-x[:, 1:])
-    #     * (torch.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * torch.sin(np.pi * x[:, 0:1]))
-    # )
-    # Backend paddle
-    # return (
-    #     dy_t
-    #     - C * dy_xx
-    #     + paddle.exp(-x[:, 1:])
-    #     * (paddle.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * paddle.sin(np.pi * x[:, 0:1]))
-    # )
 
 
 def func(x):


### PR DESCRIPTION
Try to modify some examples to support paddle with an uniform format if a example could be modified simply.

Uniform format:

    # Define function
    if dde.backend.backend_name == "paddle":
        # Backend paddle
        import paddle
    
        xxx = paddle.xxx
    elif dde.backend.backend_name == "pytorch":
        # Backend pytorch
        import torch
    
        xxx = torch.xxx
    elif dde.backend.backend_name in ["tensorflow.compat.v1", "tensorflow"]:
        # Backend tensorflow.compat.v1 or tensorflow
        from deepxde.backend import tf
        
        xxx = tf.xxx
    elif dde.backend.backend_name == "jax":
        # Backend jax
        import jax.numpy as jnp
    
        xxx = jnp.xxx