### PR TITLE
JAX checkpointing via Orbax

### DIFF
--- a/deepxde/model.py
+++ b/deepxde/model.py
@@ -4,6 +4,7 @@ import pickle
 from collections import OrderedDict
 
 import numpy as np
+import orbax.checkpoint as ocp
 
 from . import config
 from . import display
@@ -1012,9 +1013,7 @@ class Model:
                 save_path += ".ckpt"
                 self.net.save_weights(save_path)
             elif backend_name == "jax":
-                # Lazy load Orbax to avoid a hard dependancy when using JAX
                 # TODO: identify a better solution that complies with PEP8 
-                import orbax.checkpoint as ocp
                 from flax.training import orbax_utils 
                 save_path += ".ckpt"
                 checkpoint = {

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 matplotlib
 numpy
+orbax-checkpoint
 scikit-learn
 scikit-optimize>=0.9.0
 scipy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
 dependencies = [
     "matplotlib",
     "numpy",
+    "orbax-checkpoint",
     "scikit-learn",
     "scikit-optimize>=0.9.0",
     "scipy",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 matplotlib
 numpy
+orbax-checkpoint
 scikit-learn
 scikit-optimize>=0.9.0
 scipy


### PR DESCRIPTION
Split from #1490 . Provides a very basic checkpointing functionality for flax based JAX models via Orbax. Essentially follows the simple example from [flax documentation](https://flax.readthedocs.io/en/latest/guides/use_checkpointing.html), without the use of the context manager.

As noted in #1490 , Orbax is currently imported lazily (only imported once first called) in a non PEP8 compliant manner, to avoid requiring Orbax as a package dependency. I feel that there should be a better way to do this, but I can't currently think of one. 
As such, I've marked this as a draft for now. 

Any thought or suggestions are greatly appreciated!