### PR TITLE
Add possibility to enable line search in pytorch.

### DIFF
--- a/deepxde/optimizers/config.py
+++ b/deepxde/optimizers/config.py
@@ -42,7 +42,7 @@ def set_LBFGS_options(
             Maximum number of iterations.
         maxfun (int): `maxfun` (scipy), `max_eval` (torch), `max_eval` (paddle).
             Maximum number of function evaluations. If ``None``, `maxiter` * 1.25.
-        maxls (int): `maxls` (scipy), `max_line_search_iterations` (tfp).
+        maxls (int): `maxls` (scipy), `max_line_search_iterations` (tfp), `maxls=0` disables line search and otherwise defaults to 25 (torch).
             Maximum number of line search steps (per iteration).
 
     Warning:

--- a/deepxde/optimizers/pytorch/optimizers.py
+++ b/deepxde/optimizers/pytorch/optimizers.py
@@ -27,7 +27,7 @@ def get(params, optimizer, learning_rate=None, decay=None, weight_decay=0):
             tolerance_grad=LBFGS_options["gtol"],
             tolerance_change=LBFGS_options["ftol"],
             history_size=LBFGS_options["maxcor"],
-            line_search_fn=None,
+            line_search_fn=("strong_wolfe" if LBFGS_options["maxls"] > 0 else None),
         )
     else:
         if learning_rate is None:


### PR DESCRIPTION
This PR adds the ability to enable/disable line search in pytorch.
It activates line search by default, as this makes L-BFGS converge much more stable.

Unfortunately, there is no way to set the `maxls` parameter in pytorch (it always defaults to 25).
To give the possibility to disable the line search, I suggest to disable if `maxls` is non-positive.