### PR TITLE
kernel initializer is fixed

### DIFF
--- a/deepxde/nn/tensorflow_compat_v1/deeponet.py
+++ b/deepxde/nn/tensorflow_compat_v1/deeponet.py
@@ -58,7 +58,7 @@ class DeepONet(NN):
         self.kernel_initializer = initializers.get(kernel_initializer)
         if stacked:
             self.kernel_initializer_stacked = initializers.get(
-                kernel_initializer + "stacked"
+                "stacked " + kernel_initializer
             )
         self.regularizer = regularizers.get(regularization)
         self.use_bias = use_bias


### PR DESCRIPTION
Fix a little mistake in kernel initializer naming. It's relevant for tensorFlow 1.x backend.