### PR TITLE
Backend paddle: Support batch_size

### DIFF
--- a/deepxde/callbacks.py
+++ b/deepxde/callbacks.py
@@ -396,24 +396,22 @@ class OperatorPredictor(Callback):
     def on_train_begin(self):
         self.on_predict_end()
         print(
-                self.model.train_state.epoch,
-                utils.list_to_str(
-                    self.value.flatten().tolist(), precision=self.precision
-                ),
-                file=self.file,
-            )
+            self.model.train_state.epoch,
+            utils.list_to_str(self.value.flatten().tolist(), precision=self.precision),
+            file=self.file,
+        )
         self.file.flush()
-    
+
     def on_train_end(self):
         if not self.epochs_since_last == 0:
             self.on_train_begin()
-        
+
     def on_epoch_end(self):
         self.epochs_since_last += 1
         if self.epochs_since_last >= self.period:
             self.epochs_since_last = 0
             self.on_train_begin()
-            
+
     def on_predict_end(self):
         if backend_name == "tensorflow.compat.v1":
             self.value = self.model.sess.run(
@@ -545,7 +543,7 @@ class PDEPointResampler(Callback):
         pde_points: If True, resample the training points for PDE losses (default is
             True).
         bc_points: If True, resample the training points for BC losses (default is
-            False; only supported by pytorch backend currently).
+            False; only supported by PyTorch and PaddlePaddle backend currently).
     """
 
     def __init__(self, period=100, pde_points=True, bc_points=False):

--- a/examples/pinn_inverse/elliptic_inverse_field_batch.py
+++ b/examples/pinn_inverse/elliptic_inverse_field_batch.py
@@ -1,4 +1,4 @@
-"""Backend supported: tensorflow.compat.v1, pytorch"""
+"""Backend supported: tensorflow.compat.v1, pytorch, paddle"""
 import deepxde as dde
 import matplotlib.pyplot as plt
 import numpy as np
@@ -27,7 +27,7 @@ geom = dde.geometry.Interval(-1, 1)
 bc = dde.icbc.DirichletBC(geom, sol, lambda _, on_boundary: on_boundary, component=0)
 ob_x, ob_u = gen_traindata(10000)
 observe_u = dde.icbc.PointSetBC(ob_x, ob_u, component=0, batch_size=100)
-pde_resampler = dde.callbacks.PDEPointResampler()
+pde_resampler = dde.callbacks.PDEPointResampler(bc_points=True)
 
 data = dde.data.PDE(
     geom,
@@ -57,7 +57,7 @@ plt.plot(x, utrue, "-", label="u_true")
 plt.plot(x, uhat, "--", label="u_NN")
 plt.legend()
 
-qtrue = -np.pi ** 2 * np.sin(np.pi * x)
+qtrue = -np.pi**2 * np.sin(np.pi * x)
 print("l2 relative error for q: " + str(dde.metrics.l2_relative_error(qtrue, qhat)))
 plt.figure()
 plt.plot(x, qtrue, "-", label="q_true")


### PR DESCRIPTION
1. 'batch_size' also can be supported by paddlepaddle. So update boundary_conditions.py to support elliptic_inverse_field_batch example. The training results are as follows, attention, time may not be the shortest time becuase of GPU usage.
paddle backend
![image](https://github.com/lululxvi/deepxde/assets/124568209/216fe34e-63d6-42d0-ae09-72090ab714da)
pytorch backend
![image](https://github.com/lululxvi/deepxde/assets/124568209/ed0efc7d-6e7e-4aa1-b6dd-a72effcca023)