### PR TITLE
update import of LBFGS in backend 'paddle'

### DIFF
--- a/deepxde/optimizers/paddle/optimizers.py
+++ b/deepxde/optimizers/paddle/optimizers.py
@@ -1,7 +1,6 @@
 __all__ = ["get", "is_external_optimizer"]
 
 import paddle
-from paddle.incubate.optimizer import LBFGS
 
 from ..config import LBFGS_options
 
@@ -28,8 +27,8 @@ def get(params, optimizer, learning_rate=None, decay=None):
     if optimizer in ["L-BFGS", "L-BFGS-B"]:
         if learning_rate is not None or decay is not None:
             print("Warning: learning rate is ignored for {}".format(optimizer))
-        optim = LBFGS(
-            lr=1,
+        optim = paddle.optimizer.LBFGS(
+            learning_rate=1,
             max_iter=LBFGS_options["iter_per_step"],
             max_eval=LBFGS_options["fun_per_step"],
             tolerance_grad=LBFGS_options["gtol"],
@@ -39,7 +38,7 @@ def get(params, optimizer, learning_rate=None, decay=None):
             parameters=params,
         )
         return optim
-    
+
     if learning_rate is None:
         raise ValueError("No learning rate for {}.".format(optimizer))
 


### PR DESCRIPTION
LBFGS moved from paddle.incubate.optimizer to paddle.optimizer in paddle develop version after 2023.4.27 and also in incoming paddle release 2.5 version. Modify import in code to adapt to it.
What is more, 'lr' param of LBFGS has been change to 'learning_rate' to keep consistent with other optimizers of paddle.