### PR TITLE
Bug fix, add gelu for torch, add lambda lr scheduler for torch, allow `predict` to handle CartesianProd` data for torch, automatically change the dataset's datatype for torch.

### DIFF
--- a/deepxde/backend/backend.py
+++ b/deepxde/backend/backend.py
@@ -274,6 +274,8 @@ def elu(x):
 def relu(x):
     """Applies the rectified linear unit activation function."""
 
+def gelu(x):
+    """Computes Gaussian Error Linear Unit."""
 
 def selu(x):
     """Computes scaled exponential linear."""

--- a/deepxde/backend/pytorch/tensor.py
+++ b/deepxde/backend/pytorch/tensor.py
@@ -125,6 +125,8 @@ def elu(x):
 def relu(x):
     return torch.nn.functional.relu(x)
 
+def gelu(x):
+    return torch.nn.functional.gelu(x)
 
 def selu(x):
     return torch.nn.functional.selu(x)

--- a/deepxde/nn/activations.py
+++ b/deepxde/nn/activations.py
@@ -57,6 +57,7 @@ def get(identifier):
             "sin": bkd.sin,
             "swish": bkd.silu,
             "tanh": bkd.tanh,
+            "gelu": bkd.gelu,
         }[identifier]
     if callable(identifier):
         return identifier

--- a/deepxde/nn/pytorch/__init__.py
+++ b/deepxde/nn/pytorch/__init__.py
@@ -8,9 +8,10 @@ __all__ = [
     "PFNN",
     "PODDeepONet",
     "PODMIONet",
+    "DeepONet",
 ]
 
-from .deeponet import DeepONetCartesianProd, PODDeepONet
+from .deeponet import DeepONetCartesianProd, PODDeepONet, DeepONet
 from .mionet import MIONetCartesianProd, PODMIONet
 from .fnn import FNN, PFNN
 from .nn import NN

--- a/deepxde/optimizers/pytorch/optimizers.py
+++ b/deepxde/optimizers/pytorch/optimizers.py
@@ -64,6 +64,10 @@ def _get_learningrate_scheduler(optim, decay):
         return torch.optim.lr_scheduler.StepLR(
             optim, step_size=decay[1], gamma=decay[2]
         )
+    elif decay[0] == "lambda":
+        return torch.optim.lr_scheduler.LambdaLR(optim, decay[1])
+    elif isinstance(decay[0], torch.optim.Optimizer):
+        return decay[0]
 
     # TODO: More learning rate scheduler
     raise NotImplementedError(


### PR DESCRIPTION
1. In torch, the `predict` doesn't accept tuple input, that is a bug.
2. The second thing is for `CartesianProd`, `predict` can not deal with the differential equation `operator`. So added some code for torch to resolve it.
3. automatically change the data type for torch training.

* add torch gelu

* add lambda lr scheduler for torch

* repair missing deeponet for pytorch