### PR TITLE
Default float type to numpy double precision.

### DIFF
--- a/deepxde/config.py
+++ b/deepxde/config.py
@@ -38,7 +38,7 @@ if "OMPI_COMM_WORLD_SIZE" in os.environ:
 
 
 # Default float type
-real = Real(32)
+real = Real(8 * np.dtype(np.double).itemsize)
 # Random seed
 random_seed = None
 if backend_name == "jax":


### PR DESCRIPTION
The default float precision in DeepXDE is currently hard-coded to 32. This can lead to dtype mismatches if numpy defaults to float64.

```
dde.config.default_float() = 'float32'
np.array(0.0).dtype = dtype('float64')
```

Of course, this mismatch can be resolved by `dde.config.set_default_float('float64')`.
However, as we cannot change the default precision of numpy, we could already set its precision as default for DeepXDE.

This PR proposes to set the default float type to numpy's double precision.

Related to some comments in #1311.