### PR TITLE
Add approximate distance functions for hard-constraint methods

### DIFF
--- a/deepxde/backend/backend.py
+++ b/deepxde/backend/backend.py
@@ -305,6 +305,14 @@ def square(x):
     """Returns the square of the elements of input."""
 
 
+def abs(x):
+    """Computes the absolute value of a tensor."""
+
+
+def minimum(x, y):
+    """Returns the minimum of x and y (i.e. x < y ? x : y) element-wise."""
+
+
 def tanh(x):
     """Computes hyperbolic tangent of x element-wise."""
 

--- a/deepxde/backend/backend.py
+++ b/deepxde/backend/backend.py
@@ -305,7 +305,7 @@ def square(x):
     """Returns the square of the elements of input."""
 
 
-def absolute(x):
+def abs(x):
     """Computes the absolute value element-wise."""
 
 
@@ -366,7 +366,7 @@ def prod(input_tensor, dim, keepdims=False):
     Args:
         input_tensor (Tensor). The input tensor.
         dim (int). The reduce dim.
-        keepdims (bool). Whether to keep the summed dimension.
+        keepdims (bool). Whether to keep the product dimension.
 
     Returns:
         Tensor: A framework-specific tensor.
@@ -384,13 +384,13 @@ def reduce_prod(input_tensor):
     """
 
 
-def amin(input_tensor, dim, keepdims=False):
+def min(input_tensor, dim, keepdims=False):
     """Returns the minimum of the input tensor along the given dim.
 
     Args:
         input_tensor (Tensor). The input tensor.
         dim (int). The reduce dim.
-        keepdims (bool). Whether to keep the summed dimension.
+        keepdims (bool). Whether to keep the dimension.
 
     Returns:
         Tensor: A framework-specific tensor.
@@ -408,13 +408,13 @@ def reduce_min(input_tensor):
     """
 
 
-def amax(input_tensor, dim, keepdims=False):
+def max(input_tensor, dim, keepdims=False):
     """Returns the maximum of the input tensor along the given dim.
 
     Args:
         input_tensor (Tensor). The input tensor.
         dim (int). The reduce dim.
-        keepdims (bool). Whether to keep the summed dimension.
+        keepdims (bool). Whether to keep the dimension.
 
     Returns:
         Tensor: A framework-specific tensor.

--- a/deepxde/backend/backend.py
+++ b/deepxde/backend/backend.py
@@ -360,6 +360,78 @@ def reduce_sum(input_tensor):
     """
 
 
+def prod(input_tensor, dim, keepdims=False):
+    """Returns the product of the input tensor along the given dim.
+
+    Args:
+        input_tensor (Tensor). The input tensor.
+        dim (int). The reduce dim.
+        keepdims (bool). Whether to keep the summed dimension.
+
+    Returns:
+        Tensor: A framework-specific tensor.
+    """
+
+
+def reduce_prod(input_tensor):
+    """Returns the product of all elements in the input tensor.
+
+    Args:
+        input_tensor (Tensor). The input tensor.
+
+    Returns:
+        Tensor.
+    """
+
+
+def min(input_tensor, dim, keepdims=False):
+    """Returns the minimum of the input tensor along the given dim.
+
+    Args:
+        input_tensor (Tensor). The input tensor.
+        dim (int). The reduce dim.
+        keepdims (bool). Whether to keep the summed dimension.
+
+    Returns:
+        Tensor: A framework-specific tensor.
+    """
+
+
+def reduce_min(input_tensor):
+    """Returns the minimum of all elements in the input tensor.
+
+    Args:
+        input_tensor (Tensor). The input tensor.
+
+    Returns:
+        Tensor.
+    """
+
+
+def max(input_tensor, dim, keepdims=False):
+    """Returns the maximum of the input tensor along the given dim.
+
+    Args:
+        input_tensor (Tensor). The input tensor.
+        dim (int). The reduce dim.
+        keepdims (bool). Whether to keep the summed dimension.
+
+    Returns:
+        Tensor: A framework-specific tensor.
+    """
+
+
+def reduce_max(input_tensor):
+    """Returns the maximum of all elements in the input tensor.
+
+    Args:
+        input_tensor (Tensor). The input tensor.
+
+    Returns:
+        Tensor.
+    """
+
+
 def norm(tensor, ord=None, axis=None, keepdims=False):
     """Computes a vector norm.
 

--- a/deepxde/backend/backend.py
+++ b/deepxde/backend/backend.py
@@ -305,8 +305,8 @@ def square(x):
     """Returns the square of the elements of input."""
 
 
-def abs(x):
-    """Computes the absolute value of a tensor."""
+def absolute(x):
+    """Computes the absolute value element-wise."""
 
 
 def minimum(x, y):
@@ -384,7 +384,7 @@ def reduce_prod(input_tensor):
     """
 
 
-def min(input_tensor, dim, keepdims=False):
+def amin(input_tensor, dim, keepdims=False):
     """Returns the minimum of the input tensor along the given dim.
 
     Args:
@@ -408,7 +408,7 @@ def reduce_min(input_tensor):
     """
 
 
-def max(input_tensor, dim, keepdims=False):
+def amax(input_tensor, dim, keepdims=False):
     """Returns the maximum of the input tensor along the given dim.
 
     Args:

--- a/deepxde/backend/jax/tensor.py
+++ b/deepxde/backend/jax/tensor.py
@@ -89,6 +89,14 @@ def square(x):
     return jnp.square(x)
 
 
+def abs(x):
+    return jnp.abs(x)
+
+
+def minimum(x, y):
+    return jnp.minimum(x, y)
+
+
 def tanh(x):
     return jnp.tanh(x)
 

--- a/deepxde/backend/jax/tensor.py
+++ b/deepxde/backend/jax/tensor.py
@@ -117,6 +117,30 @@ def reduce_sum(input_tensor):
     return jnp.sum(input_tensor)
 
 
+def prod(input_tensor, dim, keepdims=False):
+    return jnp.prod(input_tensor, axis=dim, keepdims=keepdims)
+
+
+def reduce_prod(input_tensor):
+    return jnp.prod(input_tensor)
+
+
+def max(input_tensor, dim, keepdims=False):
+    return jnp.max(input_tensor, axis=dim, keepdims=keepdims)
+
+
+def reduce_max(input_tensor):
+    return jnp.max(input_tensor)
+
+
+def min(input_tensor, dim, keepdims=False):
+    return jnp.min(input_tensor, axis=dim, keepdims=keepdims)
+
+
+def reduce_min(input_tensor):
+    return jnp.min(input_tensor)
+
+
 def zeros(shape, dtype):
     return jnp.zeros(shape, dtype=dtype)
 

--- a/deepxde/backend/jax/tensor.py
+++ b/deepxde/backend/jax/tensor.py
@@ -89,6 +89,7 @@ def square(x):
     return jnp.square(x)
 
 
+# pylint: disable=redefined-builtin
 def abs(x):
     return jnp.abs(x)
 
@@ -125,6 +126,7 @@ def reduce_prod(input_tensor):
     return jnp.prod(input_tensor)
 
 
+# pylint: disable=redefined-builtin
 def min(input_tensor, dim, keepdims=False):
     return jnp.min(input_tensor, axis=dim, keepdims=keepdims)
 
@@ -133,6 +135,7 @@ def reduce_min(input_tensor):
     return jnp.min(input_tensor)
 
 
+# pylint: disable=redefined-builtin
 def max(input_tensor, dim, keepdims=False):
     return jnp.max(input_tensor, axis=dim, keepdims=keepdims)
 

--- a/deepxde/backend/jax/tensor.py
+++ b/deepxde/backend/jax/tensor.py
@@ -89,7 +89,7 @@ def square(x):
     return jnp.square(x)
 
 
-def absolute(x):
+def abs(x):
     return jnp.abs(x)
 
 
@@ -125,20 +125,20 @@ def reduce_prod(input_tensor):
     return jnp.prod(input_tensor)
 
 
-def amax(input_tensor, dim, keepdims=False):
-    return jnp.max(input_tensor, axis=dim, keepdims=keepdims)
-
-
-def reduce_max(input_tensor):
-    return jnp.max(input_tensor)
-
-
-def amin(input_tensor, dim, keepdims=False):
+def min(input_tensor, dim, keepdims=False):
     return jnp.min(input_tensor, axis=dim, keepdims=keepdims)
 
 
 def reduce_min(input_tensor):
     return jnp.min(input_tensor)
+
+
+def max(input_tensor, dim, keepdims=False):
+    return jnp.max(input_tensor, axis=dim, keepdims=keepdims)
+
+
+def reduce_max(input_tensor):
+    return jnp.max(input_tensor)
 
 
 def zeros(shape, dtype):

--- a/deepxde/backend/jax/tensor.py
+++ b/deepxde/backend/jax/tensor.py
@@ -89,7 +89,7 @@ def square(x):
     return jnp.square(x)
 
 
-def abs(x):
+def absolute(x):
     return jnp.abs(x)
 
 
@@ -125,7 +125,7 @@ def reduce_prod(input_tensor):
     return jnp.prod(input_tensor)
 
 
-def max(input_tensor, dim, keepdims=False):
+def amax(input_tensor, dim, keepdims=False):
     return jnp.max(input_tensor, axis=dim, keepdims=keepdims)
 
 
@@ -133,7 +133,7 @@ def reduce_max(input_tensor):
     return jnp.max(input_tensor)
 
 
-def min(input_tensor, dim, keepdims=False):
+def amin(input_tensor, dim, keepdims=False):
     return jnp.min(input_tensor, axis=dim, keepdims=keepdims)
 
 

--- a/deepxde/backend/paddle/tensor.py
+++ b/deepxde/backend/paddle/tensor.py
@@ -146,6 +146,7 @@ def square(x):
     return paddle.square(x)
 
 
+# pylint: disable=redefined-builtin
 def abs(x):
     return paddle.abs(x)
 
@@ -186,6 +187,7 @@ def reduce_prod(input_tensor):
     return paddle.prod(input_tensor)
 
 
+# pylint: disable=redefined-builtin
 def min(input_tensor, dim, keepdims=False):
     return paddle.min(input_tensor, axis=dim, keepdim=keepdims)
 
@@ -194,6 +196,7 @@ def reduce_min(input_tensor):
     return paddle.min(input_tensor)
 
 
+# pylint: disable=redefined-builtin
 def max(input_tensor, dim, keepdims=False):
     return paddle.max(input_tensor, axis=dim, keepdim=keepdims)
 

--- a/deepxde/backend/paddle/tensor.py
+++ b/deepxde/backend/paddle/tensor.py
@@ -146,7 +146,7 @@ def square(x):
     return paddle.square(x)
 
 
-def abs(x):
+def absolute(x):
     return paddle.abs(x)
 
 
@@ -186,7 +186,7 @@ def reduce_prod(input_tensor):
     return paddle.prod(input_tensor)
 
 
-def max(input_tensor, dim, keepdims=False):
+def amax(input_tensor, dim, keepdims=False):
     return paddle.max(input_tensor, axis=dim, keepdim=keepdims)
 
 
@@ -194,7 +194,7 @@ def reduce_max(input_tensor):
     return paddle.max(input_tensor)
 
 
-def min(input_tensor, dim, keepdims=False):
+def amin(input_tensor, dim, keepdims=False):
     return paddle.min(input_tensor, axis=dim, keepdim=keepdims)
 
 

--- a/deepxde/backend/paddle/tensor.py
+++ b/deepxde/backend/paddle/tensor.py
@@ -178,6 +178,30 @@ def reduce_sum(input_tensor):
     return paddle.sum(input_tensor)
 
 
+def prod(input_tensor, dim, keepdims=False):
+    return paddle.prod(input_tensor, axis=dim, keepdim=keepdims)
+
+
+def reduce_prod(input_tensor):
+    return paddle.prod(input_tensor)
+
+
+def max(input_tensor, dim, keepdims=False):
+    return paddle.max(input_tensor, axis=dim, keepdim=keepdims)
+
+
+def reduce_max(input_tensor):
+    return paddle.max(input_tensor)
+
+
+def min(input_tensor, dim, keepdims=False):
+    return paddle.min(input_tensor, axis=dim, keepdim=keepdims)
+
+
+def reduce_min(input_tensor):
+    return paddle.min(input_tensor)
+
+
 def norm(x, ord=None, axis=None, keepdims=False):
     return paddle.linalg.norm(x, p=ord, axis=axis, keepdim=keepdims)
 

--- a/deepxde/backend/paddle/tensor.py
+++ b/deepxde/backend/paddle/tensor.py
@@ -146,7 +146,7 @@ def square(x):
     return paddle.square(x)
 
 
-def absolute(x):
+def abs(x):
     return paddle.abs(x)
 
 
@@ -186,20 +186,20 @@ def reduce_prod(input_tensor):
     return paddle.prod(input_tensor)
 
 
-def amax(input_tensor, dim, keepdims=False):
-    return paddle.max(input_tensor, axis=dim, keepdim=keepdims)
-
-
-def reduce_max(input_tensor):
-    return paddle.max(input_tensor)
-
-
-def amin(input_tensor, dim, keepdims=False):
+def min(input_tensor, dim, keepdims=False):
     return paddle.min(input_tensor, axis=dim, keepdim=keepdims)
 
 
 def reduce_min(input_tensor):
     return paddle.min(input_tensor)
+
+
+def max(input_tensor, dim, keepdims=False):
+    return paddle.max(input_tensor, axis=dim, keepdim=keepdims)
+
+
+def reduce_max(input_tensor):
+    return paddle.max(input_tensor)
 
 
 def norm(x, ord=None, axis=None, keepdims=False):

--- a/deepxde/backend/paddle/tensor.py
+++ b/deepxde/backend/paddle/tensor.py
@@ -146,6 +146,14 @@ def square(x):
     return paddle.square(x)
 
 
+def abs(x):
+    return paddle.abs(x)
+
+
+def minimum(x, y):
+    return paddle.minimum(x, y)
+
+
 def tanh(x):
     return paddle.tanh(x)
 

--- a/deepxde/backend/pytorch/tensor.py
+++ b/deepxde/backend/pytorch/tensor.py
@@ -154,7 +154,7 @@ def square(x):
     return torch.square(x)
 
 
-def absolute(x):
+def abs(x):
     return torch.abs(x)
 
 
@@ -194,7 +194,7 @@ def reduce_prod(input_tensor):
     return torch.prod(input_tensor)
 
 
-def amin(input_tensor, dim, keepdims=False):
+def min(input_tensor, dim, keepdims=False):
     return torch.amin(input_tensor, dim, keepdim=keepdims)
 
 
@@ -202,7 +202,7 @@ def reduce_min(input_tensor):
     return torch.min(input_tensor)
 
 
-def amax(input_tensor, dim, keepdims=False):
+def max(input_tensor, dim, keepdims=False):
     return torch.amax(input_tensor, dim, keepdim=keepdims)
 
 

--- a/deepxde/backend/pytorch/tensor.py
+++ b/deepxde/backend/pytorch/tensor.py
@@ -186,6 +186,30 @@ def reduce_sum(input_tensor):
     return torch.sum(input_tensor)
 
 
+def prod(input_tensor, dim, keepdims=False):
+    return torch.prod(input_tensor, dim, keepdim=keepdims)
+
+
+def reduce_prod(input_tensor):
+    return torch.prod(input_tensor)
+
+
+def min(input_tensor, dim, keepdims=False):
+    return torch.min(input_tensor, dim, keepdim=keepdims)
+
+
+def reduce_min(input_tensor):
+    return torch.min(input_tensor)
+
+
+def max(input_tensor, dim, keepdims=False):
+    return torch.max(input_tensor, dim, keepdim=keepdims)
+
+
+def reduce_max(input_tensor):
+    return torch.max(input_tensor)
+
+
 def norm(tensor, ord=None, axis=None, keepdims=False):
     return torch.linalg.norm(tensor, ord=ord, dim=axis, keepdim=keepdims)
 

--- a/deepxde/backend/pytorch/tensor.py
+++ b/deepxde/backend/pytorch/tensor.py
@@ -154,6 +154,14 @@ def square(x):
     return torch.square(x)
 
 
+def abs(x):
+    return torch.abs(x)
+
+
+def minimum(x, y):
+    return torch.minimum(x, y)
+
+
 def tanh(x):
     return torch.tanh(x)
 

--- a/deepxde/backend/pytorch/tensor.py
+++ b/deepxde/backend/pytorch/tensor.py
@@ -154,6 +154,7 @@ def square(x):
     return torch.square(x)
 
 
+# pylint: disable=redefined-builtin
 def abs(x):
     return torch.abs(x)
 
@@ -194,6 +195,7 @@ def reduce_prod(input_tensor):
     return torch.prod(input_tensor)
 
 
+# pylint: disable=redefined-builtin
 def min(input_tensor, dim, keepdims=False):
     return torch.amin(input_tensor, dim, keepdim=keepdims)
 
@@ -202,6 +204,7 @@ def reduce_min(input_tensor):
     return torch.min(input_tensor)
 
 
+# pylint: disable=redefined-builtin
 def max(input_tensor, dim, keepdims=False):
     return torch.amax(input_tensor, dim, keepdim=keepdims)
 

--- a/deepxde/backend/pytorch/tensor.py
+++ b/deepxde/backend/pytorch/tensor.py
@@ -195,7 +195,7 @@ def reduce_prod(input_tensor):
 
 
 def min(input_tensor, dim, keepdims=False):
-    return torch.min(input_tensor, dim, keepdim=keepdims)
+    return torch.amin(input_tensor, dim, keepdim=keepdims)
 
 
 def reduce_min(input_tensor):
@@ -203,7 +203,7 @@ def reduce_min(input_tensor):
 
 
 def max(input_tensor, dim, keepdims=False):
-    return torch.max(input_tensor, dim, keepdim=keepdims)
+    return torch.amax(input_tensor, dim, keepdim=keepdims)
 
 
 def reduce_max(input_tensor):

--- a/deepxde/backend/pytorch/tensor.py
+++ b/deepxde/backend/pytorch/tensor.py
@@ -154,7 +154,7 @@ def square(x):
     return torch.square(x)
 
 
-def abs(x):
+def absolute(x):
     return torch.abs(x)
 
 
@@ -194,7 +194,7 @@ def reduce_prod(input_tensor):
     return torch.prod(input_tensor)
 
 
-def min(input_tensor, dim, keepdims=False):
+def amin(input_tensor, dim, keepdims=False):
     return torch.amin(input_tensor, dim, keepdim=keepdims)
 
 
@@ -202,7 +202,7 @@ def reduce_min(input_tensor):
     return torch.min(input_tensor)
 
 
-def max(input_tensor, dim, keepdims=False):
+def amax(input_tensor, dim, keepdims=False):
     return torch.amax(input_tensor, dim, keepdim=keepdims)
 
 

--- a/deepxde/backend/tensorflow/tensor.py
+++ b/deepxde/backend/tensorflow/tensor.py
@@ -111,7 +111,7 @@ def square(x):
     return tf.math.square(x)
 
 
-def abs(x):
+def absolute(x):
     return tf.math.abs(x)
 
 
@@ -147,7 +147,7 @@ def reduce_prod(input_tensor):
     return tf.math.reduce_prod(input_tensor)
 
 
-def max(input_tensor, dim, keepdims=False):
+def amax(input_tensor, dim, keepdims=False):
     return tf.math.reduce_max(input_tensor, axis=dim, keepdims=keepdims)
 
 
@@ -155,7 +155,7 @@ def reduce_max(input_tensor):
     return tf.math.reduce_max(input_tensor)
 
 
-def min(input_tensor, dim, keepdims=False):
+def amin(input_tensor, dim, keepdims=False):
     return tf.math.reduce_min(input_tensor, axis=dim, keepdims=keepdims)
 
 

--- a/deepxde/backend/tensorflow/tensor.py
+++ b/deepxde/backend/tensorflow/tensor.py
@@ -111,7 +111,7 @@ def square(x):
     return tf.math.square(x)
 
 
-def absolute(x):
+def abs(x):
     return tf.math.abs(x)
 
 
@@ -147,20 +147,20 @@ def reduce_prod(input_tensor):
     return tf.math.reduce_prod(input_tensor)
 
 
-def amax(input_tensor, dim, keepdims=False):
-    return tf.math.reduce_max(input_tensor, axis=dim, keepdims=keepdims)
-
-
-def reduce_max(input_tensor):
-    return tf.math.reduce_max(input_tensor)
-
-
-def amin(input_tensor, dim, keepdims=False):
+def min(input_tensor, dim, keepdims=False):
     return tf.math.reduce_min(input_tensor, axis=dim, keepdims=keepdims)
 
 
 def reduce_min(input_tensor):
     return tf.math.reduce_min(input_tensor)
+
+
+def max(input_tensor, dim, keepdims=False):
+    return tf.math.reduce_max(input_tensor, axis=dim, keepdims=keepdims)
+
+
+def reduce_max(input_tensor):
+    return tf.math.reduce_max(input_tensor)
 
 
 def norm(tensor, ord=None, axis=None, keepdims=False):

--- a/deepxde/backend/tensorflow/tensor.py
+++ b/deepxde/backend/tensorflow/tensor.py
@@ -139,6 +139,30 @@ def reduce_sum(input_tensor):
     return tf.math.reduce_sum(input_tensor)
 
 
+def prod(input_tensor, dim, keepdims=False):
+    return tf.math.reduce_prod(input_tensor, axis=dim, keepdims=keepdims)
+
+
+def reduce_prod(input_tensor):
+    return tf.math.reduce_prod(input_tensor)
+
+
+def max(input_tensor, dim, keepdims=False):
+    return tf.math.reduce_max(input_tensor, axis=dim, keepdims=keepdims)
+
+
+def reduce_max(input_tensor):
+    return tf.math.reduce_max(input_tensor)
+
+
+def min(input_tensor, dim, keepdims=False):
+    return tf.math.reduce_min(input_tensor, axis=dim, keepdims=keepdims)
+
+
+def reduce_min(input_tensor):
+    return tf.math.reduce_min(input_tensor)
+
+
 def norm(tensor, ord=None, axis=None, keepdims=False):
     if ord is None:
         ord = "euclidean"

--- a/deepxde/backend/tensorflow/tensor.py
+++ b/deepxde/backend/tensorflow/tensor.py
@@ -111,6 +111,14 @@ def square(x):
     return tf.math.square(x)
 
 
+def abs(x):
+    return tf.math.abs(x)
+
+
+def minimum(x, y):
+    return tf.math.minimum(x, y)
+
+
 def tanh(x):
     return tf.math.tanh(x)
 

--- a/deepxde/backend/tensorflow/tensor.py
+++ b/deepxde/backend/tensorflow/tensor.py
@@ -111,6 +111,7 @@ def square(x):
     return tf.math.square(x)
 
 
+# pylint: disable=redefined-builtin
 def abs(x):
     return tf.math.abs(x)
 
@@ -147,6 +148,7 @@ def reduce_prod(input_tensor):
     return tf.math.reduce_prod(input_tensor)
 
 
+# pylint: disable=redefined-builtin
 def min(input_tensor, dim, keepdims=False):
     return tf.math.reduce_min(input_tensor, axis=dim, keepdims=keepdims)
 
@@ -155,6 +157,7 @@ def reduce_min(input_tensor):
     return tf.math.reduce_min(input_tensor)
 
 
+# pylint: disable=redefined-builtin
 def max(input_tensor, dim, keepdims=False):
     return tf.math.reduce_max(input_tensor, axis=dim, keepdims=keepdims)
 

--- a/deepxde/backend/tensorflow_compat_v1/tensor.py
+++ b/deepxde/backend/tensorflow_compat_v1/tensor.py
@@ -164,6 +164,14 @@ def square(x):
     return tf.math.square(x)
 
 
+def abs(x):
+    return tf.math.abs(x)
+
+
+def minimum(x, y):
+    return tf.math.minimum(x, y)
+
+
 def tanh(x):
     return tf.math.tanh(x)
 

--- a/deepxde/backend/tensorflow_compat_v1/tensor.py
+++ b/deepxde/backend/tensorflow_compat_v1/tensor.py
@@ -164,7 +164,7 @@ def square(x):
     return tf.math.square(x)
 
 
-def abs(x):
+def absolute(x):
     return tf.math.abs(x)
 
 
@@ -204,7 +204,7 @@ def reduce_prod(input_tensor):
     return tf.math.reduce_prod(input_tensor)
 
 
-def max(input_tensor, dim, keepdims=False):
+def amax(input_tensor, dim, keepdims=False):
     return tf.math.reduce_max(input_tensor, axis=dim, keepdims=keepdims)
 
 
@@ -212,7 +212,7 @@ def reduce_max(input_tensor):
     return tf.math.reduce_max(input_tensor)
 
 
-def min(input_tensor, dim, keepdims=False):
+def amin(input_tensor, dim, keepdims=False):
     return tf.math.reduce_min(input_tensor, axis=dim, keepdims=keepdims)
 
 

--- a/deepxde/backend/tensorflow_compat_v1/tensor.py
+++ b/deepxde/backend/tensorflow_compat_v1/tensor.py
@@ -164,6 +164,7 @@ def square(x):
     return tf.math.square(x)
 
 
+# pylint: disable=redefined-builtin
 def abs(x):
     return tf.math.abs(x)
 
@@ -204,6 +205,7 @@ def reduce_prod(input_tensor):
     return tf.math.reduce_prod(input_tensor)
 
 
+# pylint: disable=redefined-builtin
 def min(input_tensor, dim, keepdims=False):
     return tf.math.reduce_min(input_tensor, axis=dim, keepdims=keepdims)
 
@@ -212,6 +214,7 @@ def reduce_min(input_tensor):
     return tf.math.reduce_min(input_tensor)
 
 
+# pylint: disable=redefined-builtin
 def max(input_tensor, dim, keepdims=False):
     return tf.math.reduce_max(input_tensor, axis=dim, keepdims=keepdims)
 

--- a/deepxde/backend/tensorflow_compat_v1/tensor.py
+++ b/deepxde/backend/tensorflow_compat_v1/tensor.py
@@ -164,7 +164,7 @@ def square(x):
     return tf.math.square(x)
 
 
-def absolute(x):
+def abs(x):
     return tf.math.abs(x)
 
 
@@ -204,20 +204,20 @@ def reduce_prod(input_tensor):
     return tf.math.reduce_prod(input_tensor)
 
 
-def amax(input_tensor, dim, keepdims=False):
-    return tf.math.reduce_max(input_tensor, axis=dim, keepdims=keepdims)
-
-
-def reduce_max(input_tensor):
-    return tf.math.reduce_max(input_tensor)
-
-
-def amin(input_tensor, dim, keepdims=False):
+def min(input_tensor, dim, keepdims=False):
     return tf.math.reduce_min(input_tensor, axis=dim, keepdims=keepdims)
 
 
 def reduce_min(input_tensor):
     return tf.math.reduce_min(input_tensor)
+
+
+def max(input_tensor, dim, keepdims=False):
+    return tf.math.reduce_max(input_tensor, axis=dim, keepdims=keepdims)
+
+
+def reduce_max(input_tensor):
+    return tf.math.reduce_max(input_tensor)
 
 
 def norm(tensor, ord=None, axis=None, keepdims=False):

--- a/deepxde/backend/tensorflow_compat_v1/tensor.py
+++ b/deepxde/backend/tensorflow_compat_v1/tensor.py
@@ -196,6 +196,30 @@ def reduce_sum(input_tensor):
     return tf.math.reduce_sum(input_tensor)
 
 
+def prod(input_tensor, dim, keepdims=False):
+    return tf.math.reduce_prod(input_tensor, axis=dim, keepdims=keepdims)
+
+
+def reduce_prod(input_tensor):
+    return tf.math.reduce_prod(input_tensor)
+
+
+def max(input_tensor, dim, keepdims=False):
+    return tf.math.reduce_max(input_tensor, axis=dim, keepdims=keepdims)
+
+
+def reduce_max(input_tensor):
+    return tf.math.reduce_max(input_tensor)
+
+
+def min(input_tensor, dim, keepdims=False):
+    return tf.math.reduce_min(input_tensor, axis=dim, keepdims=keepdims)
+
+
+def reduce_min(input_tensor):
+    return tf.math.reduce_min(input_tensor)
+
+
 def norm(tensor, ord=None, axis=None, keepdims=False):
     if ord is None:
         ord = "euclidean"

--- a/deepxde/geometry/geometry.py
+++ b/deepxde/geometry/geometry.py
@@ -28,17 +28,15 @@ class Geometry(abc.ABC):
             "{}.mindist2boundary to be implemented".format(self.idstr)
         )
     
-    def approxdist2boundary(self, x, 
-        smoothness: Literal["L", "M", "H"] = "M"):
+    def approxdist2boundary(self, x, smoothness: Literal["L", "M", "H"] = "M"):
         """Compute the approximate distance at x to the boundary.
 
-        - This function is used for the hard-constraint methods.
+        This function is used for the hard-constraint methods. The approximate distance function 
+        satisfies the following properties:
 
-        - The approximate distance function satisfies the following properties:
-
-            - The function is zero on the boundary and positive elsewhere.
-            - The function is almost differentiable at any order.
-            - The function is not necessarily equal to the exact distance function.
+        - The function is zero on the boundary and positive elsewhere.
+        - The function is almost differentiable at any order.
+        - The function is not necessarily equal to the exact distance function.
 
         Args:
             x: a 2D array of shape (n, dim), where `n` is the number of points and
@@ -48,15 +46,18 @@ class Geometry(abc.ABC):
                 e.g., "L", "M", "H". "L" is the least smooth, "H" is the most smooth.
                 Default is "M".
 
-                - "L": the distance function is continuous but can be non-differentiable on a
-                  set of points, which has measure zero.
+                - L
+                The distance function is continuous but can be non-differentiable on a
+                set of points, which has measure zero.
 
-                - "M": the distance function is continuous and differentiable at any order. The
-                  non-differentiable points can only appear on boundaries. If the points in `x` are
-                  all inside or outside the geometry, the distance function is smooth.
-                
-                - "H": the distance function is continuous and differentiable at any order on any 
-                  points. This option may result in a polynomial of HIGH order.
+                - M
+                The distance function is continuous and differentiable at any order. The
+                non-differentiable points can only appear on boundaries. If the points in `x` are
+                all inside or outside the geometry, the distance function is smooth.
+
+                - H
+                The distance function is continuous and differentiable at any order on any 
+                points. This option may result in a polynomial of HIGH order.
 
         Returns:
             A NumPy array of shape (n, 1). The distance at each point in `x`.

--- a/deepxde/geometry/geometry.py
+++ b/deepxde/geometry/geometry.py
@@ -28,7 +28,7 @@ class Geometry(abc.ABC):
             "{}.mindist2boundary to be implemented".format(self.idstr)
         )
     
-    def approxdist2boundary(self, x, smoothness: Literal["C0", "Cinf", "Cinf+"] = "Cinf"):
+    def approxdist2boundary(self, x, smoothness: Literal["C0", "C0+", "Cinf"] = "C0+"):
         """Compute the approximate distance at x to the boundary.
 
         This function is used for the hard-constraint methods. The approximate distance function 
@@ -43,24 +43,24 @@ class Geometry(abc.ABC):
                 `dim` is the dimension of the geometry. Note that `x` should be a tensor type
                 of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
             smoothness (string, optional): A string to specify the smoothness of the distance function,
-                e.g., "C0", "Cinf", "Cinf+". "C0" is the least smooth, "Cinf+" is the most smooth.
-                Default is "Cinf".
+                e.g., "C0", "C0+", "Cinf". "C0" is the least smooth, "Cinf" is the most smooth.
+                Default is "C0+".
 
                 - C0
-                The distance function is continuous but can be non-differentiable on a
-                set of points, which has measure zero.
+                The distance function is continuous but may not be non-differentiable.
 
-                - Cinf
-                The distance function is continuous and differentiable at any order. The
+                - C0+
+                The distance function is continuous and differentiable almost everywhere. The
                 non-differentiable points can only appear on boundaries. If the points in `x` are
                 all inside or outside the geometry, the distance function is smooth.
 
-                - Cinf+
+                - Cinf
                 The distance function is continuous and differentiable at any order on any 
                 points. This option may result in a polynomial of HIGH order.
 
         Returns:
-            A NumPy array of shape (n, 1). The distance at each point in `x`.
+            A tensor of a type determined by the backend, which will have a shape of (n, 1). 
+            Each element in the tensor corresponds to the computed distance value for the respective point in 'x'.
         """
         raise NotImplementedError(
             "{}.approxdist2boundary to be implemented".format(self.idstr)

--- a/deepxde/geometry/geometry.py
+++ b/deepxde/geometry/geometry.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Literal, Union
+from typing import Literal
 import numpy as np
 
 
@@ -28,8 +28,7 @@ class Geometry(abc.ABC):
             "{}.mindist2boundary to be implemented".format(self.idstr)
         )
     
-    def approxdist2boundary(self, x, where: Union[
-        None, Literal["left", "right", "top", "bottom"]] = None,
+    def approxdist2boundary(self, x, 
         smoothness: Literal["L", "M", "H"] = "M"):
         """Compute the approximate distance at x to the boundary.
         - This function is used for the hard-constraint methods.
@@ -38,31 +37,27 @@ class Geometry(abc.ABC):
             - The function is almost differentiable at any order.
             - The function is not necessarily equal to the exact distance function.
 
-        Parameter
-        ---------
+        Args:
 
-        - `x`: a 2D array of shape (n, dim), where `n` is the number of points and
-            `dim` is the dimension of the geometry. Note that `x` should be a tensor type
-            of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
-        - `where`: a string to specify which part of the boundary to compute the distance, 
-            e.g., "left", "right", "top", "bottom". If `None`, compute the distance to 
-            the whole boundary.
-        - `smoothness`: a string to specify the smoothness of the distance function,
-            e.g., "L", "M", "H". "L" is the least smooth, "H" is the most smooth.
-            - "L": the distance function is continuous but can be non-differentiable on a 
-            set of points, which has measure zero.
-            - "M": the distance function is continuous and differentiable at any order. The 
-            non-differentiable points can only appear on boundaries. If the points in `x` are
-            all inside or outside the geometry, the distance function is smooth.
-            - "H": the distance function is continuous and differentiable at any order on any 
-            points. This option may result in a polynomial of HIGH order. 
+            x: a 2D array of shape (n, dim), where `n` is the number of points and
+                `dim` is the dimension of the geometry. Note that `x` should be a tensor type
+                of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
+            smoothness: a string to specify the smoothness of the distance function,
+                e.g., "L", "M", "H". "L" is the least smooth, "H" is the most smooth.
+                Default is "M".
 
-        Please refer to the definition of this function in each subclass 
-        for the optional values of parameters `where` and `smoothness`.
+                - "L": the distance function is continuous but can be non-differentiable on a 
+                set of points, which has measure zero.
 
-        Returns
-        -------
-        A 2D array of shape (n, 1). The distance at each point in `x`.
+                - "M": the distance function is continuous and differentiable at any order. The 
+                non-differentiable points can only appear on boundaries. If the points in `x` are
+                all inside or outside the geometry, the distance function is smooth.
+                
+                - "H": the distance function is continuous and differentiable at any order on any 
+                points. This option may result in a polynomial of HIGH order. 
+
+        Returns:
+            A NumPy array of shape (n, 1). The distance at each point in `x`.
         """
         raise NotImplementedError(
             "{}.approxdist2boundary to be implemented".format(self.idstr)

--- a/deepxde/geometry/geometry.py
+++ b/deepxde/geometry/geometry.py
@@ -39,10 +39,10 @@ class Geometry(abc.ABC):
         - The function is not necessarily equal to the exact distance function.
 
         Args:
-            x: a 2D array of shape (n, dim), where `n` is the number of points and
+            x: A 2D array of shape (n, dim), where `n` is the number of points and
                 `dim` is the dimension of the geometry. Note that `x` should be a tensor type
                 of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
-            smoothness: a string to specify the smoothness of the distance function,
+            smoothness (string, optional): A string to specify the smoothness of the distance function,
                 e.g., "L", "M", "H". "L" is the least smooth, "H" is the most smooth.
                 Default is "M".
 

--- a/deepxde/geometry/geometry.py
+++ b/deepxde/geometry/geometry.py
@@ -28,7 +28,7 @@ class Geometry(abc.ABC):
             "{}.mindist2boundary to be implemented".format(self.idstr)
         )
     
-    def approxdist2boundary(self, x, smoothness: Literal["L", "M", "H"] = "M"):
+    def approxdist2boundary(self, x, smoothness: Literal["C0", "Cinf", "Cinf+"] = "Cinf"):
         """Compute the approximate distance at x to the boundary.
 
         This function is used for the hard-constraint methods. The approximate distance function 
@@ -43,19 +43,19 @@ class Geometry(abc.ABC):
                 `dim` is the dimension of the geometry. Note that `x` should be a tensor type
                 of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
             smoothness (string, optional): A string to specify the smoothness of the distance function,
-                e.g., "L", "M", "H". "L" is the least smooth, "H" is the most smooth.
-                Default is "M".
+                e.g., "C0", "Cinf", "Cinf+". "C0" is the least smooth, "Cinf+" is the most smooth.
+                Default is "Cinf".
 
-                - L
+                - C0
                 The distance function is continuous but can be non-differentiable on a
                 set of points, which has measure zero.
 
-                - M
+                - Cinf
                 The distance function is continuous and differentiable at any order. The
                 non-differentiable points can only appear on boundaries. If the points in `x` are
                 all inside or outside the geometry, the distance function is smooth.
 
-                - H
+                - Cinf+
                 The distance function is continuous and differentiable at any order on any 
                 points. This option may result in a polynomial of HIGH order.
 

--- a/deepxde/geometry/geometry.py
+++ b/deepxde/geometry/geometry.py
@@ -1,5 +1,6 @@
 import abc
 from typing import Literal
+
 import numpy as np
 
 
@@ -27,18 +28,20 @@ class Geometry(abc.ABC):
         raise NotImplementedError(
             "{}.mindist2boundary to be implemented".format(self.idstr)
         )
-    
-    def boundary_constraint_factor(self, x, smoothness: Literal["C0", "C0+", "Cinf"] = "C0+"):
+
+    def boundary_constraint_factor(
+        self, x, smoothness: Literal["C0", "C0+", "Cinf"] = "C0+"
+    ):
         """Compute the hard constraint factor at x for the boundary.
 
-        This function is used for the hard-constraint methods in Physics-Informed Neural Networks (PINNs). 
+        This function is used for the hard-constraint methods in Physics-Informed Neural Networks (PINNs).
         The hard constraint factor satisfies the following properties:
 
         - The function is zero on the boundary and positive elsewhere.
         - The function is at least continuous.
 
-        In the ansatz `boundary_constraint_factor(x) * NN(x) + boundary_condition(x)`, when `x` is on the boundary, 
-        `boundary_constraint_factor(x)` will be zero, making the ansatz be the boundary condition, which in 
+        In the ansatz `boundary_constraint_factor(x) * NN(x) + boundary_condition(x)`, when `x` is on the boundary,
+        `boundary_constraint_factor(x)` will be zero, making the ansatz be the boundary condition, which in
         turn makes the boundary condition a "hard constraint".
 
         Args:
@@ -51,7 +54,7 @@ class Geometry(abc.ABC):
 
                 - C0
                 The distance function is continuous but may not be non-differentiable.
-                But the set of non-differentiable points should have measure zero, 
+                But the set of non-differentiable points should have measure zero,
                 which makes the probability of the collocation point falling in this set be zero.
 
                 - C0+
@@ -60,11 +63,11 @@ class Geometry(abc.ABC):
                 all inside or outside the geometry, the distance function is smooth.
 
                 - Cinf
-                The distance function is continuous and differentiable at any order on any 
+                The distance function is continuous and differentiable at any order on any
                 points. This option may result in a polynomial of HIGH order.
 
         Returns:
-            A tensor of a type determined by the backend, which will have a shape of (n, 1). 
+            A tensor of a type determined by the backend, which will have a shape of (n, 1).
             Each element in the tensor corresponds to the computed distance value for the respective point in `x`.
         """
         raise NotImplementedError(

--- a/deepxde/geometry/geometry.py
+++ b/deepxde/geometry/geometry.py
@@ -31,14 +31,16 @@ class Geometry(abc.ABC):
     def approxdist2boundary(self, x, 
         smoothness: Literal["L", "M", "H"] = "M"):
         """Compute the approximate distance at x to the boundary.
+
         - This function is used for the hard-constraint methods.
+
         - The approximate distance function satisfies the following properties:
+
             - The function is zero on the boundary and positive elsewhere.
             - The function is almost differentiable at any order.
             - The function is not necessarily equal to the exact distance function.
 
         Args:
-
             x: a 2D array of shape (n, dim), where `n` is the number of points and
                 `dim` is the dimension of the geometry. Note that `x` should be a tensor type
                 of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
@@ -46,15 +48,15 @@ class Geometry(abc.ABC):
                 e.g., "L", "M", "H". "L" is the least smooth, "H" is the most smooth.
                 Default is "M".
 
-                - "L": the distance function is continuous but can be non-differentiable on a 
-                set of points, which has measure zero.
+                - "L": the distance function is continuous but can be non-differentiable on a
+                  set of points, which has measure zero.
 
-                - "M": the distance function is continuous and differentiable at any order. The 
-                non-differentiable points can only appear on boundaries. If the points in `x` are
-                all inside or outside the geometry, the distance function is smooth.
+                - "M": the distance function is continuous and differentiable at any order. The
+                  non-differentiable points can only appear on boundaries. If the points in `x` are
+                  all inside or outside the geometry, the distance function is smooth.
                 
                 - "H": the distance function is continuous and differentiable at any order on any 
-                points. This option may result in a polynomial of HIGH order. 
+                  points. This option may result in a polynomial of HIGH order.
 
         Returns:
             A NumPy array of shape (n, 1). The distance at each point in `x`.

--- a/deepxde/geometry/geometry.py
+++ b/deepxde/geometry/geometry.py
@@ -1,5 +1,5 @@
 import abc
-
+from typing import Literal, Union
 import numpy as np
 
 
@@ -26,6 +26,46 @@ class Geometry(abc.ABC):
     def mindist2boundary(self, x):
         raise NotImplementedError(
             "{}.mindist2boundary to be implemented".format(self.idstr)
+        )
+    
+    def approxdist2boundary(self, x, where:Union[
+        None, Literal["left", "right", "top", "bottom"]]=None,
+        smoothness:Literal["L", "M", "H"]="M"):
+        """Compute the approximate distance at x to the boundary.
+        - This function is used for the hard-constraint methods.
+        - The approximate distance function satisfies the following properties:
+            - The function is zero on the boundary and positive elsewhere.
+            - The function is almost differentiable at any order.
+            - The function is not necessarily equal to the exact distance function.
+
+        Parameter
+        ---------
+
+        - `x`: a 2D array of shape (n, dim), where `n` is the number of points and
+            `dim` is the dimension of the geometry. Note that `x` should be a tensor type
+            of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
+        - `where`: a string to specify which part of the boundary to compute the distance, 
+            e.g., "left", "right", "top", "bottom". If `None`, compute the distance to 
+            the whole boundary.
+        - `smoothness`: a string to specify the smoothness of the distance function,
+            e.g., "L", "M", "H". "L" is the least smooth, "H" is the most smooth.
+            - "L": the distance function is continuous but can be non-differentiable on a 
+            set of points, which has measure zero.
+            - "M": the distance function is continuous and differentiable at any order. The 
+            non-differentiable points can only appear on boundaries. If the points in `x` are
+            all inside or outside the geometry, the distance function is smooth.
+            - "H": the distance function is continuous and differentiable at any order on any 
+            points. This option may result in a polynomial of HIGH order. 
+
+        Please refer to the definition of this function in each subclass 
+        for the optional values of parameters `where` and `smoothness`.
+
+        Returns
+        -------
+        A 2D array of shape (n, 1). The distance at each point in `x`.
+        """
+        raise NotImplementedError(
+            "{}.approxdist2boundary to be implemented".format(self.idstr)
         )
 
     def boundary_normal(self, x):

--- a/deepxde/geometry/geometry.py
+++ b/deepxde/geometry/geometry.py
@@ -28,9 +28,9 @@ class Geometry(abc.ABC):
             "{}.mindist2boundary to be implemented".format(self.idstr)
         )
     
-    def approxdist2boundary(self, x, where:Union[
-        None, Literal["left", "right", "top", "bottom"]]=None,
-        smoothness:Literal["L", "M", "H"]="M"):
+    def approxdist2boundary(self, x, where: Union[
+        None, Literal["left", "right", "top", "bottom"]] = None,
+        smoothness: Literal["L", "M", "H"] = "M"):
         """Compute the approximate distance at x to the boundary.
         - This function is used for the hard-constraint methods.
         - The approximate distance function satisfies the following properties:

--- a/deepxde/geometry/geometry.py
+++ b/deepxde/geometry/geometry.py
@@ -28,15 +28,18 @@ class Geometry(abc.ABC):
             "{}.mindist2boundary to be implemented".format(self.idstr)
         )
     
-    def approxdist2boundary(self, x, smoothness: Literal["C0", "C0+", "Cinf"] = "C0+"):
-        """Compute the approximate distance at x to the boundary.
+    def boundary_constraint_factor(self, x, smoothness: Literal["C0", "C0+", "Cinf"] = "C0+"):
+        """Compute the hard constraint factor at x for the boundary.
 
-        This function is used for the hard-constraint methods. The approximate distance function 
-        satisfies the following properties:
+        This function is used for the hard-constraint methods in Physics-Informed Neural Networks (PINNs). 
+        The hard constraint factor satisfies the following properties:
 
         - The function is zero on the boundary and positive elsewhere.
-        - The function is almost differentiable at any order.
-        - The function is not necessarily equal to the exact distance function.
+        - The function is at least continuous.
+
+        In the ansatz `boundary_constraint_factor(x) * NN(x) + boundary_condition(x)`, when `x` is on the boundary, 
+        `boundary_constraint_factor(x)` will be zero, making the ansatz be the boundary condition, which in 
+        turn makes the boundary condition a "hard constraint".
 
         Args:
             x: A 2D array of shape (n, dim), where `n` is the number of points and
@@ -48,6 +51,8 @@ class Geometry(abc.ABC):
 
                 - C0
                 The distance function is continuous but may not be non-differentiable.
+                But the set of non-differentiable points should have measure zero, 
+                which makes the probability of the collocation point falling in this set be zero.
 
                 - C0+
                 The distance function is continuous and differentiable almost everywhere. The
@@ -60,10 +65,10 @@ class Geometry(abc.ABC):
 
         Returns:
             A tensor of a type determined by the backend, which will have a shape of (n, 1). 
-            Each element in the tensor corresponds to the computed distance value for the respective point in 'x'.
+            Each element in the tensor corresponds to the computed distance value for the respective point in `x`.
         """
         raise NotImplementedError(
-            "{}.approxdist2boundary to be implemented".format(self.idstr)
+            "{}.boundary_constraint_factor to be implemented".format(self.idstr)
         )
 
     def boundary_normal(self, x):

--- a/deepxde/geometry/geometry_1d.py
+++ b/deepxde/geometry/geometry_1d.py
@@ -1,10 +1,11 @@
+from typing import Literal, Union
+
 import numpy as np
 
 from .geometry import Geometry
-from typing import Literal, Union
 from .sampler import sample
-from .. import config
 from .. import backend as bkd
+from .. import config
 
 
 class Interval(Geometry):

--- a/deepxde/geometry/geometry_1d.py
+++ b/deepxde/geometry/geometry_1d.py
@@ -29,33 +29,37 @@ class Interval(Geometry):
         smoothness: Literal["L", "M", "H"] = "M",
         where: Union[None, Literal["left", "right"]] = None):
         """Compute the approximate distance at x to the boundary.
-        - This function is used for the hard-constraint methods.
-        - The approximate distance function satisfies the following properties:
-            - The function is zero on the boundary and positive elsewhere.
-            - The function is almost differentiable at any order.
-            - The function is not necessarily equal to the exact distance function.
+
+        This function is used for the hard-constraint methods. The approximate distance function 
+        satisfies the following properties:
+
+        - The function is zero on the boundary and positive elsewhere.
+        - The function is almost differentiable at any order.
+        - The function is not necessarily equal to the exact distance function.
 
         Args:
-
-            x: a 2D array of shape (n, dim), where `n` is the number of points and
+            x: A 2D array of shape (n, dim), where `n` is the number of points and
                 `dim` is the dimension of the geometry. Note that `x` should be a tensor type
                 of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
-            smoothness: a string to specify the smoothness of the distance function,
+            smoothness (string, optional): A string to specify the smoothness of the distance function,
                 e.g., "L", "M", "H". "L" is the least smooth, "H" is the most smooth.
                 Default is "M".
 
-                - "L": the distance function is continuous but can be non-differentiable on a 
+                - L
+                The distance function is continuous but can be non-differentiable on a
                 set of points, which has measure zero.
 
-                - "M": the distance function is continuous and differentiable at any order. The 
+                - M
+                The distance function is continuous and differentiable at any order. The
                 non-differentiable points can only appear on boundaries. If the points in `x` are
                 all inside or outside the geometry, the distance function is smooth.
-                
-                - "H": the distance function is continuous and differentiable at any order on any 
-                points. This option may result in a polynomial of HIGH order. 
 
-            where: a string to specify which part of the boundary to compute the distance, 
-                e.g., "left", "right". If `None`, compute the distance to the whole boundary.
+                - H
+                The distance function is continuous and differentiable at any order on any 
+                points. This option may result in a polynomial of HIGH order.
+
+            where (string, optional): A string to specify which part of the boundary to compute the distance, 
+                e.g., "left", "right". If `None`, compute the distance to the whole boundary. Default is `None`.
 
         Returns:
             A NumPy array of shape (n, 1). The distance at each point in `x`.

--- a/deepxde/geometry/geometry_1d.py
+++ b/deepxde/geometry/geometry_1d.py
@@ -73,12 +73,10 @@ class Interval(Geometry):
             Each element in the tensor corresponds to the computed distance value for the respective point in `x`.
         """
 
-        assert where in [None, "left", "right"], "where must be None, left, or right"
-        assert smoothness in [
-            "C0",
-            "C0+",
-            "Cinf",
-        ], "smoothness must be one of C0, C0+, Cinf"
+        if where not in [None, "left"]:
+            raise ValueError("where must be None or left")
+        if smoothness not in ["C0", "C0+", "Cinf"]:
+            raise ValueError("smoothness must be one of C0, C0+, Cinf")
 
         # To convert self.l and self.r to tensor,
         # and avoid repeated conversion in the loop

--- a/deepxde/geometry/geometry_1d.py
+++ b/deepxde/geometry/geometry_1d.py
@@ -25,17 +25,20 @@ class Interval(Geometry):
     def mindist2boundary(self, x):
         return min(np.amin(x - self.l), np.amin(self.r - x))
 
-    def approxdist2boundary(self, x,
+    def boundary_constraint_factor(self, x,
         smoothness: Literal["C0", "C0+", "Cinf"] = "C0+",
         where: Union[None, Literal["left", "right"]] = None):
-        """Compute the approximate distance at x to the boundary.
+        """Compute the hard constraint factor at x for the boundary.
 
-        This function is used for the hard-constraint methods. The approximate distance function 
-        satisfies the following properties:
+        This function is used for the hard-constraint methods in Physics-Informed Neural Networks (PINNs). 
+        The hard constraint factor satisfies the following properties:
 
         - The function is zero on the boundary and positive elsewhere.
-        - The function is almost differentiable at any order.
-        - The function is not necessarily equal to the exact distance function.
+        - The function is at least continuous.
+
+        In the ansatz `boundary_constraint_factor(x) * NN(x) + boundary_condition(x)`, when `x` is on the boundary, 
+        `boundary_constraint_factor(x)` will be zero, making the ansatz be the boundary condition, which in 
+        turn makes the boundary condition a "hard constraint".
 
         Args:
             x: A 2D array of shape (n, dim), where `n` is the number of points and
@@ -47,6 +50,8 @@ class Interval(Geometry):
 
                 - C0
                 The distance function is continuous but may not be non-differentiable.
+                But the set of non-differentiable points should have measure zero, 
+                which makes the probability of the collocation point falling in this set be zero.
 
                 - C0+
                 The distance function is continuous and differentiable almost everywhere. The
@@ -62,7 +67,7 @@ class Interval(Geometry):
 
         Returns:
             A tensor of a type determined by the backend, which will have a shape of (n, 1). 
-            Each element in the tensor corresponds to the computed distance value for the respective point in 'x'.
+            Each element in the tensor corresponds to the computed distance value for the respective point in `x`.
         """
 
         assert where in [None, "left", "right"], "where must be None, left, or right"

--- a/deepxde/geometry/geometry_1d.py
+++ b/deepxde/geometry/geometry_1d.py
@@ -36,10 +36,12 @@ class Interval(Geometry):
             self.l_tensor = bkd.as_tensor(self.l)
             self.r_tensor = bkd.as_tensor(self.r)
 
-        dist_l = bkd.abs((x - self.l_tensor) 
-            / (self.r_tensor - self.l_tensor) * 2)
-        dist_r = bkd.abs((x - self.r_tensor) 
-            / (self.r_tensor - self.l_tensor) * 2)
+        if where != "right":
+            dist_l = bkd.abs((x - self.l_tensor) 
+                / (self.r_tensor - self.l_tensor) * 2)
+        if where != "left":
+            dist_r = bkd.abs((x - self.r_tensor) 
+                / (self.r_tensor - self.l_tensor) * 2)
         if where is None:
             if smoothness == "L":
                 return bkd.minimum(dist_l, dist_r)

--- a/deepxde/geometry/geometry_1d.py
+++ b/deepxde/geometry/geometry_1d.py
@@ -24,9 +24,9 @@ class Interval(Geometry):
     def mindist2boundary(self, x):
         return min(np.amin(x - self.l), np.amin(self.r - x))
 
-    def approxdist2boundary(self, x, where: Union[
-        None, Literal["left", "right"]] = None,
-        smoothness: Literal["L", "M", "H"] = "M"):
+    def approxdist2boundary(self, x,
+        smoothness: Literal["L", "M", "H"] = "M",
+        where: Union[None, Literal["left", "right"]] = None):
         """Compute the approximate distance at x to the boundary.
         - This function is used for the hard-constraint methods.
         - The approximate distance function satisfies the following properties:
@@ -39,8 +39,6 @@ class Interval(Geometry):
             x: a 2D array of shape (n, dim), where `n` is the number of points and
                 `dim` is the dimension of the geometry. Note that `x` should be a tensor type
                 of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
-            where: a string to specify which part of the boundary to compute the distance, 
-                e.g., "left", "right". If `None`, compute the distance to the whole boundary.
             smoothness: a string to specify the smoothness of the distance function,
                 e.g., "L", "M", "H". "L" is the least smooth, "H" is the most smooth.
                 Default is "M".
@@ -55,6 +53,9 @@ class Interval(Geometry):
                 - "H": the distance function is continuous and differentiable at any order on any 
                 points. This option may result in a polynomial of HIGH order. 
 
+            where: a string to specify which part of the boundary to compute the distance, 
+                e.g., "left", "right". If `None`, compute the distance to the whole boundary.
+
         Returns:
             A NumPy array of shape (n, 1). The distance at each point in `x`.
         """
@@ -68,12 +69,14 @@ class Interval(Geometry):
             self.l_tensor = bkd.as_tensor(self.l)
             self.r_tensor = bkd.as_tensor(self.r)
 
+        dist_l = dist_r = None
         if where != "right":
             dist_l = bkd.abs((x - self.l_tensor) 
                 / (self.r_tensor - self.l_tensor) * 2)
         if where != "left":
             dist_r = bkd.abs((x - self.r_tensor) 
                 / (self.r_tensor - self.l_tensor) * 2)
+
         if where is None:
             if smoothness == "L":
                 return bkd.minimum(dist_l, dist_r)

--- a/deepxde/geometry/geometry_1d.py
+++ b/deepxde/geometry/geometry_1d.py
@@ -26,7 +26,7 @@ class Interval(Geometry):
         return min(np.amin(x - self.l), np.amin(self.r - x))
 
     def approxdist2boundary(self, x,
-        smoothness: Literal["L", "M", "H"] = "M",
+        smoothness: Literal["C0", "Cinf", "Cinf+"] = "Cinf",
         where: Union[None, Literal["left", "right"]] = None):
         """Compute the approximate distance at x to the boundary.
 
@@ -42,19 +42,19 @@ class Interval(Geometry):
                 `dim` is the dimension of the geometry. Note that `x` should be a tensor type
                 of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
             smoothness (string, optional): A string to specify the smoothness of the distance function,
-                e.g., "L", "M", "H". "L" is the least smooth, "H" is the most smooth.
-                Default is "M".
+                e.g., "C0", "Cinf", "Cinf+". "C0" is the least smooth, "Cinf+" is the most smooth.
+                Default is "Cinf".
 
-                - L
+                - C0
                 The distance function is continuous but can be non-differentiable on a
                 set of points, which has measure zero.
 
-                - M
+                - Cinf
                 The distance function is continuous and differentiable at any order. The
                 non-differentiable points can only appear on boundaries. If the points in `x` are
                 all inside or outside the geometry, the distance function is smooth.
 
-                - H
+                - Cinf+
                 The distance function is continuous and differentiable at any order on any 
                 points. This option may result in a polynomial of HIGH order.
 
@@ -66,7 +66,7 @@ class Interval(Geometry):
         """
 
         assert where in [None, "left", "right"], "where must be None, left, or right"
-        assert smoothness in ["L", "M", "H"], "smoothness must be one of L, M, H"
+        assert smoothness in ["C0", "Cinf", "Cinf+"], "smoothness must be one of C0, Cinf, Cinf+"
         
         # To convert self.l and self.r to tensor,
         # and avoid repeated conversion in the loop
@@ -83,16 +83,16 @@ class Interval(Geometry):
                 / (self.r_tensor - self.l_tensor) * 2)
 
         if where is None:
-            if smoothness == "L":
+            if smoothness == "C0":
                 return bkd.minimum(dist_l, dist_r)
-            if smoothness == "M":
+            if smoothness == "Cinf":
                 return dist_l * dist_r
             return bkd.square(dist_l * dist_r)
         if where == "left":
-            if smoothness == "H":
+            if smoothness == "Cinf+":
                 dist_l = bkd.square(dist_l)
             return dist_l
-        if smoothness == "H":
+        if smoothness == "Cinf+":
             dist_r = bkd.square(dist_r)
         return dist_r
 

--- a/deepxde/geometry/geometry_1d.py
+++ b/deepxde/geometry/geometry_1d.py
@@ -49,12 +49,12 @@ class Interval(Geometry):
                 return dist_l * dist_r
             return bkd.square(dist_l * dist_r)
         if where == "left":
-            if smoothness == "L" or smoothness == "M":
-                return dist_l
-            return bkd.square(dist_l)
-        if smoothness == "L" or smoothness == "M":
-            return dist_r
-        return bkd.square(dist_r)
+            if smoothness == "H":
+                dist_l = bkd.square(dist_l)
+            return dist_l
+        if smoothness == "H":
+            dist_r = bkd.square(dist_r)
+        return dist_r
 
     def boundary_normal(self, x):
         return -np.isclose(x, self.l).astype(config.real(np)) + np.isclose(x, self.r)

--- a/deepxde/geometry/geometry_1d.py
+++ b/deepxde/geometry/geometry_1d.py
@@ -25,19 +25,22 @@ class Interval(Geometry):
     def mindist2boundary(self, x):
         return min(np.amin(x - self.l), np.amin(self.r - x))
 
-    def boundary_constraint_factor(self, x,
+    def boundary_constraint_factor(
+        self,
+        x,
         smoothness: Literal["C0", "C0+", "Cinf"] = "C0+",
-        where: Union[None, Literal["left", "right"]] = None):
+        where: Union[None, Literal["left", "right"]] = None,
+    ):
         """Compute the hard constraint factor at x for the boundary.
 
-        This function is used for the hard-constraint methods in Physics-Informed Neural Networks (PINNs). 
+        This function is used for the hard-constraint methods in Physics-Informed Neural Networks (PINNs).
         The hard constraint factor satisfies the following properties:
 
         - The function is zero on the boundary and positive elsewhere.
         - The function is at least continuous.
 
-        In the ansatz `boundary_constraint_factor(x) * NN(x) + boundary_condition(x)`, when `x` is on the boundary, 
-        `boundary_constraint_factor(x)` will be zero, making the ansatz be the boundary condition, which in 
+        In the ansatz `boundary_constraint_factor(x) * NN(x) + boundary_condition(x)`, when `x` is on the boundary,
+        `boundary_constraint_factor(x)` will be zero, making the ansatz be the boundary condition, which in
         turn makes the boundary condition a "hard constraint".
 
         Args:
@@ -50,7 +53,7 @@ class Interval(Geometry):
 
                 - C0
                 The distance function is continuous but may not be non-differentiable.
-                But the set of non-differentiable points should have measure zero, 
+                But the set of non-differentiable points should have measure zero,
                 which makes the probability of the collocation point falling in this set be zero.
 
                 - C0+
@@ -59,33 +62,35 @@ class Interval(Geometry):
                 all inside or outside the geometry, the distance function is smooth.
 
                 - Cinf
-                The distance function is continuous and differentiable at any order on any 
+                The distance function is continuous and differentiable at any order on any
                 points. This option may result in a polynomial of HIGH order.
 
-            where (string, optional): A string to specify which part of the boundary to compute the distance, 
+            where (string, optional): A string to specify which part of the boundary to compute the distance,
                 e.g., "left", "right". If `None`, compute the distance to the whole boundary. Default is `None`.
 
         Returns:
-            A tensor of a type determined by the backend, which will have a shape of (n, 1). 
+            A tensor of a type determined by the backend, which will have a shape of (n, 1).
             Each element in the tensor corresponds to the computed distance value for the respective point in `x`.
         """
 
         assert where in [None, "left", "right"], "where must be None, left, or right"
-        assert smoothness in ["C0", "C0+", "Cinf"], "smoothness must be one of C0, C0+, Cinf"
-        
+        assert smoothness in [
+            "C0",
+            "C0+",
+            "Cinf",
+        ], "smoothness must be one of C0, C0+, Cinf"
+
         # To convert self.l and self.r to tensor,
         # and avoid repeated conversion in the loop
-        if not hasattr(self, 'self.l_tensor'):
+        if not hasattr(self, "self.l_tensor"):
             self.l_tensor = bkd.as_tensor(self.l)
             self.r_tensor = bkd.as_tensor(self.r)
 
         dist_l = dist_r = None
         if where != "right":
-            dist_l = bkd.abs((x - self.l_tensor) 
-                / (self.r_tensor - self.l_tensor) * 2)
+            dist_l = bkd.abs((x - self.l_tensor) / (self.r_tensor - self.l_tensor) * 2)
         if where != "left":
-            dist_r = bkd.abs((x - self.r_tensor) 
-                / (self.r_tensor - self.l_tensor) * 2)
+            dist_r = bkd.abs((x - self.r_tensor) / (self.r_tensor - self.l_tensor) * 2)
 
         if where is None:
             if smoothness == "C0":

--- a/deepxde/geometry/geometry_1d.py
+++ b/deepxde/geometry/geometry_1d.py
@@ -37,10 +37,10 @@ class Interval(Geometry):
             self.r_tensor = bkd.as_tensor(self.r)
 
         if where != "right":
-            dist_l = bkd.absolute((x - self.l_tensor) 
+            dist_l = bkd.abs((x - self.l_tensor) 
                 / (self.r_tensor - self.l_tensor) * 2)
         if where != "left":
-            dist_r = bkd.absolute((x - self.r_tensor) 
+            dist_r = bkd.abs((x - self.r_tensor) 
                 / (self.r_tensor - self.l_tensor) * 2)
         if where is None:
             if smoothness == "L":

--- a/deepxde/geometry/geometry_1d.py
+++ b/deepxde/geometry/geometry_1d.py
@@ -37,28 +37,25 @@ class Interval(Geometry):
             self.r_tensor = bkd.as_tensor(self.r)
 
         if where != "right":
-            dist_l = bkd.abs((x - self.l_tensor) 
+            dist_l = bkd.absolute((x - self.l_tensor) 
                 / (self.r_tensor - self.l_tensor) * 2)
         if where != "left":
-            dist_r = bkd.abs((x - self.r_tensor) 
+            dist_r = bkd.absolute((x - self.r_tensor) 
                 / (self.r_tensor - self.l_tensor) * 2)
         if where is None:
             if smoothness == "L":
                 return bkd.minimum(dist_l, dist_r)
-            elif smoothness == "M":
+            if smoothness == "M":
                 return dist_l * dist_r
-            else:
-                return bkd.square(dist_l * dist_r)
+            return bkd.square(dist_l * dist_r)
         elif where == "left":
             if smoothness == "L" or smoothness == "M":
                 return dist_l
-            else:
-                return bkd.square(dist_l)
-        elif where == "right":
+            return bkd.square(dist_l)
+        else:
             if smoothness == "L" or smoothness == "M":
                 return dist_r
-            else:
-                return bkd.square(dist_r)
+            return bkd.square(dist_r)
 
     def boundary_normal(self, x):
         return -np.isclose(x, self.l).astype(config.real(np)) + np.isclose(x, self.r)

--- a/deepxde/geometry/geometry_1d.py
+++ b/deepxde/geometry/geometry_1d.py
@@ -34,26 +34,29 @@ class Interval(Geometry):
         # and avoid repeated conversion in the loop
         if not hasattr(self, 'self.l_tensor'):
             self.l_tensor = bkd.as_tensor(self.l)
-        if not hasattr(self, 'self.r_tensor'):
             self.r_tensor = bkd.as_tensor(self.r)
 
+        dist_l = bkd.abs((x - self.l_tensor) 
+            / (self.r_tensor - self.l_tensor) * 2)
+        dist_r = bkd.abs((x - self.r_tensor) 
+            / (self.r_tensor - self.l_tensor) * 2)
         if where is None:
             if smoothness == "L":
-                return bkd.minimum(bkd.abs(x - self.l_tensor), bkd.abs(x - self.r_tensor))
+                return bkd.minimum(dist_l, dist_r)
             elif smoothness == "M":
-                return bkd.abs(x - self.l_tensor) * bkd.abs(x - self.r_tensor)
+                return dist_l * dist_r
             else:
-                return bkd.square(x - self.l_tensor) * bkd.square(x - self.r_tensor)
+                return bkd.square(dist_l * dist_r)
         elif where == "left":
             if smoothness == "L" or smoothness == "M":
-                return bkd.abs(x - self.l_tensor)
+                return dist_l
             else:
-                return bkd.square(x - self.l_tensor)
+                return bkd.square(dist_l)
         elif where == "right":
             if smoothness == "L" or smoothness == "M":
-                return bkd.abs(x - self.r_tensor)
+                return dist_r
             else:
-                return bkd.square(x - self.r_tensor)
+                return bkd.square(dist_r)
 
     def boundary_normal(self, x):
         return -np.isclose(x, self.l).astype(config.real(np)) + np.isclose(x, self.r)

--- a/deepxde/geometry/geometry_1d.py
+++ b/deepxde/geometry/geometry_1d.py
@@ -48,14 +48,13 @@ class Interval(Geometry):
             if smoothness == "M":
                 return dist_l * dist_r
             return bkd.square(dist_l * dist_r)
-        elif where == "left":
+        if where == "left":
             if smoothness == "L" or smoothness == "M":
                 return dist_l
             return bkd.square(dist_l)
-        else:
-            if smoothness == "L" or smoothness == "M":
-                return dist_r
-            return bkd.square(dist_r)
+        if smoothness == "L" or smoothness == "M":
+            return dist_r
+        return bkd.square(dist_r)
 
     def boundary_normal(self, x):
         return -np.isclose(x, self.l).astype(config.real(np)) + np.isclose(x, self.r)

--- a/deepxde/geometry/geometry_1d.py
+++ b/deepxde/geometry/geometry_1d.py
@@ -1,6 +1,7 @@
 import numpy as np
 
-from .geometry import Geometry, Literal, Union
+from .geometry import Geometry
+from typing import Literal, Union
 from .sampler import sample
 from .. import config
 from .. import backend as bkd
@@ -26,6 +27,37 @@ class Interval(Geometry):
     def approxdist2boundary(self, x, where: Union[
         None, Literal["left", "right"]] = None,
         smoothness: Literal["L", "M", "H"] = "M"):
+        """Compute the approximate distance at x to the boundary.
+        - This function is used for the hard-constraint methods.
+        - The approximate distance function satisfies the following properties:
+            - The function is zero on the boundary and positive elsewhere.
+            - The function is almost differentiable at any order.
+            - The function is not necessarily equal to the exact distance function.
+
+        Args:
+
+            x: a 2D array of shape (n, dim), where `n` is the number of points and
+                `dim` is the dimension of the geometry. Note that `x` should be a tensor type
+                of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
+            where: a string to specify which part of the boundary to compute the distance, 
+                e.g., "left", "right". If `None`, compute the distance to the whole boundary.
+            smoothness: a string to specify the smoothness of the distance function,
+                e.g., "L", "M", "H". "L" is the least smooth, "H" is the most smooth.
+                Default is "M".
+
+                - "L": the distance function is continuous but can be non-differentiable on a 
+                set of points, which has measure zero.
+
+                - "M": the distance function is continuous and differentiable at any order. The 
+                non-differentiable points can only appear on boundaries. If the points in `x` are
+                all inside or outside the geometry, the distance function is smooth.
+                
+                - "H": the distance function is continuous and differentiable at any order on any 
+                points. This option may result in a polynomial of HIGH order. 
+
+        Returns:
+            A NumPy array of shape (n, 1). The distance at each point in `x`.
+        """
 
         assert where in [None, "left", "right"], "where must be None, left, or right"
         assert smoothness in ["L", "M", "H"], "smoothness must be one of L, M, H"

--- a/deepxde/geometry/geometry_2d.py
+++ b/deepxde/geometry/geometry_2d.py
@@ -296,7 +296,7 @@ class Rectangle(Hypercube):
         dist_r = bkd.prod(dist_r, dim=-1, keepdims=True)
         return dist_l * dist_r
 
-
+    # pylint: disable=inconsistent-return-statements
     def approxdist2boundary(self, x,
         smoothness: Literal["L", "M", "H"] = "M",
         where: Union[None, Literal["left", "right",
@@ -337,7 +337,6 @@ class Rectangle(Hypercube):
         Returns:
             A NumPy array of shape (n, 1). The distance at each point in `x`.
         """
-        # pylint: disable=inconsistent-return-statements
         assert where in [None, "left", "right", "bottom", "top"], \
             "where must be one of None, left, right, bottom, top"
         assert smoothness in ["L", "M", "H"], "smoothness must be one of L, M, H"

--- a/deepxde/geometry/geometry_2d.py
+++ b/deepxde/geometry/geometry_2d.py
@@ -297,10 +297,10 @@ class Rectangle(Hypercube):
         return dist_l * dist_r
 
 
-    def approxdist2boundary(self, x, where: Union[
-            None, Literal["left", "right",
-                        "bottom", "top"]] = None,
+    def approxdist2boundary(self, x,
         smoothness: Literal["L", "M", "H"] = "M",
+        where: Union[None, Literal["left", "right",
+            "bottom", "top"]] = None,
         inside: bool = True):
         """Compute the approximate distance at x to the boundary.
         - This function is used for the hard-constraint methods.
@@ -314,8 +314,6 @@ class Rectangle(Hypercube):
             x: a 2D array of shape (n, dim), where `n` is the number of points and
                 `dim` is the dimension of the geometry. Note that `x` should be a tensor type
                 of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
-            where: a string to specify which part of the boundary to compute the distance, 
-                e.g., "left", "right", "bottom", "top". If `None`, compute the distance to the whole boundary.
             smoothness: a string to specify the smoothness of the distance function,
                 e.g., "L", "M", "H". "L" is the least smooth, "H" is the most smooth.
                 Default is "M".
@@ -330,6 +328,8 @@ class Rectangle(Hypercube):
                 - "H": the distance function is continuous and differentiable at any order on any 
                 points. This option may result in a polynomial of HIGH order.
 
+            where: a string to specify which part of the boundary to compute the distance, 
+                e.g., "left", "right", "bottom", "top". If `None`, compute the distance to the whole boundary.
             inside: `x` is either inside or outside the geometry.
                 The cases where there are both points inside and points
                 outside the geometry are NOT allowed.
@@ -547,8 +547,8 @@ class Triangle(Geometry):
         return np.vstack(x)
 
     def approxdist2boundary(self, x, 
-        where: Union[None, Literal["x1-x2", "x1-x3", "x2-x3"]] = None, 
-        smoothness: Literal["L", "M", "H"] = "M"):
+        smoothness: Literal["L", "M", "H"] = "M",
+        where: Union[None, Literal["x1-x2", "x1-x3", "x2-x3"]] = None, ):
         """Compute the approximate distance at x to the boundary.
         - This function is used for the hard-constraint methods.
         - The approximate distance function satisfies the following properties:
@@ -561,9 +561,6 @@ class Triangle(Geometry):
             x: a 2D array of shape (n, dim), where `n` is the number of points and
                 `dim` is the dimension of the geometry. Note that `x` should be a tensor type
                 of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
-            where: a string to specify which part of the boundary to compute the distance. 
-                "x1-x2" indicates the line segment with vertices x1 and x2 (after reordered). 
-                If `None`, compute the distance to the whole boundary.
             smoothness: a string to specify the smoothness of the distance function,
                 e.g., "L", "M", "H". "L" is the least smooth, "H" is the most smooth.
                 Default is "M".
@@ -578,6 +575,10 @@ class Triangle(Geometry):
                 - "H": the distance function is continuous and differentiable at any order on any 
                 points. This option may result in a polynomial of HIGH order. 
 
+            where: a string to specify which part of the boundary to compute the distance. 
+                "x1-x2" indicates the line segment with vertices x1 and x2 (after reordered). 
+                If `None`, compute the distance to the whole boundary.
+
         Returns:
             A NumPy array of shape (n, 1). The distance at each point in `x`.
         """
@@ -590,6 +591,7 @@ class Triangle(Geometry):
             self.x2_tensor = bkd.as_tensor(self.x2)
             self.x3_tensor = bkd.as_tensor(self.x3)
         
+        diff_x1_x2 = diff_x1_x3 = diff_x2_x3 = None
         if where not in ["x1-x3", "x2-x3"]:
             diff_x1_x2 = bkd.norm(
                 x - self.x1_tensor, axis=-1, keepdims=True) + bkd.norm(

--- a/deepxde/geometry/geometry_2d.py
+++ b/deepxde/geometry/geometry_2d.py
@@ -296,7 +296,6 @@ class Rectangle(Hypercube):
         dist_r = bkd.prod(dist_r, dim=-1, keepdims=True)
         return dist_l * dist_r
 
-    # pylint: disable=inconsistent-return-statements
     def approxdist2boundary(self, x,
         smoothness: Literal["L", "M", "H"] = "M",
         where: Union[None, Literal["left", "right",

--- a/deepxde/geometry/geometry_2d.py
+++ b/deepxde/geometry/geometry_2d.py
@@ -585,7 +585,7 @@ class Triangle(Geometry):
                 points. This option may result in a polynomial of HIGH order.
 
             where (string, optional): A string to specify which part of the boundary to compute the distance. 
-            If `None`, compute the distance to the whole boundary. "x1-x2" indicates the line segment with vertices x1 and x2 (after reordered). Default is `None`.
+                If `None`, compute the distance to the whole boundary. "x1-x2" indicates the line segment with vertices x1 and x2 (after reordered). Default is `None`.
 
         Returns:
             A NumPy array of shape (n, 1). The distance at each point in `x`.

--- a/deepxde/geometry/geometry_2d.py
+++ b/deepxde/geometry/geometry_2d.py
@@ -188,7 +188,7 @@ class Ellipse(Geometry):
         if smoothness == "H":
             dist = bkd.square(dist)
         else:
-            dist = bkd.absolute(dist)
+            dist = bkd.abs(dist)
 
         return dist
 
@@ -274,10 +274,10 @@ class Rectangle(Hypercube):
             self.xmin_tensor = bkd.as_tensor(self.xmin)
             self.xmax_tensor = bkd.as_tensor(self.xmax)
         if where not in ["right", "top"]:
-            dist_l = bkd.absolute((x - self.xmin_tensor) /
+            dist_l = bkd.abs((x - self.xmin_tensor) /
                             (self.xmax_tensor - self.xmin_tensor) * 2)
         if where not in ["left", "bottom"]:
-            dist_r = bkd.absolute((x - self.xmax_tensor) /
+            dist_r = bkd.abs((x - self.xmax_tensor) /
                             (self.xmax_tensor - self.xmin_tensor) * 2)
         
         if where == "left":
@@ -290,8 +290,8 @@ class Rectangle(Hypercube):
             return dist_r[:, 1:]
 
         if smoothness == "L":
-            dist_l = bkd.amin(dist_l, dim=-1, keepdims=True)
-            dist_r = bkd.amin(dist_r, dim=-1, keepdims=True)
+            dist_l = bkd.min(dist_l, dim=-1, keepdims=True)
+            dist_r = bkd.min(dist_r, dim=-1, keepdims=True)
             return bkd.minimum(dist_l, dist_r)
         dist_l = bkd.prod(dist_l, dim=-1, keepdims=True)
         dist_r = bkd.prod(dist_r, dim=-1, keepdims=True)
@@ -326,19 +326,19 @@ class Rectangle(Hypercube):
             self.x21_tensor = bkd.as_tensor([self.xmax[0], self.xmin[1]])
         
         if where is None or where == "left":
-            dist_left = bkd.absolute(bkd.norm(
+            dist_left = bkd.abs(bkd.norm(
                 x - self.x11_tensor, axis=-1, keepdims=True) + bkd.norm(
                 x - self.x12_tensor, axis=-1, keepdims=True) - (self.xmax[1] - self.xmin[1]))
         if where is None or where == "right":
-            dist_right = bkd.absolute(bkd.norm(
+            dist_right = bkd.abs(bkd.norm(
                 x - self.x21_tensor, axis=-1, keepdims=True) + bkd.norm(
                 x - self.x22_tensor, axis=-1, keepdims=True) - (self.xmax[1] - self.xmin[1]))
         if where is None or where == "bottom":
-            dist_bottom = bkd.absolute(bkd.norm(
+            dist_bottom = bkd.abs(bkd.norm(
                 x - self.x11_tensor, axis=-1, keepdims=True) + bkd.norm(
                 x - self.x21_tensor, axis=-1, keepdims=True) - (self.xmax[0] - self.xmin[0]))
         if where is None or where == "top":
-            dist_top = bkd.absolute(bkd.norm(
+            dist_top = bkd.abs(bkd.norm(
                 x - self.x12_tensor, axis=-1, keepdims=True) + bkd.norm(
                 x - self.x22_tensor, axis=-1, keepdims=True) - (self.xmax[0] - self.xmin[0]))
         

--- a/deepxde/geometry/geometry_2d.py
+++ b/deepxde/geometry/geometry_2d.py
@@ -1,12 +1,14 @@
 __all__ = ["Disk", "Ellipse", "Polygon", "Rectangle", "Triangle"]
 
+from typing import Union, Literal
+
 import numpy as np
 from scipy import spatial
 
-from typing import Union, Literal
 from .geometry import Geometry
-from .geometry_nd import Hypercube, Hypersphere, bkd
+from .geometry_nd import Hypercube, Hypersphere
 from .sampler import sample
+from .. import backend as bkd
 from .. import config
 from ..utils import vectorize
 

--- a/deepxde/geometry/geometry_2d.py
+++ b/deepxde/geometry/geometry_2d.py
@@ -623,7 +623,8 @@ class Triangle(Geometry):
                 points. This option may result in a polynomial of HIGH order.
 
             where (string, optional): A string to specify which part of the boundary to compute the distance.
-                If `None`, compute the distance to the whole boundary. "x1-x2" indicates the line segment with vertices x1 and x2 (after reordered). Default is `None`.
+                If `None`, compute the distance to the whole boundary. 
+                "x1-x2" indicates the line segment with vertices x1 and x2 (after reordered). Default is `None`.
 
         Returns:
             A tensor of a type determined by the backend, which will have a shape of (n, 1).

--- a/deepxde/geometry/geometry_2d.py
+++ b/deepxde/geometry/geometry_2d.py
@@ -304,36 +304,40 @@ class Rectangle(Hypercube):
             "bottom", "top"]] = None,
         inside: bool = True):
         """Compute the approximate distance at x to the boundary.
-        - This function is used for the hard-constraint methods.
-        - The approximate distance function satisfies the following properties:
-            - The function is zero on the boundary and positive elsewhere.
-            - The function is almost differentiable at any order.
-            - The function is not necessarily equal to the exact distance function.
+
+        This function is used for the hard-constraint methods. The approximate distance function 
+        satisfies the following properties:
+
+        - The function is zero on the boundary and positive elsewhere.
+        - The function is almost differentiable at any order.
+        - The function is not necessarily equal to the exact distance function.
 
         Args:
-
-            x: a 2D array of shape (n, dim), where `n` is the number of points and
+            x: A 2D array of shape (n, dim), where `n` is the number of points and
                 `dim` is the dimension of the geometry. Note that `x` should be a tensor type
                 of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
-            smoothness: a string to specify the smoothness of the distance function,
+            smoothness (string, optional): A string to specify the smoothness of the distance function,
                 e.g., "L", "M", "H". "L" is the least smooth, "H" is the most smooth.
                 Default is "M".
 
-                - "L": the distance function is continuous but can be non-differentiable on a 
+                - L
+                The distance function is continuous but can be non-differentiable on a
                 set of points, which has measure zero.
 
-                - "M": the distance function is continuous and differentiable at any order. The 
+                - M
+                The distance function is continuous and differentiable at any order. The
                 non-differentiable points can only appear on boundaries. If the points in `x` are
                 all inside or outside the geometry, the distance function is smooth.
-                
-                - "H": the distance function is continuous and differentiable at any order on any 
+
+                - H
+                The distance function is continuous and differentiable at any order on any 
                 points. This option may result in a polynomial of HIGH order.
 
-            where: a string to specify which part of the boundary to compute the distance, 
-                e.g., "left", "right", "bottom", "top". If `None`, compute the distance to the whole boundary.
-            inside: `x` is either inside or outside the geometry.
+            where (string, optional): A string to specify which part of the boundary to compute the distance, 
+                e.g., "left", "right", "bottom", "top". If `None`, compute the distance to the whole boundary. Default is `None`.
+            inside (bool, optional): The `x` is either inside or outside the geometry.
                 The cases where there are both points inside and points
-                outside the geometry are NOT allowed.
+                outside the geometry are NOT allowed. Default is `True`.
 
         Returns:
             A NumPy array of shape (n, 1). The distance at each point in `x`.
@@ -551,34 +555,37 @@ class Triangle(Geometry):
         smoothness: Literal["L", "M", "H"] = "M",
         where: Union[None, Literal["x1-x2", "x1-x3", "x2-x3"]] = None, ):
         """Compute the approximate distance at x to the boundary.
-        - This function is used for the hard-constraint methods.
-        - The approximate distance function satisfies the following properties:
-            - The function is zero on the boundary and positive elsewhere.
-            - The function is almost differentiable at any order.
-            - The function is not necessarily equal to the exact distance function.
+
+        This function is used for the hard-constraint methods. The approximate distance function 
+        satisfies the following properties:
+
+        - The function is zero on the boundary and positive elsewhere.
+        - The function is almost differentiable at any order.
+        - The function is not necessarily equal to the exact distance function.
 
         Args:
-
-            x: a 2D array of shape (n, dim), where `n` is the number of points and
+            x: A 2D array of shape (n, dim), where `n` is the number of points and
                 `dim` is the dimension of the geometry. Note that `x` should be a tensor type
                 of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
-            smoothness: a string to specify the smoothness of the distance function,
+            smoothness (string, optional): A string to specify the smoothness of the distance function,
                 e.g., "L", "M", "H". "L" is the least smooth, "H" is the most smooth.
                 Default is "M".
 
-                - "L": the distance function is continuous but can be non-differentiable on a 
+                - L
+                The distance function is continuous but can be non-differentiable on a
                 set of points, which has measure zero.
 
-                - "M": the distance function is continuous and differentiable at any order. The 
+                - M
+                The distance function is continuous and differentiable at any order. The
                 non-differentiable points can only appear on boundaries. If the points in `x` are
                 all inside or outside the geometry, the distance function is smooth.
-                
-                - "H": the distance function is continuous and differentiable at any order on any 
-                points. This option may result in a polynomial of HIGH order. 
 
-            where: a string to specify which part of the boundary to compute the distance. 
-                "x1-x2" indicates the line segment with vertices x1 and x2 (after reordered). 
-                If `None`, compute the distance to the whole boundary.
+                - H
+                The distance function is continuous and differentiable at any order on any 
+                points. This option may result in a polynomial of HIGH order.
+
+            where (string, optional): A string to specify which part of the boundary to compute the distance. 
+            If `None`, compute the distance to the whole boundary. "x1-x2" indicates the line segment with vertices x1 and x2 (after reordered). Default is `None`.
 
         Returns:
             A NumPy array of shape (n, 1). The distance at each point in `x`.

--- a/deepxde/geometry/geometry_2d.py
+++ b/deepxde/geometry/geometry_2d.py
@@ -179,11 +179,8 @@ class Ellipse(Geometry):
     def boundary_constraint_factor(
         self, x, smoothness: Literal["C0", "C0+", "Cinf"] = "C0+"
     ):
-        assert smoothness in [
-            "C0",
-            "C0+",
-            "Cinf",
-        ], "`smoothness` must be one of C0, C0+, Cinf"
+        if smoothness not in ["C0", "C0+", "Cinf"]:
+            raise ValueError("`smoothness` must be one of C0, C0+, Cinf")
 
         if not hasattr(self, "self.focus1_tensor"):
             self.focus1_tensor = bkd.as_tensor(self.focus1)
@@ -366,19 +363,12 @@ class Rectangle(Hypercube):
             A tensor of a type determined by the backend, which will have a shape of (n, 1).
             Each element in the tensor corresponds to the computed distance value for the respective point in `x`.
         """
-        assert where in [
-            None,
-            "left",
-            "right",
-            "bottom",
-            "top",
-        ], "where must be one of None, left, right, bottom, top"
-        assert smoothness in [
-            "C0",
-            "C0+",
-            "Cinf",
-        ], "smoothness must be one of C0, C0+, Cinf"
-        assert self.dim == 2
+        if where not in [None, "left", "right", "bottom", "top"]:
+            raise ValueError("where must be one of None, left, right, bottom, top")
+        if smoothness not in ["C0", "C0+", "Cinf"]:
+            raise ValueError("smoothness must be one of C0, C0+, Cinf")
+        if self.dim != 2:
+            raise ValueError("self.dim must be 2")
 
         if inside:
             return self._boundary_constraint_factor_inside(x, where, smoothness)
@@ -640,8 +630,10 @@ class Triangle(Geometry):
             Each element in the tensor corresponds to the computed distance value for the respective point in `x`.
         """
 
-        assert where in [None, "x1-x2", "x1-x3", "x2-x3"], "Invalid value for `where`."
-        assert smoothness in ["C0", "C0+", "Cinf"], "Invalid value for `smoothness`."
+        if where not in [None, "x1-x2", "x1-x3", "x2-x3"]:
+            raise ValueError("where must be one of None, x1-x2, x1-x3, x2-x3")
+        if smoothness not in ["C0", "C0+", "Cinf"]:
+            raise ValueError("smoothness must be one of C0, C0+, Cinf")
 
         if not hasattr(self, "self.x1_tensor"):
             self.x1_tensor = bkd.as_tensor(self.x1)

--- a/deepxde/geometry/geometry_2d.py
+++ b/deepxde/geometry/geometry_2d.py
@@ -353,8 +353,9 @@ class Rectangle(Hypercube):
                 The distance function is continuous and differentiable at any order on any
                 points. This option may result in a polynomial of HIGH order.
 
-            where (string, optional): A string to specify which part of the boundary to compute the distance,
-                e.g., "left", "right", "bottom", "top". If `None`, compute the distance to the whole boundary. Default is `None`.
+            where (string, optional): A string to specify which part of the boundary to compute the distance.
+                "left": x[0] = xmin[0], "right": x[0] = xmax[0], "bottom": x[1] = xmin[1], "top": x[1] = xmax[1]. 
+                If `None`, compute the distance to the whole boundary. Default is `None`.
             inside (bool, optional): The `x` is either inside or outside the geometry.
                 The cases where there are both points inside and points
                 outside the geometry are NOT allowed. Default is `True`.

--- a/deepxde/geometry/geometry_2d.py
+++ b/deepxde/geometry/geometry_2d.py
@@ -174,7 +174,7 @@ class Ellipse(Geometry):
         X = np.hstack((self.semimajor * np.cos(theta), self.semiminor * np.sin(theta)))
         return np.matmul(self.rotation_mat, X.T).T + self.center
 
-    def approxdist2boundary(self, x, 
+    def boundary_constraint_factor(self, x, 
         smoothness: Literal["C0", "C0+", "Cinf"] = "C0+"):
         assert smoothness in ["C0", "C0+", "Cinf"], "`smoothness` must be one of C0, C0+, Cinf"
         
@@ -266,7 +266,7 @@ class Rectangle(Hypercube):
                 x.append([self.xmin[0], self.xmax[1] - l + l3])
         return np.vstack(x)
 
-    def approxdist2boundary_inside(self, x, where: Union[
+    def boundary_constraint_factor_inside(self, x, where: Union[
             None, Literal["left", "right",
                         "bottom", "top"]] = None,
         smoothness: Literal["C0", "C0+", "Cinf"] = "C0+"):
@@ -298,19 +298,22 @@ class Rectangle(Hypercube):
         dist_r = bkd.prod(dist_r, dim=-1, keepdims=True)
         return dist_l * dist_r
 
-    def approxdist2boundary(self, x,
+    def boundary_constraint_factor(self, x,
         smoothness: Literal["C0", "C0+", "Cinf"] = "C0+",
         where: Union[None, Literal["left", "right",
             "bottom", "top"]] = None,
         inside: bool = True):
-        """Compute the approximate distance at x to the boundary.
+        """Compute the hard constraint factor at x for the boundary.
 
-        This function is used for the hard-constraint methods. The approximate distance function 
-        satisfies the following properties:
+        This function is used for the hard-constraint methods in Physics-Informed Neural Networks (PINNs). 
+        The hard constraint factor satisfies the following properties:
 
         - The function is zero on the boundary and positive elsewhere.
-        - The function is almost differentiable at any order.
-        - The function is not necessarily equal to the exact distance function.
+        - The function is at least continuous.
+
+        In the ansatz `boundary_constraint_factor(x) * NN(x) + boundary_condition(x)`, when `x` is on the boundary, 
+        `boundary_constraint_factor(x)` will be zero, making the ansatz be the boundary condition, which in 
+        turn makes the boundary condition a "hard constraint".
 
         Args:
             x: A 2D array of shape (n, dim), where `n` is the number of points and
@@ -322,6 +325,8 @@ class Rectangle(Hypercube):
 
                 - C0
                 The distance function is continuous but may not be non-differentiable.
+                But the set of non-differentiable points should have measure zero, 
+                which makes the probability of the collocation point falling in this set be zero.
 
                 - C0+
                 The distance function is continuous and differentiable almost everywhere. The
@@ -340,7 +345,7 @@ class Rectangle(Hypercube):
 
         Returns:
             A tensor of a type determined by the backend, which will have a shape of (n, 1). 
-            Each element in the tensor corresponds to the computed distance value for the respective point in 'x'.
+            Each element in the tensor corresponds to the computed distance value for the respective point in `x`.
         """
         assert where in [None, "left", "right", "bottom", "top"], \
             "where must be one of None, left, right, bottom, top"
@@ -348,7 +353,7 @@ class Rectangle(Hypercube):
         assert self.dim == 2
 
         if inside:
-            return self.approxdist2boundary_inside(x, where, smoothness)
+            return self.boundary_constraint_factor_inside(x, where, smoothness)
 
         if not hasattr(self, "self.x11_tensor"):
             self.x11_tensor = bkd.as_tensor(self.xmin)
@@ -551,17 +556,20 @@ class Triangle(Geometry):
                 x.append((l - self.l12 - self.l23) * self.n31 + self.x3)
         return np.vstack(x)
 
-    def approxdist2boundary(self, x, 
+    def boundary_constraint_factor(self, x, 
         smoothness: Literal["C0", "C0+", "Cinf"] = "C0+",
         where: Union[None, Literal["x1-x2", "x1-x3", "x2-x3"]] = None, ):
-        """Compute the approximate distance at x to the boundary.
+        """Compute the hard constraint factor at x for the boundary.
 
-        This function is used for the hard-constraint methods. The approximate distance function 
-        satisfies the following properties:
+        This function is used for the hard-constraint methods in Physics-Informed Neural Networks (PINNs). 
+        The hard constraint factor satisfies the following properties:
 
         - The function is zero on the boundary and positive elsewhere.
-        - The function is almost differentiable at any order.
-        - The function is not necessarily equal to the exact distance function.
+        - The function is at least continuous.
+
+        In the ansatz `boundary_constraint_factor(x) * NN(x) + boundary_condition(x)`, when `x` is on the boundary, 
+        `boundary_constraint_factor(x)` will be zero, making the ansatz be the boundary condition, which in 
+        turn makes the boundary condition a "hard constraint".
 
         Args:
             x: A 2D array of shape (n, dim), where `n` is the number of points and
@@ -573,6 +581,8 @@ class Triangle(Geometry):
 
                 - C0
                 The distance function is continuous but may not be non-differentiable.
+                But the set of non-differentiable points should have measure zero, 
+                which makes the probability of the collocation point falling in this set be zero.
 
                 - C0+
                 The distance function is continuous and differentiable almost everywhere. The
@@ -588,7 +598,7 @@ class Triangle(Geometry):
 
         Returns:
             A tensor of a type determined by the backend, which will have a shape of (n, 1). 
-            Each element in the tensor corresponds to the computed distance value for the respective point in 'x'.
+            Each element in the tensor corresponds to the computed distance value for the respective point in `x`.
         """
 
         assert where in [None, "x1-x2", "x1-x3", "x2-x3"], "Invalid value for `where`."

--- a/deepxde/geometry/geometry_2d.py
+++ b/deepxde/geometry/geometry_2d.py
@@ -352,7 +352,7 @@ class Rectangle(Hypercube):
             self.x12_tensor = bkd.as_tensor([self.xmin[0], self.xmax[1]])
             self.x21_tensor = bkd.as_tensor([self.xmax[0], self.xmin[1]])
         
-        dist_left = dist_right = dist_bottom = dist_top = None
+        dist_left = dist_right = dist_bottom = dist_top = 0.
         if where is None or where == "left":
             dist_left = bkd.abs(bkd.norm(
                 x - self.x11_tensor, axis=-1, keepdims=True) + bkd.norm(

--- a/deepxde/geometry/geometry_2d.py
+++ b/deepxde/geometry/geometry_2d.py
@@ -266,10 +266,16 @@ class Rectangle(Hypercube):
                 x.append([self.xmin[0], self.xmax[1] - l + l3])
         return np.vstack(x)
 
-    def boundary_constraint_factor_inside(self, x, where: Union[
+    def _boundary_constraint_factor_inside(self, x, where: Union[
             None, Literal["left", "right",
                         "bottom", "top"]] = None,
         smoothness: Literal["C0", "C0+", "Cinf"] = "C0+"):
+        """(Internal use only) Compute the hard constraint factor at `x` for the boundary.
+        The points in `x` are assumed to live inside the geometry.  
+
+        This function is a helper function used internally by the `boundary_constraint_factor` function. 
+        It should not be called directly in most cases.
+        """
 
         if not hasattr(self, "self.xmin_tensor"):
             self.xmin_tensor = bkd.as_tensor(self.xmin)
@@ -353,7 +359,7 @@ class Rectangle(Hypercube):
         assert self.dim == 2
 
         if inside:
-            return self.boundary_constraint_factor_inside(x, where, smoothness)
+            return self._boundary_constraint_factor_inside(x, where, smoothness)
 
         if not hasattr(self, "self.x11_tensor"):
             self.x11_tensor = bkd.as_tensor(self.xmin)

--- a/deepxde/geometry/geometry_2d.py
+++ b/deepxde/geometry/geometry_2d.py
@@ -337,7 +337,7 @@ class Rectangle(Hypercube):
         Returns:
             A NumPy array of shape (n, 1). The distance at each point in `x`.
         """
-        
+        # pylint: disable=inconsistent-return-statements
         assert where in [None, "left", "right", "bottom", "top"], \
             "where must be one of None, left, right, bottom, top"
         assert smoothness in ["L", "M", "H"], "smoothness must be one of L, M, H"
@@ -352,7 +352,7 @@ class Rectangle(Hypercube):
             self.x12_tensor = bkd.as_tensor([self.xmin[0], self.xmax[1]])
             self.x21_tensor = bkd.as_tensor([self.xmax[0], self.xmin[1]])
         
-        dist_left = dist_right = dist_bottom = dist_top = 0.
+        dist_left = dist_right = dist_bottom = dist_top = None
         if where is None or where == "left":
             dist_left = bkd.abs(bkd.norm(
                 x - self.x11_tensor, axis=-1, keepdims=True) + bkd.norm(

--- a/deepxde/geometry/geometry_2d.py
+++ b/deepxde/geometry/geometry_2d.py
@@ -352,6 +352,7 @@ class Rectangle(Hypercube):
             self.x12_tensor = bkd.as_tensor([self.xmin[0], self.xmax[1]])
             self.x21_tensor = bkd.as_tensor([self.xmax[0], self.xmin[1]])
         
+        dist_left = dist_right = dist_bottom = dist_top = None
         if where is None or where == "left":
             dist_left = bkd.abs(bkd.norm(
                 x - self.x11_tensor, axis=-1, keepdims=True) + bkd.norm(

--- a/deepxde/geometry/geometry_2d.py
+++ b/deepxde/geometry/geometry_2d.py
@@ -185,9 +185,8 @@ class Ellipse(Geometry):
         d2 = bkd.norm(x - self.focus2_tensor, axis=-1, keepdims=True)
 
         if smoothness == "L" or smoothness == "M":
-            return bkd.abs(d1 + d2 - 2 * self.semimajor)
-        else:
-            return bkd.square(d1 + d2 - 2 * self.semimajor)
+            return bkd.absolute(d1 + d2 - 2 * self.semimajor)
+        return bkd.square(d1 + d2 - 2 * self.semimajor)
 
 
 class Rectangle(Hypercube):
@@ -283,29 +282,28 @@ class Rectangle(Hypercube):
                 self.xmin_tensor = bkd.as_tensor(self.xmin)
                 self.xmax_tensor = bkd.as_tensor(self.xmax)
             if where not in ["right", "top"]:
-                dist_l = bkd.abs((x - self.xmin_tensor) /
+                dist_l = bkd.absolute((x - self.xmin_tensor) /
                                 (self.xmax_tensor - self.xmin_tensor) * 2)
             if where not in ["left", "bottom"]:
-                dist_r = bkd.abs((x - self.xmax_tensor) /
+                dist_r = bkd.absolute((x - self.xmax_tensor) /
                                 (self.xmax_tensor - self.xmin_tensor) * 2)
             
             if where == "left":
                 return dist_l[:, 0:1]
-            elif where == "right":
+            if where == "right":
                 return dist_r[:, 0:1]
-            elif where == "bottom":
+            if where == "bottom":
                 return dist_l[:, 1:]
-            elif where == "top":
+            if where == "top":
                 return dist_r[:, 1:]
 
             if smoothness == "L":
-                dist_l = bkd.min(dist_l, dim=-1, keepdims=True)
-                dist_r = bkd.min(dist_r, dim=-1, keepdims=True)
+                dist_l = bkd.amin(dist_l, dim=-1, keepdims=True)
+                dist_r = bkd.amin(dist_r, dim=-1, keepdims=True)
                 return bkd.minimum(dist_l, dist_r)
-            else:
-                dist_l = bkd.prod(dist_l, dim=-1, keepdims=True)
-                dist_r = bkd.prod(dist_r, dim=-1, keepdims=True)
-                return dist_l * dist_r
+            dist_l = bkd.prod(dist_l, dim=-1, keepdims=True)
+            dist_r = bkd.prod(dist_r, dim=-1, keepdims=True)
+            return dist_l * dist_r
         else:
             if not hasattr(self, "self.x11_tensor"):
                 self.x11_tensor = bkd.as_tensor(self.xmin)
@@ -314,37 +312,35 @@ class Rectangle(Hypercube):
                 self.x21_tensor = bkd.as_tensor([self.xmax[0], self.xmin[1]])
             
             if where is None or where == "left":
-                dist_left = bkd.abs(bkd.norm(
+                dist_left = bkd.absolute(bkd.norm(
                     x - self.x11_tensor, axis=-1, keepdims=True) + bkd.norm(
                     x - self.x12_tensor, axis=-1, keepdims=True) - (self.xmax[1] - self.xmin[1]))
             if where is None or where == "right":
-                dist_right = bkd.abs(bkd.norm(
+                dist_right = bkd.absolute(bkd.norm(
                     x - self.x21_tensor, axis=-1, keepdims=True) + bkd.norm(
                     x - self.x22_tensor, axis=-1, keepdims=True) - (self.xmax[1] - self.xmin[1]))
             if where is None or where == "bottom":
-                dist_bottom = bkd.abs(bkd.norm(
+                dist_bottom = bkd.absolute(bkd.norm(
                     x - self.x11_tensor, axis=-1, keepdims=True) + bkd.norm(
                     x - self.x21_tensor, axis=-1, keepdims=True) - (self.xmax[0] - self.xmin[0]))
             if where is None or where == "top":
-                dist_top = bkd.abs(bkd.norm(
+                dist_top = bkd.absolute(bkd.norm(
                     x - self.x12_tensor, axis=-1, keepdims=True) + bkd.norm(
                     x - self.x22_tensor, axis=-1, keepdims=True) - (self.xmax[0] - self.xmin[0]))
             
             if where == "left":
                 return dist_left
-            elif where == "right":
+            if where == "right":
                 return dist_right
-            elif where == "bottom":
+            if where == "bottom":
                 return dist_bottom
-            elif where == "top":
+            if where == "top":
                 return dist_top
-            else:
-                if smoothness == "L":
-                    return bkd.minimum(
-                        bkd.minimum(dist_left, dist_right),
-                        bkd.minimum(dist_bottom, dist_top))
-                else:
-                    return dist_left * dist_right * dist_bottom * dist_top
+            if smoothness == "L":
+                return bkd.minimum(
+                    bkd.minimum(dist_left, dist_right),
+                    bkd.minimum(dist_bottom, dist_top))
+            return dist_left * dist_right * dist_bottom * dist_top
 
     @staticmethod
     def is_valid(vertices):
@@ -543,14 +539,12 @@ class Triangle(Geometry):
         if where is None:
             if smoothness == "L":
                 return bkd.minimum(bkd.minimum(diff_x1_x2, diff_x1_x3), diff_x2_x3)
-            else:
-                return diff_x1_x2 * diff_x1_x3 * diff_x2_x3
-        elif where == "x1-x2":
+            return diff_x1_x2 * diff_x1_x3 * diff_x2_x3
+        if where == "x1-x2":
             return diff_x1_x2
-        elif where == "x1-x3":
+        if where == "x1-x3":
             return diff_x1_x3
-        elif where == "x2-x3":
-            return diff_x2_x3
+        return diff_x2_x3
 
 
 class Polygon(Geometry):

--- a/deepxde/geometry/geometry_2d.py
+++ b/deepxde/geometry/geometry_2d.py
@@ -183,10 +183,14 @@ class Ellipse(Geometry):
         
         d1 = bkd.norm(x - self.focus1_tensor, axis=-1, keepdims=True)
         d2 = bkd.norm(x - self.focus2_tensor, axis=-1, keepdims=True)
+        dist = d1 + d2 - 2 * self.semimajor
 
-        if smoothness == "L" or smoothness == "M":
-            return bkd.absolute(d1 + d2 - 2 * self.semimajor)
-        return bkd.square(d1 + d2 - 2 * self.semimajor)
+        if smoothness == "H":
+            dist = bkd.square(dist)
+        else:
+            dist = bkd.absolute(dist)
+
+        return dist
 
 
 class Rectangle(Hypercube):

--- a/deepxde/geometry/geometry_3d.py
+++ b/deepxde/geometry/geometry_3d.py
@@ -90,33 +90,32 @@ class Cuboid(Hypercube):
             self.xmax_tensor = bkd.as_tensor(self.xmax)
 
         if where not in ["front", "right", "top"]:
-            dist_l = bkd.abs((x - self.xmin_tensor) /
+            dist_l = bkd.absolute((x - self.xmin_tensor) /
                             (self.xmax_tensor - self.xmin_tensor) * 2)
         if where not in ["back", "left", "bottom"]:
-            dist_r = bkd.abs((x - self.xmax_tensor) /
+            dist_r = bkd.absolute((x - self.xmax_tensor) /
                             (self.xmax_tensor - self.xmin_tensor) * 2)
         
         if where == "back":
             return dist_l[:, 0:1]
-        elif where == "front":
+        if where == "front":
             return dist_r[:, 0:1]
-        elif where == "left":
+        if where == "left":
             return dist_l[:, 1:2]
-        elif where == "right":
+        if where == "right":
             return dist_r[:, 1:2]
-        elif where == "bottom":
+        if where == "bottom":
             return dist_l[:, 2:]
-        elif where == "top":
+        if where == "top":
             return dist_r[:, 2:]
 
         if smoothness == "L":
-            dist_l = bkd.min(dist_l, dim=-1, keepdims=True)
-            dist_r = bkd.min(dist_r, dim=-1, keepdims=True)
+            dist_l = bkd.amin(dist_l, dim=-1, keepdims=True)
+            dist_r = bkd.amin(dist_r, dim=-1, keepdims=True)
             return bkd.minimum(dist_l, dist_r)
-        else:
-            dist_l = bkd.prod(dist_l, dim=-1, keepdims=True)
-            dist_r = bkd.prod(dist_r, dim=-1, keepdims=True)
-            return dist_l * dist_r
+        dist_l = bkd.prod(dist_l, dim=-1, keepdims=True)
+        dist_r = bkd.prod(dist_r, dim=-1, keepdims=True)
+        return dist_l * dist_r
 
 
 class Sphere(Hypersphere):

--- a/deepxde/geometry/geometry_3d.py
+++ b/deepxde/geometry/geometry_3d.py
@@ -90,10 +90,10 @@ class Cuboid(Hypercube):
             self.xmax_tensor = bkd.as_tensor(self.xmax)
 
         if where not in ["front", "right", "top"]:
-            dist_l = bkd.absolute((x - self.xmin_tensor) /
+            dist_l = bkd.abs((x - self.xmin_tensor) /
                             (self.xmax_tensor - self.xmin_tensor) * 2)
         if where not in ["back", "left", "bottom"]:
-            dist_r = bkd.absolute((x - self.xmax_tensor) /
+            dist_r = bkd.abs((x - self.xmax_tensor) /
                             (self.xmax_tensor - self.xmin_tensor) * 2)
         
         if where == "back":
@@ -110,8 +110,8 @@ class Cuboid(Hypercube):
             return dist_r[:, 2:]
 
         if smoothness == "L":
-            dist_l = bkd.amin(dist_l, dim=-1, keepdims=True)
-            dist_r = bkd.amin(dist_r, dim=-1, keepdims=True)
+            dist_l = bkd.min(dist_l, dim=-1, keepdims=True)
+            dist_r = bkd.min(dist_r, dim=-1, keepdims=True)
             return bkd.minimum(dist_l, dist_r)
         dist_l = bkd.prod(dist_l, dim=-1, keepdims=True)
         dist_r = bkd.prod(dist_r, dim=-1, keepdims=True)

--- a/deepxde/geometry/geometry_3d.py
+++ b/deepxde/geometry/geometry_3d.py
@@ -68,19 +68,22 @@ class Cuboid(Hypercube):
             )
         return pts
 
-    def approxdist2boundary(self, x, 
+    def boundary_constraint_factor(self, x, 
         smoothness: Literal["C0", "C0+", "Cinf"] = "C0+",
         where: Union[None, Literal["back", "front", "left", "right", 
             "bottom", "top"]] = None,
         inside: bool = True):
-        """Compute the approximate distance at x to the boundary.
+        """Compute the hard constraint factor at x for the boundary.
 
-        This function is used for the hard-constraint methods. The approximate distance function 
-        satisfies the following properties:
+        This function is used for the hard-constraint methods in Physics-Informed Neural Networks (PINNs). 
+        The hard constraint factor satisfies the following properties:
 
         - The function is zero on the boundary and positive elsewhere.
-        - The function is almost differentiable at any order.
-        - The function is not necessarily equal to the exact distance function.
+        - The function is at least continuous.
+
+        In the ansatz `boundary_constraint_factor(x) * NN(x) + boundary_condition(x)`, when `x` is on the boundary, 
+        `boundary_constraint_factor(x)` will be zero, making the ansatz be the boundary condition, which in 
+        turn makes the boundary condition a "hard constraint".
 
         Args:
             x: A 2D array of shape (n, dim), where `n` is the number of points and
@@ -92,6 +95,8 @@ class Cuboid(Hypercube):
 
                 - C0
                 The distance function is continuous but may not be non-differentiable.
+                But the set of non-differentiable points should have measure zero, 
+                which makes the probability of the collocation point falling in this set be zero.
 
                 - C0+
                 The distance function is continuous and differentiable almost everywhere. The
@@ -110,7 +115,7 @@ class Cuboid(Hypercube):
 
         Returns:
             A tensor of a type determined by the backend, which will have a shape of (n, 1). 
-            Each element in the tensor corresponds to the computed distance value for the respective point in 'x'.
+            Each element in the tensor corresponds to the computed distance value for the respective point in `x`.
         """
         assert where in [None, "back", "front", "left", "right", "bottom", "top"], \
             "where must be one of None, back, front, left, right, bottom, top"

--- a/deepxde/geometry/geometry_3d.py
+++ b/deepxde/geometry/geometry_3d.py
@@ -66,7 +66,6 @@ class Cuboid(Hypercube):
             )
         return pts
 
-    # pylint: disable=inconsistent-return-statements
     def approxdist2boundary(self, x, 
         smoothness: Literal["L", "M", "H"] = "M",
         where: Union[None, Literal["back", "front", "left", "right", 

--- a/deepxde/geometry/geometry_3d.py
+++ b/deepxde/geometry/geometry_3d.py
@@ -111,8 +111,10 @@ class Cuboid(Hypercube):
                 The distance function is continuous and differentiable at any order on any
                 points. This option may result in a polynomial of HIGH order.
 
-            where (string, optional): A string to specify which part of the boundary to compute the distance,
-                e.g., "left", "right", "front", "back", "bottom", "top". If `None`, compute the distance to the whole boundary. Default is `None`.
+            where (string, optional): A string to specify which part of the boundary to compute the distance.
+                "back": x[0] = xmin[0], "front": x[0] = xmax[0], "left": x[1] = xmin[1], 
+                "right": x[1] = xmax[1], "bottom": x[2] = xmin[2], "top": x[2] = xmax[2]. 
+                If `None`, compute the distance to the whole boundary. Default is `None`.
             inside (bool, optional): The `x` is either inside or outside the geometry.
                 The cases where there are both points inside and points
                 outside the geometry are NOT allowed. NOTE: currently only support `inside=True`.

--- a/deepxde/geometry/geometry_3d.py
+++ b/deepxde/geometry/geometry_3d.py
@@ -116,6 +116,7 @@ class Cuboid(Hypercube):
             self.xmin_tensor = bkd.as_tensor(self.xmin)
             self.xmax_tensor = bkd.as_tensor(self.xmax)
 
+        dist_l = dist_r = None
         if where not in ["front", "right", "top"]:
             dist_l = bkd.abs((x - self.xmin_tensor) /
                             (self.xmax_tensor - self.xmin_tensor) * 2)

--- a/deepxde/geometry/geometry_3d.py
+++ b/deepxde/geometry/geometry_3d.py
@@ -66,6 +66,7 @@ class Cuboid(Hypercube):
             )
         return pts
 
+    # pylint: disable=inconsistent-return-statements
     def approxdist2boundary(self, x, 
         smoothness: Literal["L", "M", "H"] = "M",
         where: Union[None, Literal["back", "front", "left", "right", 
@@ -107,7 +108,6 @@ class Cuboid(Hypercube):
         Returns:
             A NumPy array of shape (n, 1). The distance at each point in `x`.
         """
-        # pylint: disable=inconsistent-return-statements
         assert where in [None, "back", "front", "left", "right", "bottom", "top"], \
             "where must be one of None, back, front, left, right, bottom, top"
         assert smoothness in ["L", "M", "H"], "smoothness must be one of L, M, H"

--- a/deepxde/geometry/geometry_3d.py
+++ b/deepxde/geometry/geometry_3d.py
@@ -107,6 +107,7 @@ class Cuboid(Hypercube):
         Returns:
             A NumPy array of shape (n, 1). The distance at each point in `x`.
         """
+        # pylint: disable=inconsistent-return-statements
         assert where in [None, "back", "front", "left", "right", "bottom", "top"], \
             "where must be one of None, back, front, left, right, bottom, top"
         assert smoothness in ["L", "M", "H"], "smoothness must be one of L, M, H"
@@ -117,7 +118,7 @@ class Cuboid(Hypercube):
             self.xmin_tensor = bkd.as_tensor(self.xmin)
             self.xmax_tensor = bkd.as_tensor(self.xmax)
 
-        dist_l = dist_r = 0.
+        dist_l = dist_r = None
         if where not in ["front", "right", "top"]:
             dist_l = bkd.abs((x - self.xmin_tensor) /
                             (self.xmax_tensor - self.xmin_tensor) * 2)

--- a/deepxde/geometry/geometry_3d.py
+++ b/deepxde/geometry/geometry_3d.py
@@ -69,7 +69,7 @@ class Cuboid(Hypercube):
         return pts
 
     def approxdist2boundary(self, x, 
-        smoothness: Literal["L", "M", "H"] = "M",
+        smoothness: Literal["C0", "Cinf", "Cinf+"] = "Cinf",
         where: Union[None, Literal["back", "front", "left", "right", 
             "bottom", "top"]] = None,
         inside: bool = True):
@@ -87,19 +87,19 @@ class Cuboid(Hypercube):
                 `dim` is the dimension of the geometry. Note that `x` should be a tensor type
                 of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
             smoothness (string, optional): A string to specify the smoothness of the distance function,
-                e.g., "L", "M", "H". "L" is the least smooth, "H" is the most smooth.
-                Default is "M".
+                e.g., "C0", "Cinf", "Cinf+". "C0" is the least smooth, "Cinf+" is the most smooth.
+                Default is "Cinf".
 
-                - L
+                - C0
                 The distance function is continuous but can be non-differentiable on a
                 set of points, which has measure zero.
 
-                - M
+                - Cinf
                 The distance function is continuous and differentiable at any order. The
                 non-differentiable points can only appear on boundaries. If the points in `x` are
                 all inside or outside the geometry, the distance function is smooth.
 
-                - H
+                - Cinf+
                 The distance function is continuous and differentiable at any order on any 
                 points. This option may result in a polynomial of HIGH order.
 
@@ -114,7 +114,7 @@ class Cuboid(Hypercube):
         """
         assert where in [None, "back", "front", "left", "right", "bottom", "top"], \
             "where must be one of None, back, front, left, right, bottom, top"
-        assert smoothness in ["L", "M", "H"], "smoothness must be one of L, M, H"
+        assert smoothness in ["C0", "Cinf", "Cinf+"], "smoothness must be one of C0, Cinf, Cinf+"
         assert self.dim == 3
         assert inside, "inside=False is not supported for Cuboid"
 
@@ -143,7 +143,7 @@ class Cuboid(Hypercube):
         if where == "top":
             return dist_r[:, 2:]
 
-        if smoothness == "L":
+        if smoothness == "C0":
             dist_l = bkd.min(dist_l, dim=-1, keepdims=True)
             dist_r = bkd.min(dist_r, dim=-1, keepdims=True)
             return bkd.minimum(dist_l, dist_r)

--- a/deepxde/geometry/geometry_3d.py
+++ b/deepxde/geometry/geometry_3d.py
@@ -71,14 +71,41 @@ class Cuboid(Hypercube):
                         "bottom", "top"]] = None,
         smoothness: Literal["L", "M", "H"] = "M",
         inside: bool = True):
-        """
-        `inside`: `x` is either inside or outside the geometry.
-        The case where there are both points inside and points
-        outside the geometry is NOT allowed.
+        """Compute the approximate distance at x to the boundary.
+        - This function is used for the hard-constraint methods.
+        - The approximate distance function satisfies the following properties:
+            - The function is zero on the boundary and positive elsewhere.
+            - The function is almost differentiable at any order.
+            - The function is not necessarily equal to the exact distance function.
 
-        NOTE: currently only support `inside=True`.
+        Args:
 
-        See `Geometry.approxdist2boundary()` for more info on args.
+            x: a 2D array of shape (n, dim), where `n` is the number of points and
+                `dim` is the dimension of the geometry. Note that `x` should be a tensor type
+                of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
+            where: a string to specify which part of the boundary to compute the distance, 
+                e.g., "left", "right", "front", "back", "bottom", "top". 
+                If `None`, compute the distance to the whole boundary.
+            smoothness: a string to specify the smoothness of the distance function,
+                e.g., "L", "M", "H". "L" is the least smooth, "H" is the most smooth.
+                Default is "M".
+
+                - "L": the distance function is continuous but can be non-differentiable on a 
+                set of points, which has measure zero.
+
+                - "M": the distance function is continuous and differentiable at any order. The 
+                non-differentiable points can only appear on boundaries. If the points in `x` are
+                all inside or outside the geometry, the distance function is smooth.
+                
+                - "H": the distance function is continuous and differentiable at any order on any 
+                points. This option may result in a polynomial of HIGH order.
+
+            inside: `x` is either inside or outside the geometry.
+                The cases where there are both points inside and points
+                outside the geometry are NOT allowed. NOTE: currently only support `inside=True`.
+
+        Returns:
+            A NumPy array of shape (n, 1). The distance at each point in `x`.
         """
         
         assert smoothness in ["L", "M", "H"], "smoothness must be one of L, M, H"

--- a/deepxde/geometry/geometry_3d.py
+++ b/deepxde/geometry/geometry_3d.py
@@ -66,10 +66,10 @@ class Cuboid(Hypercube):
             )
         return pts
 
-    def approxdist2boundary(self, x, where: Union[
-            None, Literal["back", "front", "left", "right", 
-                        "bottom", "top"]] = None,
+    def approxdist2boundary(self, x, 
         smoothness: Literal["L", "M", "H"] = "M",
+        where: Union[None, Literal["back", "front", "left", "right", 
+            "bottom", "top"]] = None,
         inside: bool = True):
         """Compute the approximate distance at x to the boundary.
         - This function is used for the hard-constraint methods.
@@ -83,9 +83,6 @@ class Cuboid(Hypercube):
             x: a 2D array of shape (n, dim), where `n` is the number of points and
                 `dim` is the dimension of the geometry. Note that `x` should be a tensor type
                 of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
-            where: a string to specify which part of the boundary to compute the distance, 
-                e.g., "left", "right", "front", "back", "bottom", "top". 
-                If `None`, compute the distance to the whole boundary.
             smoothness: a string to specify the smoothness of the distance function,
                 e.g., "L", "M", "H". "L" is the least smooth, "H" is the most smooth.
                 Default is "M".
@@ -100,6 +97,9 @@ class Cuboid(Hypercube):
                 - "H": the distance function is continuous and differentiable at any order on any 
                 points. This option may result in a polynomial of HIGH order.
 
+            where: a string to specify which part of the boundary to compute the distance, 
+                e.g., "left", "right", "front", "back", "bottom", "top". 
+                If `None`, compute the distance to the whole boundary.
             inside: `x` is either inside or outside the geometry.
                 The cases where there are both points inside and points
                 outside the geometry are NOT allowed. NOTE: currently only support `inside=True`.

--- a/deepxde/geometry/geometry_3d.py
+++ b/deepxde/geometry/geometry_3d.py
@@ -74,35 +74,38 @@ class Cuboid(Hypercube):
             "bottom", "top"]] = None,
         inside: bool = True):
         """Compute the approximate distance at x to the boundary.
-        - This function is used for the hard-constraint methods.
-        - The approximate distance function satisfies the following properties:
-            - The function is zero on the boundary and positive elsewhere.
-            - The function is almost differentiable at any order.
-            - The function is not necessarily equal to the exact distance function.
+
+        This function is used for the hard-constraint methods. The approximate distance function 
+        satisfies the following properties:
+
+        - The function is zero on the boundary and positive elsewhere.
+        - The function is almost differentiable at any order.
+        - The function is not necessarily equal to the exact distance function.
 
         Args:
-
-            x: a 2D array of shape (n, dim), where `n` is the number of points and
+            x: A 2D array of shape (n, dim), where `n` is the number of points and
                 `dim` is the dimension of the geometry. Note that `x` should be a tensor type
                 of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
-            smoothness: a string to specify the smoothness of the distance function,
+            smoothness (string, optional): A string to specify the smoothness of the distance function,
                 e.g., "L", "M", "H". "L" is the least smooth, "H" is the most smooth.
                 Default is "M".
 
-                - "L": the distance function is continuous but can be non-differentiable on a 
+                - L
+                The distance function is continuous but can be non-differentiable on a
                 set of points, which has measure zero.
 
-                - "M": the distance function is continuous and differentiable at any order. The 
+                - M
+                The distance function is continuous and differentiable at any order. The
                 non-differentiable points can only appear on boundaries. If the points in `x` are
                 all inside or outside the geometry, the distance function is smooth.
-                
-                - "H": the distance function is continuous and differentiable at any order on any 
+
+                - H
+                The distance function is continuous and differentiable at any order on any 
                 points. This option may result in a polynomial of HIGH order.
 
-            where: a string to specify which part of the boundary to compute the distance, 
-                e.g., "left", "right", "front", "back", "bottom", "top". 
-                If `None`, compute the distance to the whole boundary.
-            inside: `x` is either inside or outside the geometry.
+            where (string, optional): A string to specify which part of the boundary to compute the distance, 
+                e.g., "left", "right", "front", "back", "bottom", "top". If `None`, compute the distance to the whole boundary. Default is `None`.
+            inside (bool, optional): The `x` is either inside or outside the geometry.
                 The cases where there are both points inside and points
                 outside the geometry are NOT allowed. NOTE: currently only support `inside=True`.
 

--- a/deepxde/geometry/geometry_3d.py
+++ b/deepxde/geometry/geometry_3d.py
@@ -121,22 +121,16 @@ class Cuboid(Hypercube):
             A tensor of a type determined by the backend, which will have a shape of (n, 1).
             Each element in the tensor corresponds to the computed distance value for the respective point in `x`.
         """
-        assert where in [
-            None,
-            "back",
-            "front",
-            "left",
-            "right",
-            "bottom",
-            "top",
-        ], "where must be one of None, back, front, left, right, bottom, top"
-        assert smoothness in [
-            "C0",
-            "C0+",
-            "Cinf",
-        ], "smoothness must be one of C0, C0+, Cinf"
-        assert self.dim == 3
-        assert inside, "inside=False is not supported for Cuboid"
+        if where not in [None, "back", "front", "left", "right", "bottom", "top"]:
+            raise ValueError(
+                "where must be one of None, back, front, left, right, bottom, top"
+            )
+        if smoothness not in ["C0", "C0+", "Cinf"]:
+            raise ValueError("smoothness must be one of C0, C0+, Cinf")
+        if self.dim != 3:
+            raise ValueError("self.dim must be 3")
+        if not inside:
+            raise ValueError("inside=False is not supported for Cuboid")
 
         if not hasattr(self, "self.xmin_tensor"):
             self.xmin_tensor = bkd.as_tensor(self.xmin)

--- a/deepxde/geometry/geometry_3d.py
+++ b/deepxde/geometry/geometry_3d.py
@@ -1,9 +1,11 @@
 import itertools
+from typing import Union, Literal
 
 import numpy as np
 
-from .geometry_2d import Rectangle, Union
-from .geometry_nd import Hypercube, Hypersphere, Literal, bkd
+from .geometry_2d import Rectangle
+from .geometry_nd import Hypercube, Hypersphere
+from .. import backend as bkd
 
 
 class Cuboid(Hypercube):

--- a/deepxde/geometry/geometry_3d.py
+++ b/deepxde/geometry/geometry_3d.py
@@ -2,8 +2,8 @@ import itertools
 
 import numpy as np
 
-from .geometry_2d import Rectangle
-from .geometry_nd import Hypercube, Hypersphere, Literal, Union, bkd
+from .geometry_2d import Rectangle, Union
+from .geometry_nd import Hypercube, Hypersphere, Literal, bkd
 
 
 class Cuboid(Hypercube):

--- a/deepxde/geometry/geometry_3d.py
+++ b/deepxde/geometry/geometry_3d.py
@@ -69,7 +69,7 @@ class Cuboid(Hypercube):
         return pts
 
     def approxdist2boundary(self, x, 
-        smoothness: Literal["C0", "Cinf", "Cinf+"] = "Cinf",
+        smoothness: Literal["C0", "C0+", "Cinf"] = "C0+",
         where: Union[None, Literal["back", "front", "left", "right", 
             "bottom", "top"]] = None,
         inside: bool = True):
@@ -87,19 +87,18 @@ class Cuboid(Hypercube):
                 `dim` is the dimension of the geometry. Note that `x` should be a tensor type
                 of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
             smoothness (string, optional): A string to specify the smoothness of the distance function,
-                e.g., "C0", "Cinf", "Cinf+". "C0" is the least smooth, "Cinf+" is the most smooth.
-                Default is "Cinf".
+                e.g., "C0", "C0+", "Cinf". "C0" is the least smooth, "Cinf" is the most smooth.
+                Default is "C0+".
 
                 - C0
-                The distance function is continuous but can be non-differentiable on a
-                set of points, which has measure zero.
+                The distance function is continuous but may not be non-differentiable.
 
-                - Cinf
-                The distance function is continuous and differentiable at any order. The
+                - C0+
+                The distance function is continuous and differentiable almost everywhere. The
                 non-differentiable points can only appear on boundaries. If the points in `x` are
                 all inside or outside the geometry, the distance function is smooth.
 
-                - Cinf+
+                - Cinf
                 The distance function is continuous and differentiable at any order on any 
                 points. This option may result in a polynomial of HIGH order.
 
@@ -110,11 +109,12 @@ class Cuboid(Hypercube):
                 outside the geometry are NOT allowed. NOTE: currently only support `inside=True`.
 
         Returns:
-            A NumPy array of shape (n, 1). The distance at each point in `x`.
+            A tensor of a type determined by the backend, which will have a shape of (n, 1). 
+            Each element in the tensor corresponds to the computed distance value for the respective point in 'x'.
         """
         assert where in [None, "back", "front", "left", "right", "bottom", "top"], \
             "where must be one of None, back, front, left, right, bottom, top"
-        assert smoothness in ["C0", "Cinf", "Cinf+"], "smoothness must be one of C0, Cinf, Cinf+"
+        assert smoothness in ["C0", "C0+", "Cinf"], "smoothness must be one of C0, C0+, Cinf"
         assert self.dim == 3
         assert inside, "inside=False is not supported for Cuboid"
 

--- a/deepxde/geometry/geometry_3d.py
+++ b/deepxde/geometry/geometry_3d.py
@@ -89,10 +89,12 @@ class Cuboid(Hypercube):
             self.xmin_tensor = bkd.as_tensor(self.xmin)
             self.xmax_tensor = bkd.as_tensor(self.xmax)
 
-        dist_l = bkd.abs((x - self.xmin_tensor) /
-                        (self.xmax_tensor - self.xmin_tensor) * 2)
-        dist_r = bkd.abs((x - self.xmax_tensor) /
-                        (self.xmax_tensor - self.xmin_tensor) * 2)
+        if where not in ["front", "right", "top"]:
+            dist_l = bkd.abs((x - self.xmin_tensor) /
+                            (self.xmax_tensor - self.xmin_tensor) * 2)
+        if where not in ["back", "left", "bottom"]:
+            dist_r = bkd.abs((x - self.xmax_tensor) /
+                            (self.xmax_tensor - self.xmin_tensor) * 2)
         
         if where == "back":
             return dist_l[:, 0:1]

--- a/deepxde/geometry/geometry_3d.py
+++ b/deepxde/geometry/geometry_3d.py
@@ -107,7 +107,8 @@ class Cuboid(Hypercube):
         Returns:
             A NumPy array of shape (n, 1). The distance at each point in `x`.
         """
-        
+        assert where in [None, "back", "front", "left", "right", "bottom", "top"], \
+            "where must be one of None, back, front, left, right, bottom, top"
         assert smoothness in ["L", "M", "H"], "smoothness must be one of L, M, H"
         assert self.dim == 3
         assert inside, "inside=False is not supported for Cuboid"
@@ -116,7 +117,7 @@ class Cuboid(Hypercube):
             self.xmin_tensor = bkd.as_tensor(self.xmin)
             self.xmax_tensor = bkd.as_tensor(self.xmax)
 
-        dist_l = dist_r = None
+        dist_l = dist_r = 0.
         if where not in ["front", "right", "top"]:
             dist_l = bkd.abs((x - self.xmin_tensor) /
                             (self.xmax_tensor - self.xmin_tensor) * 2)

--- a/deepxde/geometry/geometry_3d.py
+++ b/deepxde/geometry/geometry_3d.py
@@ -68,21 +68,25 @@ class Cuboid(Hypercube):
             )
         return pts
 
-    def boundary_constraint_factor(self, x, 
+    def boundary_constraint_factor(
+        self,
+        x,
         smoothness: Literal["C0", "C0+", "Cinf"] = "C0+",
-        where: Union[None, Literal["back", "front", "left", "right", 
-            "bottom", "top"]] = None,
-        inside: bool = True):
+        where: Union[
+            None, Literal["back", "front", "left", "right", "bottom", "top"]
+        ] = None,
+        inside: bool = True,
+    ):
         """Compute the hard constraint factor at x for the boundary.
 
-        This function is used for the hard-constraint methods in Physics-Informed Neural Networks (PINNs). 
+        This function is used for the hard-constraint methods in Physics-Informed Neural Networks (PINNs).
         The hard constraint factor satisfies the following properties:
 
         - The function is zero on the boundary and positive elsewhere.
         - The function is at least continuous.
 
-        In the ansatz `boundary_constraint_factor(x) * NN(x) + boundary_condition(x)`, when `x` is on the boundary, 
-        `boundary_constraint_factor(x)` will be zero, making the ansatz be the boundary condition, which in 
+        In the ansatz `boundary_constraint_factor(x) * NN(x) + boundary_condition(x)`, when `x` is on the boundary,
+        `boundary_constraint_factor(x)` will be zero, making the ansatz be the boundary condition, which in
         turn makes the boundary condition a "hard constraint".
 
         Args:
@@ -95,7 +99,7 @@ class Cuboid(Hypercube):
 
                 - C0
                 The distance function is continuous but may not be non-differentiable.
-                But the set of non-differentiable points should have measure zero, 
+                But the set of non-differentiable points should have measure zero,
                 which makes the probability of the collocation point falling in this set be zero.
 
                 - C0+
@@ -104,22 +108,33 @@ class Cuboid(Hypercube):
                 all inside or outside the geometry, the distance function is smooth.
 
                 - Cinf
-                The distance function is continuous and differentiable at any order on any 
+                The distance function is continuous and differentiable at any order on any
                 points. This option may result in a polynomial of HIGH order.
 
-            where (string, optional): A string to specify which part of the boundary to compute the distance, 
+            where (string, optional): A string to specify which part of the boundary to compute the distance,
                 e.g., "left", "right", "front", "back", "bottom", "top". If `None`, compute the distance to the whole boundary. Default is `None`.
             inside (bool, optional): The `x` is either inside or outside the geometry.
                 The cases where there are both points inside and points
                 outside the geometry are NOT allowed. NOTE: currently only support `inside=True`.
 
         Returns:
-            A tensor of a type determined by the backend, which will have a shape of (n, 1). 
+            A tensor of a type determined by the backend, which will have a shape of (n, 1).
             Each element in the tensor corresponds to the computed distance value for the respective point in `x`.
         """
-        assert where in [None, "back", "front", "left", "right", "bottom", "top"], \
-            "where must be one of None, back, front, left, right, bottom, top"
-        assert smoothness in ["C0", "C0+", "Cinf"], "smoothness must be one of C0, C0+, Cinf"
+        assert where in [
+            None,
+            "back",
+            "front",
+            "left",
+            "right",
+            "bottom",
+            "top",
+        ], "where must be one of None, back, front, left, right, bottom, top"
+        assert smoothness in [
+            "C0",
+            "C0+",
+            "Cinf",
+        ], "smoothness must be one of C0, C0+, Cinf"
         assert self.dim == 3
         assert inside, "inside=False is not supported for Cuboid"
 
@@ -129,12 +144,14 @@ class Cuboid(Hypercube):
 
         dist_l = dist_r = None
         if where not in ["front", "right", "top"]:
-            dist_l = bkd.abs((x - self.xmin_tensor) /
-                            (self.xmax_tensor - self.xmin_tensor) * 2)
+            dist_l = bkd.abs(
+                (x - self.xmin_tensor) / (self.xmax_tensor - self.xmin_tensor) * 2
+            )
         if where not in ["back", "left", "bottom"]:
-            dist_r = bkd.abs((x - self.xmax_tensor) /
-                            (self.xmax_tensor - self.xmin_tensor) * 2)
-        
+            dist_r = bkd.abs(
+                (x - self.xmax_tensor) / (self.xmax_tensor - self.xmin_tensor) * 2
+            )
+
         if where == "back":
             return dist_l[:, 0:1]
         if where == "front":

--- a/deepxde/geometry/geometry_nd.py
+++ b/deepxde/geometry/geometry_nd.py
@@ -157,14 +157,12 @@ class Hypercube(Geometry):
             A tensor of a type determined by the backend, which will have a shape of (n, 1).
             Each element in the tensor corresponds to the computed distance value for the respective point in `x`.
         """
-        assert smoothness in [
-            "C0",
-            "C0+",
-            "Cinf",
-        ], "smoothness must be one of C0, C0+, Cinf"
-        assert where is None, "where is currently not supported for Hypercube"
-        assert self.dim >= 2
-        assert inside, "inside=False is not supported for Hypercube"
+        if where is not None:
+            raise ValueError("where is currently not supported for Hypercube")
+        if smoothness not in ["C0", "C0+", "Cinf"]:
+            raise ValueError("smoothness must be one of C0, C0+, Cinf")
+        if not inside:
+            raise ValueError("inside=False is not supported for Hypercube")
 
         if not hasattr(self, "self.xmin_tensor"):
             self.xmin_tensor = bkd.as_tensor(self.xmin)
@@ -219,11 +217,8 @@ class Hypersphere(Geometry):
     def boundary_constraint_factor(
         self, x, smoothness: Literal["C0", "C0+", "Cinf"] = "C0+"
     ):
-        assert smoothness in [
-            "C0",
-            "C0+",
-            "Cinf",
-        ], "smoothness must be one of C0, C0+, Cinf"
+        if smoothness not in ["C0", "C0+", "Cinf"]:
+            raise ValueError("smoothness must be one of C0, C0+, Cinf")
 
         if not hasattr(self, "self.center_tensor"):
             self.center_tensor = bkd.as_tensor(self.center)

--- a/deepxde/geometry/geometry_nd.py
+++ b/deepxde/geometry/geometry_nd.py
@@ -1,10 +1,11 @@
 import itertools
+from typing import overload
 
 import numpy as np
 from scipy import stats
 from sklearn import preprocessing
 
-from .geometry import Geometry, Literal, Union
+from .geometry import Geometry, Literal
 from .sampler import sample
 from .. import config
 from .. import backend as bkd
@@ -101,14 +102,12 @@ class Hypercube(Geometry):
         y[:, component][_on_xmax] = self.xmin[component]
         return y
 
+    @overload
     def approxdist2boundary(self, x, 
             where: None = None, 
             smoothness: None = None):
         """Do not use this overload. 
         Use the overload with `inside` argument instead."""
-        raise NotImplementedError(
-            "Do not use this overload. Use the overload with `inside` argument instead."
-        )
 
     def approxdist2boundary(self, x, 
         where: None = None, 

--- a/deepxde/geometry/geometry_nd.py
+++ b/deepxde/geometry/geometry_nd.py
@@ -107,37 +107,42 @@ class Hypercube(Geometry):
         where: None = None,
         inside: bool = True):
         """Compute the approximate distance at x to the boundary.
-        - This function is used for the hard-constraint methods.
-        - The approximate distance function satisfies the following properties:
-            - The function is zero on the boundary and positive elsewhere.
-            - The function is almost differentiable at any order.
-            - The function is not necessarily equal to the exact distance function.
+
+        This function is used for the hard-constraint methods. The approximate distance function 
+        satisfies the following properties:
+
+        - The function is zero on the boundary and positive elsewhere.
+        - The function is almost differentiable at any order.
+        - The function is not necessarily equal to the exact distance function.
 
         Args:
-
-            x: a 2D array of shape (n, dim), where `n` is the number of points and
+            x: A 2D array of shape (n, dim), where `n` is the number of points and
                 `dim` is the dimension of the geometry. Note that `x` should be a tensor type
                 of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
-            smoothness: a string to specify the smoothness of the distance function,
+            smoothness (string, optional): A string to specify the smoothness of the distance function,
                 e.g., "L", "M", "H". "L" is the least smooth, "H" is the most smooth.
-                Default is "L".
+                Default is "M".
 
-                - "L": the distance function is continuous but can be non-differentiable on a 
+                - L
+                The distance function is continuous but can be non-differentiable on a
                 set of points, which has measure zero.
 
-                - "M": the distance function is continuous and differentiable at any order. The 
+                - M
+                The distance function is continuous and differentiable at any order. The
                 non-differentiable points can only appear on boundaries. If the points in `x` are
                 all inside or outside the geometry, the distance function is smooth.
-                
-                - "H": the distance function is continuous and differentiable at any order on any 
-                points. This option may result in a polynomial of HIGH order.
 
-                WARNING: in current implementation, 
+                - H
+                The distance function is continuous and differentiable at any order on any 
+                points. This option may result in a polynomial of HIGH order.
+                
+                - WARNING
+                In current implementation, 
                 numerical underflow may happen for high dimensionalities
                 when `smoothness="M"` or `smoothness="H"`. 
 
-            where: this option is currently not supported for Hypercube.
-            inside: `x` is either inside or outside the geometry.
+            where (string, optional): This option is currently not supported for Hypercube.
+            inside (bool, optional): The `x` is either inside or outside the geometry.
                 The cases where there are both points inside and points
                 outside the geometry are NOT allowed. NOTE: currently only support `inside=True`.
 

--- a/deepxde/geometry/geometry_nd.py
+++ b/deepxde/geometry/geometry_nd.py
@@ -103,7 +103,6 @@ class Hypercube(Geometry):
         return y
 
     def approxdist2boundary(self, x, 
-        where: None = None, 
         smoothness: Literal["L", "M", "H"] = "L",
         inside: bool = True):
         """Compute the approximate distance at x to the boundary.
@@ -118,9 +117,6 @@ class Hypercube(Geometry):
             x: a 2D array of shape (n, dim), where `n` is the number of points and
                 `dim` is the dimension of the geometry. Note that `x` should be a tensor type
                 of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
-            where: a string to specify which part of the boundary to compute the distance, 
-                e.g., "left", "right", "front", "back", "bottom", "top". 
-                If `None`, compute the distance to the whole boundary.
             smoothness: a string to specify the smoothness of the distance function,
                 e.g., "L", "M", "H". "L" is the least smooth, "H" is the most smooth.
                 Default is "L".
@@ -147,7 +143,6 @@ class Hypercube(Geometry):
             A NumPy array of shape (n, 1). The distance at each point in `x`.
         """
         
-        assert where is None, "where!=None is not supported for Hypercube"
         assert smoothness in ["L", "M", "H"], "smoothness must be one of L, M, H"
         assert self.dim >= 2
         assert inside, "inside=False is not supported for Hypercube"

--- a/deepxde/geometry/geometry_nd.py
+++ b/deepxde/geometry/geometry_nd.py
@@ -1,11 +1,11 @@
 import itertools
-from typing import overload
+from typing import Literal
 
 import numpy as np
 from scipy import stats
 from sklearn import preprocessing
 
-from .geometry import Geometry, Literal
+from .geometry import Geometry
 from .sampler import sample
 from .. import config
 from .. import backend as bkd
@@ -102,29 +102,49 @@ class Hypercube(Geometry):
         y[:, component][_on_xmax] = self.xmin[component]
         return y
 
-    @overload
-    def approxdist2boundary(self, x, 
-            where: None = None, 
-            smoothness: None = None):
-        """Do not use this overload. 
-        Use the overload with `inside` argument instead."""
-
     def approxdist2boundary(self, x, 
         where: None = None, 
-        smoothness: Literal["L", "M", "H"] = "M",
+        smoothness: Literal["L", "M", "H"] = "L",
         inside: bool = True):
-        """
-        `inside`: `x` is either inside or outside the geometry.
-        The cases that there are both points inside and points
-        outside the geometry are NOT allowed.
+        """Compute the approximate distance at x to the boundary.
+        - This function is used for the hard-constraint methods.
+        - The approximate distance function satisfies the following properties:
+            - The function is zero on the boundary and positive elsewhere.
+            - The function is almost differentiable at any order.
+            - The function is not necessarily equal to the exact distance function.
 
-        NOTE: currently only support `inside=True`.
+        Args:
 
-        WARNING: in current implementation, 
-        numerical underflow may happen for high dimensionalities
-        when `smoothness="M"` or `smoothness="H"`. 
+            x: a 2D array of shape (n, dim), where `n` is the number of points and
+                `dim` is the dimension of the geometry. Note that `x` should be a tensor type
+                of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
+            where: a string to specify which part of the boundary to compute the distance, 
+                e.g., "left", "right", "front", "back", "bottom", "top". 
+                If `None`, compute the distance to the whole boundary.
+            smoothness: a string to specify the smoothness of the distance function,
+                e.g., "L", "M", "H". "L" is the least smooth, "H" is the most smooth.
+                Default is "L".
 
-        See `Geometry.approxdist2boundary()` for more info on args.
+                - "L": the distance function is continuous but can be non-differentiable on a 
+                set of points, which has measure zero.
+
+                - "M": the distance function is continuous and differentiable at any order. The 
+                non-differentiable points can only appear on boundaries. If the points in `x` are
+                all inside or outside the geometry, the distance function is smooth.
+                
+                - "H": the distance function is continuous and differentiable at any order on any 
+                points. This option may result in a polynomial of HIGH order.
+
+                WARNING: in current implementation, 
+                numerical underflow may happen for high dimensionalities
+                when `smoothness="M"` or `smoothness="H"`. 
+
+            inside: `x` is either inside or outside the geometry.
+                The cases where there are both points inside and points
+                outside the geometry are NOT allowed. NOTE: currently only support `inside=True`.
+
+        Returns:
+            A NumPy array of shape (n, 1). The distance at each point in `x`.
         """
         
         assert where is None, "where!=None is not supported for Hypercube"
@@ -179,10 +199,7 @@ class Hypersphere(Geometry):
         return np.amin(self.radius - np.linalg.norm(x - self.center, axis=-1))
 
     def approxdist2boundary(self, x, 
-        where: None = None, 
         smoothness: Literal["L", "M", "H"] = "M"):
-        
-        assert where is None, "where!=None is not supported for Hypersphere or its subclasses"
         assert smoothness in ["L", "M", "H"], "smoothness must be one of L, M, H"
 
         if not hasattr(self, "self.center_tensor"):

--- a/deepxde/geometry/geometry_nd.py
+++ b/deepxde/geometry/geometry_nd.py
@@ -103,7 +103,7 @@ class Hypercube(Geometry):
         return y
 
     def approxdist2boundary(self, x, 
-        smoothness: Literal["L", "M", "H"] = "L",
+        smoothness: Literal["C0", "Cinf", "Cinf+"] = "C0",
         where: None = None,
         inside: bool = True):
         """Compute the approximate distance at x to the boundary.
@@ -120,26 +120,26 @@ class Hypercube(Geometry):
                 `dim` is the dimension of the geometry. Note that `x` should be a tensor type
                 of backend (e.g., `tf.Tensor` or `torch.Tensor`), not a numpy array.
             smoothness (string, optional): A string to specify the smoothness of the distance function,
-                e.g., "L", "M", "H". "L" is the least smooth, "H" is the most smooth.
-                Default is "M".
+                e.g., "C0", "Cinf", "Cinf+". "C0" is the least smooth, "Cinf+" is the most smooth.
+                Default is "C0".
 
-                - L
+                - C0
                 The distance function is continuous but can be non-differentiable on a
                 set of points, which has measure zero.
 
-                - M
+                - Cinf
                 The distance function is continuous and differentiable at any order. The
                 non-differentiable points can only appear on boundaries. If the points in `x` are
                 all inside or outside the geometry, the distance function is smooth.
 
-                - H
+                - Cinf+
                 The distance function is continuous and differentiable at any order on any 
                 points. This option may result in a polynomial of HIGH order.
                 
                 - WARNING
                 In current implementation, 
                 numerical underflow may happen for high dimensionalities
-                when `smoothness="M"` or `smoothness="H"`. 
+                when `smoothness="Cinf"` or `smoothness="Cinf+"`. 
 
             where (string, optional): This option is currently not supported for Hypercube.
             inside (bool, optional): The `x` is either inside or outside the geometry.
@@ -149,7 +149,7 @@ class Hypercube(Geometry):
         Returns:
             A NumPy array of shape (n, 1). The distance at each point in `x`.
         """
-        assert smoothness in ["L", "M", "H"], "smoothness must be one of L, M, H"
+        assert smoothness in ["C0", "Cinf", "Cinf+"], "smoothness must be one of C0, Cinf, Cinf+"
         assert where is None, "where is currently not supported for Hypercube"
         assert self.dim >= 2
         assert inside, "inside=False is not supported for Hypercube"
@@ -162,7 +162,7 @@ class Hypercube(Geometry):
                         (self.xmax_tensor - self.xmin_tensor) * 2)
         dist_r = bkd.abs((x - self.xmax_tensor) /
                         (self.xmax_tensor - self.xmin_tensor) * 2)
-        if smoothness == "L":
+        if smoothness == "C0":
             dist_l = bkd.min(dist_l, dim=-1, keepdims=True)
             dist_r = bkd.min(dist_r, dim=-1, keepdims=True)
             return bkd.minimum(dist_l, dist_r)
@@ -201,8 +201,8 @@ class Hypersphere(Geometry):
         return np.amin(self.radius - np.linalg.norm(x - self.center, axis=-1))
 
     def approxdist2boundary(self, x, 
-        smoothness: Literal["L", "M", "H"] = "M"):
-        assert smoothness in ["L", "M", "H"], "smoothness must be one of L, M, H"
+        smoothness: Literal["C0", "Cinf", "Cinf+"] = "Cinf"):
+        assert smoothness in ["C0", "Cinf", "Cinf+"], "smoothness must be one of C0, Cinf, Cinf+"
 
         if not hasattr(self, "self.center_tensor"):
             self.center_tensor = bkd.as_tensor(self.center)
@@ -210,7 +210,7 @@ class Hypersphere(Geometry):
 
         dist = bkd.norm(
             x - self.center_tensor, axis=-1, keepdims=True) - self.radius
-        if smoothness == "H":
+        if smoothness == "Cinf+":
             dist = bkd.square(dist)
         else:
             dist = bkd.abs(dist)

--- a/deepxde/geometry/geometry_nd.py
+++ b/deepxde/geometry/geometry_nd.py
@@ -137,19 +137,18 @@ class Hypercube(Geometry):
             self.xmin_tensor = bkd.as_tensor(self.xmin)
             self.xmax_tensor = bkd.as_tensor(self.xmax)
 
-        dist_l = bkd.abs((x - self.xmin_tensor) /
+        dist_l = bkd.absolute((x - self.xmin_tensor) /
                         (self.xmax_tensor - self.xmin_tensor) * 2)
-        dist_r = bkd.abs((x - self.xmax_tensor) /
+        dist_r = bkd.absolute((x - self.xmax_tensor) /
                         (self.xmax_tensor - self.xmin_tensor) * 2)
         if smoothness == "L":
-            dist_l = bkd.min(dist_l, dim=-1, keepdims=True)
-            dist_r = bkd.min(dist_r, dim=-1, keepdims=True)
+            dist_l = bkd.amin(dist_l, dim=-1, keepdims=True)
+            dist_r = bkd.amin(dist_r, dim=-1, keepdims=True)
             return bkd.minimum(dist_l, dist_r)
-        else:
-            # TODO: fix potential numerical underflow
-            dist_l = bkd.prod(dist_l, dim=-1, keepdims=True)
-            dist_r = bkd.prod(dist_r, dim=-1, keepdims=True)
-            return dist_l * dist_r
+        # TODO: fix potential numerical underflow
+        dist_l = bkd.prod(dist_l, dim=-1, keepdims=True)
+        dist_r = bkd.prod(dist_r, dim=-1, keepdims=True)
+        return dist_l * dist_r
 
 
 class Hypersphere(Geometry):
@@ -194,9 +193,8 @@ class Hypersphere(Geometry):
         diff = bkd.norm(
             x - self.center_tensor, axis=-1, keepdims=True) - self.radius
         if smoothness == "L" or smoothness == "M":
-            return bkd.abs(diff)
-        else:
-            return bkd.square(diff)
+            return bkd.absolute(diff)
+        return bkd.square(diff)
 
     def boundary_normal(self, x):
         _n = x - self.center

--- a/deepxde/geometry/geometry_nd.py
+++ b/deepxde/geometry/geometry_nd.py
@@ -136,13 +136,13 @@ class Hypercube(Geometry):
             self.xmin_tensor = bkd.as_tensor(self.xmin)
             self.xmax_tensor = bkd.as_tensor(self.xmax)
 
-        dist_l = bkd.absolute((x - self.xmin_tensor) /
+        dist_l = bkd.abs((x - self.xmin_tensor) /
                         (self.xmax_tensor - self.xmin_tensor) * 2)
-        dist_r = bkd.absolute((x - self.xmax_tensor) /
+        dist_r = bkd.abs((x - self.xmax_tensor) /
                         (self.xmax_tensor - self.xmin_tensor) * 2)
         if smoothness == "L":
-            dist_l = bkd.amin(dist_l, dim=-1, keepdims=True)
-            dist_r = bkd.amin(dist_r, dim=-1, keepdims=True)
+            dist_l = bkd.min(dist_l, dim=-1, keepdims=True)
+            dist_r = bkd.min(dist_r, dim=-1, keepdims=True)
             return bkd.minimum(dist_l, dist_r)
         # TODO: fix potential numerical underflow
         dist_l = bkd.prod(dist_l, dim=-1, keepdims=True)
@@ -194,7 +194,7 @@ class Hypersphere(Geometry):
         if smoothness == "H":
             dist = bkd.square(dist)
         else:
-            dist = bkd.absolute(dist)
+            dist = bkd.abs(dist)
         return dist
 
     def boundary_normal(self, x):

--- a/deepxde/geometry/geometry_nd.py
+++ b/deepxde/geometry/geometry_nd.py
@@ -7,8 +7,8 @@ from sklearn import preprocessing
 
 from .geometry import Geometry
 from .sampler import sample
-from .. import config
 from .. import backend as bkd
+from .. import config
 
 
 class Hypercube(Geometry):

--- a/deepxde/geometry/geometry_nd.py
+++ b/deepxde/geometry/geometry_nd.py
@@ -104,6 +104,7 @@ class Hypercube(Geometry):
 
     def approxdist2boundary(self, x, 
         smoothness: Literal["L", "M", "H"] = "L",
+        where: None = None,
         inside: bool = True):
         """Compute the approximate distance at x to the boundary.
         - This function is used for the hard-constraint methods.
@@ -135,6 +136,7 @@ class Hypercube(Geometry):
                 numerical underflow may happen for high dimensionalities
                 when `smoothness="M"` or `smoothness="H"`. 
 
+            where: this option is currently not supported for Hypercube.
             inside: `x` is either inside or outside the geometry.
                 The cases where there are both points inside and points
                 outside the geometry are NOT allowed. NOTE: currently only support `inside=True`.
@@ -142,8 +144,8 @@ class Hypercube(Geometry):
         Returns:
             A NumPy array of shape (n, 1). The distance at each point in `x`.
         """
-        
         assert smoothness in ["L", "M", "H"], "smoothness must be one of L, M, H"
+        assert where is None, "where is currently not supported for Hypercube"
         assert self.dim >= 2
         assert inside, "inside=False is not supported for Hypercube"
 

--- a/deepxde/geometry/geometry_nd.py
+++ b/deepxde/geometry/geometry_nd.py
@@ -189,11 +189,13 @@ class Hypersphere(Geometry):
             self.center_tensor = bkd.as_tensor(self.center)
             self.radius_tensor = bkd.as_tensor(self.radius)
 
-        diff = bkd.norm(
+        dist = bkd.norm(
             x - self.center_tensor, axis=-1, keepdims=True) - self.radius
-        if smoothness == "L" or smoothness == "M":
-            return bkd.absolute(diff)
-        return bkd.square(diff)
+        if smoothness == "H":
+            dist = bkd.square(dist)
+        else:
+            dist = bkd.absolute(dist)
+        return dist
 
     def boundary_normal(self, x):
         _n = x - self.center

--- a/deepxde/geometry/geometry_nd.py
+++ b/deepxde/geometry/geometry_nd.py
@@ -102,20 +102,23 @@ class Hypercube(Geometry):
         y[:, component][_on_xmax] = self.xmin[component]
         return y
 
-    def boundary_constraint_factor(self, x, 
+    def boundary_constraint_factor(
+        self,
+        x,
         smoothness: Literal["C0", "C0+", "Cinf"] = "C0",
         where: None = None,
-        inside: bool = True):
+        inside: bool = True,
+    ):
         """Compute the hard constraint factor at x for the boundary.
 
-        This function is used for the hard-constraint methods in Physics-Informed Neural Networks (PINNs). 
+        This function is used for the hard-constraint methods in Physics-Informed Neural Networks (PINNs).
         The hard constraint factor satisfies the following properties:
 
         - The function is zero on the boundary and positive elsewhere.
         - The function is at least continuous.
 
-        In the ansatz `boundary_constraint_factor(x) * NN(x) + boundary_condition(x)`, when `x` is on the boundary, 
-        `boundary_constraint_factor(x)` will be zero, making the ansatz be the boundary condition, which in 
+        In the ansatz `boundary_constraint_factor(x) * NN(x) + boundary_condition(x)`, when `x` is on the boundary,
+        `boundary_constraint_factor(x)` will be zero, making the ansatz be the boundary condition, which in
         turn makes the boundary condition a "hard constraint".
 
         Args:
@@ -128,7 +131,7 @@ class Hypercube(Geometry):
 
                 - C0
                 The distance function is continuous but may not be non-differentiable.
-                But the set of non-differentiable points should have measure zero, 
+                But the set of non-differentiable points should have measure zero,
                 which makes the probability of the collocation point falling in this set be zero.
 
                 - C0+
@@ -137,13 +140,13 @@ class Hypercube(Geometry):
                 all inside or outside the geometry, the distance function is smooth.
 
                 - Cinf
-                The distance function is continuous and differentiable at any order on any 
+                The distance function is continuous and differentiable at any order on any
                 points. This option may result in a polynomial of HIGH order.
-                
+
                 - WARNING
-                In current implementation, 
+                In current implementation,
                 numerical underflow may happen for high dimensionalities
-                when `smoothness="C0+"` or `smoothness="Cinf"`. 
+                when `smoothness="C0+"` or `smoothness="Cinf"`.
 
             where (string, optional): This option is currently not supported for Hypercube.
             inside (bool, optional): The `x` is either inside or outside the geometry.
@@ -151,10 +154,14 @@ class Hypercube(Geometry):
                 outside the geometry are NOT allowed. NOTE: currently only support `inside=True`.
 
         Returns:
-            A tensor of a type determined by the backend, which will have a shape of (n, 1). 
+            A tensor of a type determined by the backend, which will have a shape of (n, 1).
             Each element in the tensor corresponds to the computed distance value for the respective point in `x`.
         """
-        assert smoothness in ["C0", "C0+", "Cinf"], "smoothness must be one of C0, C0+, Cinf"
+        assert smoothness in [
+            "C0",
+            "C0+",
+            "Cinf",
+        ], "smoothness must be one of C0, C0+, Cinf"
         assert where is None, "where is currently not supported for Hypercube"
         assert self.dim >= 2
         assert inside, "inside=False is not supported for Hypercube"
@@ -163,10 +170,12 @@ class Hypercube(Geometry):
             self.xmin_tensor = bkd.as_tensor(self.xmin)
             self.xmax_tensor = bkd.as_tensor(self.xmax)
 
-        dist_l = bkd.abs((x - self.xmin_tensor) /
-                        (self.xmax_tensor - self.xmin_tensor) * 2)
-        dist_r = bkd.abs((x - self.xmax_tensor) /
-                        (self.xmax_tensor - self.xmin_tensor) * 2)
+        dist_l = bkd.abs(
+            (x - self.xmin_tensor) / (self.xmax_tensor - self.xmin_tensor) * 2
+        )
+        dist_r = bkd.abs(
+            (x - self.xmax_tensor) / (self.xmax_tensor - self.xmin_tensor) * 2
+        )
         if smoothness == "C0":
             dist_l = bkd.min(dist_l, dim=-1, keepdims=True)
             dist_r = bkd.min(dist_r, dim=-1, keepdims=True)
@@ -185,7 +194,7 @@ class Hypersphere(Geometry):
             len(center), (self.center - radius, self.center + radius), 2 * radius
         )
 
-        self._r2 = radius ** 2
+        self._r2 = radius**2
 
     def inside(self, x):
         return np.linalg.norm(x - self.center, axis=-1) <= self.radius
@@ -197,7 +206,9 @@ class Hypersphere(Geometry):
         # https://en.wikipedia.org/wiki/Line%E2%80%93sphere_intersection
         xc = x - self.center
         ad = np.dot(xc, dirn)
-        return (-ad + (ad ** 2 - np.sum(xc * xc, axis=-1) + self._r2) ** 0.5).astype(config.real(np))
+        return (-ad + (ad**2 - np.sum(xc * xc, axis=-1) + self._r2) ** 0.5).astype(
+            config.real(np)
+        )
 
     def distance2boundary(self, x, dirn):
         return self.distance2boundary_unitdirn(x, dirn / np.linalg.norm(dirn))
@@ -205,16 +216,20 @@ class Hypersphere(Geometry):
     def mindist2boundary(self, x):
         return np.amin(self.radius - np.linalg.norm(x - self.center, axis=-1))
 
-    def boundary_constraint_factor(self, x, 
-        smoothness: Literal["C0", "C0+", "Cinf"] = "C0+"):
-        assert smoothness in ["C0", "C0+", "Cinf"], "smoothness must be one of C0, C0+, Cinf"
+    def boundary_constraint_factor(
+        self, x, smoothness: Literal["C0", "C0+", "Cinf"] = "C0+"
+    ):
+        assert smoothness in [
+            "C0",
+            "C0+",
+            "Cinf",
+        ], "smoothness must be one of C0, C0+, Cinf"
 
         if not hasattr(self, "self.center_tensor"):
             self.center_tensor = bkd.as_tensor(self.center)
             self.radius_tensor = bkd.as_tensor(self.radius)
 
-        dist = bkd.norm(
-            x - self.center_tensor, axis=-1, keepdims=True) - self.radius
+        dist = bkd.norm(x - self.center_tensor, axis=-1, keepdims=True) - self.radius
         if smoothness == "Cinf":
             dist = bkd.square(dist)
         else:
@@ -255,5 +270,10 @@ class Hypersphere(Geometry):
         dx = self.distance2boundary_unitdirn(x, -dirn)
         n = max(dist2npt(dx), 1)
         h = dx / n
-        pts = x - np.arange(-shift, n - shift + 1, dtype=config.real(np))[:, None] * h * dirn
+        pts = (
+            x
+            - np.arange(-shift, n - shift + 1, dtype=config.real(np))[:, None]
+            * h
+            * dirn
+        )
         return pts


### PR DESCRIPTION
ADFs are implemented for all geometries except CSGDifference, CSGxxx, Point Cloud, and Polygon. The functions have been tested.