### PR TITLE
Tensorflow 1.x backend: define a model multiple times in the same code

### DIFF
--- a/deepxde/nn/tensorflow_compat_v1/nn.py
+++ b/deepxde/nn/tensorflow_compat_v1/nn.py
@@ -9,6 +9,14 @@ class NN:
     """Base class for all neural network modules."""
 
     def __init__(self):
+        try:
+            seed = tf.random.get_seed(None)[0]
+        except RuntimeError:
+            seed = None
+        tf.reset_default_graph()
+        if seed is not None:
+            tf.set_random_seed(seed)
+
         self.training = tf.placeholder(tf.bool)
         self.regularizer = None
 


### PR DESCRIPTION
When you define `deepxde.Model` multiple times in the same code it leads to errors. This was briefly mentioned in [https://github.com/lululxvi/deepxde/issues/54](https://github.com/lululxvi/deepxde/issues/54). So this code:
```
import os

os.environ["DDEBACKEND"] = "tensorflow.compat.v1"
import deepxde as dde
import numpy as np


def func(x):
    return x * np.sin(5 * x)


geom = dde.geometry.Interval(-1, 1)
num_train = 16
num_test = 100
data = dde.data.Function(geom, func, num_train, num_test)

net = dde.nn.FNN([1] + [20] * 3 + [1], "tanh", "Glorot uniform")
model = dde.Model(data, net)
model.compile("adam", lr=0.001)
model.train(iterations=1000)
model.save("dump/model")

net_2 = dde.nn.FNN([1] + [20] * 3 + [1], "tanh", "Glorot uniform")
model_2 = dde.Model(data, net_2)
model_2.compile("adam", lr=0.001)
model_2.restore("dump/model-1000.ckpt", verbose=1)
```
will not be executed. I suggest resetting the global default graph to fix this.