### PR TITLE
Backend paddle: Support deeponet and other examples

### DIFF
--- a/deepxde/nn/paddle/deeponet.py
+++ b/deepxde/nn/paddle/deeponet.py
@@ -57,8 +57,7 @@ class DeepONet(NN):
         if use_bias:
             # register bias to parameter for updating in optimizer and storage
             self.b = self.create_parameter(
-                shape=(1, ),
-                default_initializer=initializers.get("zeros")
+                shape=(1,), default_initializer=initializers.get("zeros")
             )
 
     def forward(self, inputs):
@@ -75,8 +74,7 @@ class DeepONet(NN):
             raise AssertionError(
                 "Output sizes of branch net and trunk net do not match."
             )
-        x = paddle.einsum("bi,bi->b", x_func, x_loc)  # [batch_size, ]
-        x = paddle.reshape(x, [-1, 1])  # reshape [batch_size, ] to [batch_size, 1]
+        x = paddle.sum(x_func * x_loc, axis=1, keepdim=True)
         # Add bias
         if self.use_bias:
             x += self.b
@@ -124,8 +122,7 @@ class DeepONetCartesianProd(NN):
         self.trunk = FNN(layer_sizes_trunk, self.activation_trunk, kernel_initializer)
         # register bias to parameter for updating in optimizer and storage
         self.b = self.create_parameter(
-            shape=(1, ),
-            default_initializer=initializers.get("zeros")
+            shape=(1,), default_initializer=initializers.get("zeros")
         )
         self.regularizer = regularization
 
@@ -143,7 +140,7 @@ class DeepONetCartesianProd(NN):
             raise AssertionError(
                 "Output sizes of branch net and trunk net do not match."
             )
-        x = paddle.einsum("bi,ni->bn", x_func, x_loc)
+        x = x_func @ x_loc.T
         # Add bias
         x += self.b
 

--- a/examples/operator/advection_aligned_pideeponet.py
+++ b/examples/operator/advection_aligned_pideeponet.py
@@ -1,8 +1,23 @@
-"""Backend supported: tensorflow.compat.v1, tensorflow"""
+"""Backend supported: tensorflow.compat.v1, tensorflow, paddle"""
 import deepxde as dde
 import matplotlib.pyplot as plt
 import numpy as np
-from deepxde.backend import tf
+
+if dde.backend.backend_name == "paddle":
+    import paddle
+
+    dim_x = 5
+    sin = paddle.sin
+    cos = paddle.cos
+    concat = paddle.concat
+else:
+    from deepxde.backend import tf
+
+    dim_x = 2
+    sin = tf.sin
+    cos = tf.cos
+    concat = tf.concat
+
 
 # PDE
 def pde(x, y, v):
@@ -36,7 +51,7 @@ data = dde.data.PDEOperatorCartesianProd(
 # Net
 net = dde.nn.DeepONetCartesianProd(
     [50, 128, 128, 128],
-    [2, 128, 128, 128],
+    [dim_x, 128, 128, 128],
     "tanh",
     "Glorot normal",
 )
@@ -45,9 +60,7 @@ net = dde.nn.DeepONetCartesianProd(
 def periodic(x):
     x, t = x[:, :1], x[:, 1:]
     x *= 2 * np.pi
-    return tf.concat(
-        [tf.math.cos(x), tf.math.sin(x), tf.math.cos(2 * x), tf.math.sin(2 * x), t], 1
-    )
+    return concat([cos(x), sin(x), cos(2 * x), sin(2 * x), t], 1)
 
 
 net.apply_feature_transform(periodic)

--- a/examples/operator/advection_aligned_pideeponet_2d.py
+++ b/examples/operator/advection_aligned_pideeponet_2d.py
@@ -1,8 +1,23 @@
-"""Backend supported: tensorflow.compat.v1, tensorflow"""
+"""Backend supported: tensorflow.compat.v1, tensorflow, paddle"""
 import deepxde as dde
 import matplotlib.pyplot as plt
 import numpy as np
-from deepxde.backend import tf
+
+if dde.backend.backend_name == "paddle":
+    import paddle
+
+    dim_x = 5
+    sin = paddle.sin
+    cos = paddle.cos
+    concat = paddle.concat
+else:
+    from deepxde.backend import tf
+
+    dim_x = 2
+    sin = tf.sin
+    cos = tf.cos
+    concat = tf.concat
+
 
 # PDE
 def pde(x, y, v):
@@ -41,7 +56,7 @@ data = dde.data.PDEOperatorCartesianProd(
 # Net
 net = dde.nn.DeepONetCartesianProd(
     [50, 128, 128, 128],
-    [2, 128, 128, 128],
+    [dim_x, 128, 128, 128],
     "tanh",
     "Glorot normal",
 )
@@ -50,9 +65,7 @@ net = dde.nn.DeepONetCartesianProd(
 def periodic(x):
     x, t = x[:, :1], x[:, 1:]
     x *= 2 * np.pi
-    return tf.concat(
-        [tf.math.cos(x), tf.math.sin(x), tf.math.cos(2 * x), tf.math.sin(2 * x), t], 1
-    )
+    return concat([cos(x), sin(x), cos(2 * x), sin(2 * x), t], 1)
 
 
 net.apply_feature_transform(periodic)

--- a/examples/operator/advection_unaligned_pideeponet.py
+++ b/examples/operator/advection_unaligned_pideeponet.py
@@ -1,8 +1,23 @@
-"""Backend supported: tensorflow.compat.v1"""
+"""Backend supported: tensorflow.compat.v1, paddle"""
 import deepxde as dde
 import matplotlib.pyplot as plt
 import numpy as np
-from deepxde.backend import tf
+
+if dde.backend.backend_name == "paddle":
+    import paddle
+
+    dim_x = 5
+    sin = paddle.sin
+    cos = paddle.cos
+    concat = paddle.concat
+else:
+    from deepxde.backend import tf
+
+    dim_x = 2
+    sin = tf.sin
+    cos = tf.cos
+    concat = tf.concat
+
 
 # PDE
 def pde(x, y, v):
@@ -36,7 +51,7 @@ data = dde.data.PDEOperator(
 # Net
 net = dde.nn.DeepONet(
     [50, 128, 128, 128],
-    [2, 128, 128, 128],
+    [dim_x, 128, 128, 128],
     "tanh",
     "Glorot normal",
 )
@@ -45,9 +60,7 @@ net = dde.nn.DeepONet(
 def periodic(x):
     x, t = x[:, :1], x[:, 1:]
     x *= 2 * np.pi
-    return tf.concat(
-        [tf.math.cos(x), tf.math.sin(x), tf.math.cos(2 * x), tf.math.sin(2 * x), t], 1
-    )
+    return concat([cos(x), sin(x), cos(2 * x), sin(2 * x), t], 1)
 
 
 net.apply_feature_transform(periodic)

--- a/examples/operator/advection_unaligned_pideeponet_2d.py
+++ b/examples/operator/advection_unaligned_pideeponet_2d.py
@@ -1,8 +1,23 @@
-"""Backend supported: tensorflow.compat.v1"""
+"""Backend supported: tensorflow.compat.v1, paddle"""
 import deepxde as dde
 import matplotlib.pyplot as plt
 import numpy as np
-from deepxde.backend import tf
+
+if dde.backend.backend_name == "paddle":
+    import paddle
+
+    dim_x = 5
+    sin = paddle.sin
+    cos = paddle.cos
+    concat = paddle.concat
+else:
+    from deepxde.backend import tf
+
+    dim_x = 2
+    sin = tf.sin
+    cos = tf.cos
+    concat = tf.concat
+
 
 # PDE
 def pde(x, y, v):
@@ -39,7 +54,7 @@ data = dde.data.PDEOperator(pde, func_space, eval_pts, 1000, function_variables=
 # Net
 net = dde.nn.DeepONet(
     [50, 128, 128, 128],
-    [2, 128, 128, 128],
+    [dim_x, 128, 128, 128],
     "tanh",
     "Glorot normal",
 )
@@ -48,9 +63,7 @@ net = dde.nn.DeepONet(
 def periodic(x):
     x, t = x[:, :1], x[:, 1:]
     x *= 2 * np.pi
-    return tf.concat(
-        [tf.math.cos(x), tf.math.sin(x), tf.math.cos(2 * x), tf.math.sin(2 * x), t], 1
-    )
+    return concat([cos(x), sin(x), cos(2 * x), sin(2 * x), t], 1)
 
 
 net.apply_feature_transform(periodic)

--- a/examples/operator/antiderivative_aligned_pideeponet.py
+++ b/examples/operator/antiderivative_aligned_pideeponet.py
@@ -1,8 +1,16 @@
-"""Backend supported: tensorflow.compat.v1, tensorflow"""
+"""Backend supported: tensorflow.compat.v1, tensorflow, paddle"""
 import deepxde as dde
 import matplotlib.pyplot as plt
 import numpy as np
-from deepxde.backend import tf
+
+if dde.backend.backend_name == "paddle":
+    import paddle
+
+    transpose = paddle.transpose
+else:
+    from deepxde.backend import tf
+
+    transpose = tf.transpose
 
 
 dde.config.disable_xla_jit()
@@ -35,9 +43,10 @@ net = dde.nn.DeepONetCartesianProd(
     "Glorot normal",
 )
 
+
 # Hard constraint zero IC
 def zero_ic(inputs, outputs):
-    return outputs * tf.transpose(inputs[1])
+    return outputs * transpose(inputs[1], [1, 0])
 
 
 net.apply_output_transform(zero_ic)

--- a/examples/operator/antiderivative_unaligned_pideeponet.py
+++ b/examples/operator/antiderivative_unaligned_pideeponet.py
@@ -1,4 +1,4 @@
-"""Backend supported: tensorflow.compat.v1"""
+"""Backend supported: tensorflow.compat.v1, paddle"""
 import deepxde as dde
 import matplotlib.pyplot as plt
 import numpy as np
@@ -29,6 +29,7 @@ net = dde.nn.DeepONet(
     "tanh",
     "Glorot normal",
 )
+
 
 # Hard constraint zero IC
 def zero_ic(inputs, outputs):

--- a/examples/operator/diff_rec_aligned_pideeponet.py
+++ b/examples/operator/diff_rec_aligned_pideeponet.py
@@ -1,4 +1,4 @@
-"""Backend supported: tensorflow.compat.v1, tensorflow"""
+"""Backend supported: tensorflow.compat.v1, tensorflow, paddle"""
 import deepxde as dde
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/operator/diff_rec_unaligned_pideeponet.py
+++ b/examples/operator/diff_rec_unaligned_pideeponet.py
@@ -1,4 +1,4 @@
-"""Backend supported: tensorflow.compat.v1"""
+"""Backend supported: tensorflow.compat.v1, paddle"""
 import deepxde as dde
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/pinn_forward/Burgers.py
+++ b/examples/pinn_forward/Burgers.py
@@ -1,4 +1,4 @@
-"""Backend supported: tensorflow.compat.v1, tensorflow, pytorch"""
+"""Backend supported: tensorflow.compat.v1, tensorflow, pytorch, paddle"""
 import deepxde as dde
 import numpy as np
 


### PR DESCRIPTION
1. Update deeponet of paddle to support new examples
2. Update operator examples as pinn_forward/Helmholtz_Dirichlet_2d_HPO.py style

