### PR TITLE
fix norm error when using default ord value

### DIFF
--- a/deepxde/backend/paddle/tensor.py
+++ b/deepxde/backend/paddle/tensor.py
@@ -173,6 +173,8 @@ def reduce_sum(input_tensor):
 
 
 def norm(x, ord=None, axis=None, keepdims=False):
+    if ord is None:
+        ord = 2
     return paddle.linalg.norm(x, p=ord, axis=axis, keepdim=keepdims)
 
 


### PR DESCRIPTION
Fix norm default value `None`, which will occur error in `paddle.mean_l2_relative_error`

To keep default value of parameters same as `backend.py`, I do not change the default value in parameter but add new line code within function