### PR TITLE
Update tensor.py

### DIFF
--- a/deepxde/backend/pytorch/tensor.py
+++ b/deepxde/backend/pytorch/tensor.py
@@ -17,7 +17,7 @@ if Version(torch.__version__) < Version("1.9.0"):
 # TensorFlow.
 if torch.cuda.is_available():
     if Version(torch.__version__) >= Version("2.1.0"):
-        torch.set_default_device(torch.device("cuda"))
+        torch.set_default_device("cuda")
     else:
         torch.set_default_tensor_type(torch.cuda.FloatTensor)
 

--- a/deepxde/backend/pytorch/tensor.py
+++ b/deepxde/backend/pytorch/tensor.py
@@ -16,7 +16,11 @@ if Version(torch.__version__) < Version("1.9.0"):
 # An alternative way is to use GPU by default if GPU is available, which is similar to
 # TensorFlow.
 if torch.cuda.is_available():
-    torch.set_default_tensor_type(torch.cuda.FloatTensor)
+    if Version(torch.__version__) >= Version("2.1.0"):
+        torch.set_default_dtype(torch.float32)
+        torch.set_default_device(torch.device("cuda"))
+    else:
+        torch.set_default_tensor_type(torch.cuda.FloatTensor)
 
 
 lib = torch

--- a/deepxde/backend/pytorch/tensor.py
+++ b/deepxde/backend/pytorch/tensor.py
@@ -17,7 +17,6 @@ if Version(torch.__version__) < Version("1.9.0"):
 # TensorFlow.
 if torch.cuda.is_available():
     if Version(torch.__version__) >= Version("2.1.0"):
-        torch.set_default_dtype(torch.float32)
         torch.set_default_device(torch.device("cuda"))
     else:
         torch.set_default_tensor_type(torch.cuda.FloatTensor)


### PR DESCRIPTION
After torch=2.1.0, set_default_tensor_dtype is deprecated and it will give a warning, so use the way they recommended.

`
/home/supercgor/.conda/envs/ras/lib/python3.10/site-packages/torch/__init__.py:614: UserWarning: torch.set_default_tensor_type() is deprecated as of PyTorch 2.1, please use torch.set_default_dtype() and torch.set_default_device() as alternatives. (Triggered internally at /opt/conda/conda-bld/pytorch_1695392067780/work/torch/csrc/tensor/python_tensor.cpp:451.)
  _C._set_default_tensor_type(t)
`