### PR TITLE
Add auxiliary_variables for pytorch.

### DIFF
--- a/deepxde/nn/pytorch/nn.py
+++ b/deepxde/nn/pytorch/nn.py
@@ -7,8 +7,18 @@ class NN(torch.nn.Module):
     def __init__(self):
         super().__init__()
         self.regularizer = None
+        self._auxiliary_vars = None
         self._input_transform = None
         self._output_transform = None
+
+    @property
+    def auxiliary_vars(self):
+        """Tensors: Any additional variables needed."""
+        return self._auxiliary_vars
+
+    @auxiliary_vars.setter
+    def auxiliary_vars(self, value):
+        self._auxiliary_vars = value
 
     def apply_feature_transform(self, transform):
         """Compute the features by appling a transform to the network inputs, i.e.,


### PR DESCRIPTION
Adds auxiliary_variables to `pytorch.nn`.

~~Includes a fix in `backend.pytorch.tensor.to_tensor`:
Use `torch.stack` instead of `torch.to_tensor` for list/tuple of `torch.Tensors` to keep track of gradients.~~

Related to #1311.