### PR TITLE
Fix version mismatch between scikit-optimize and Numpy

### DIFF
--- a/examples/pinn_forward/Helmholtz_Dirichlet_2d_HPO.py
+++ b/examples/pinn_forward/Helmholtz_Dirichlet_2d_HPO.py
@@ -9,6 +9,11 @@ from skopt.plots import plot_convergence, plot_objective
 from skopt.space import Real, Categorical, Integer
 from skopt.utils import use_named_args
 
+# Function 'gp_minimize' of package 'skopt(scikit-optimize)' is used in this example.
+# However 'np.int' used in skopt 0.9.0(the latest version) was deprecated since NumPy 1.20.
+# Monkey patch here to fix the error.
+np.int = int
+
 if dde.backend.backend_name == "pytorch":
     sin = dde.backend.pytorch.sin
 elif dde.backend.backend_name == "paddle":


### PR DESCRIPTION
To fix version mismatch between scikit-optimize and Numpy of example Helmholtz_Dirichlet_2d_HPO.py https://github.com/lululxvi/deepxde/issues/1446 accroding to https://github.com/scikit-optimize/scikit-optimize/issues/1138.