### PR TITLE
change "plot_loss_history" because of safety

### DIFF
--- a/deepxde/utils/external.py
+++ b/deepxde/utils/external.py
@@ -192,8 +192,8 @@ def plot_loss_history(loss_history, fname=None):
         fname (string): If `fname` is a string (e.g., 'loss_history.png'), then save the
             figure to the file of the file name `fname`.
     """
-    loss_train = np.sum(loss_history.loss_train, axis=1)
-    loss_test = np.sum(loss_history.loss_test, axis=1)
+    loss_train = np.array([np.sum(loss) for loss in loss_history.loss_train])
+    loss_test = np.array([np.sum(loss) for loss in loss_history.loss_test])
 
     plt.figure()
     plt.semilogy(loss_history.steps, loss_train, label="Train loss")

--- a/deepxde/utils/external.py
+++ b/deepxde/utils/external.py
@@ -197,7 +197,6 @@ def plot_loss_history(loss_history, fname=None):
     # Handle irregular array sizes.
     loss_train = np.array([np.sum(loss) for loss in loss_history.loss_train])
     loss_test = np.array([np.sum(loss) for loss in loss_history.loss_test])
-    
 
     plt.figure()
     plt.semilogy(loss_history.steps, loss_train, label="Train loss")

--- a/deepxde/utils/external.py
+++ b/deepxde/utils/external.py
@@ -192,8 +192,15 @@ def plot_loss_history(loss_history, fname=None):
         fname (string): If `fname` is a string (e.g., 'loss_history.png'), then save the
             figure to the file of the file name `fname`.
     """
+    
+    """Updated loss calculations to handle irregular array sizes. 
+    Previous method with np.sum was error-prone for arrays of varying lengths. 
+
+    loss_train = np.array([np.sum(loss) for loss in loss_history.loss_train])
+    """
     loss_train = np.array([np.sum(loss) for loss in loss_history.loss_train])
     loss_test = np.array([np.sum(loss) for loss in loss_history.loss_test])
+    
 
     plt.figure()
     plt.semilogy(loss_history.steps, loss_train, label="Train loss")

--- a/deepxde/utils/external.py
+++ b/deepxde/utils/external.py
@@ -193,11 +193,8 @@ def plot_loss_history(loss_history, fname=None):
             figure to the file of the file name `fname`.
     """
     
-    """Updated loss calculations to handle irregular array sizes. 
-    Previous method with np.sum was error-prone for arrays of varying lengths. 
-
-    loss_train = np.array([np.sum(loss) for loss in loss_history.loss_train])
-    """
+    # Updated loss calculations to handle irregular array sizes. 
+    # Previous method with np.sum was error-prone for arrays of varying lengths.
     loss_train = np.array([np.sum(loss) for loss in loss_history.loss_train])
     loss_test = np.array([np.sum(loss) for loss in loss_history.loss_test])
     

--- a/deepxde/utils/external.py
+++ b/deepxde/utils/external.py
@@ -193,8 +193,8 @@ def plot_loss_history(loss_history, fname=None):
             figure to the file of the file name `fname`.
     """
     
-    # Updated loss calculations to handle irregular array sizes. 
-    # Previous method with np.sum was error-prone for arrays of varying lengths.
+    # np.sum(loss_history.loss_train, axis=1) is error-prone for arrays of varying lengths.
+    # Handle irregular array sizes.
     loss_train = np.array([np.sum(loss) for loss in loss_history.loss_train])
     loss_test = np.array([np.sum(loss) for loss in loss_history.loss_test])
     

--- a/deepxde/utils/external.py
+++ b/deepxde/utils/external.py
@@ -192,7 +192,6 @@ def plot_loss_history(loss_history, fname=None):
         fname (string): If `fname` is a string (e.g., 'loss_history.png'), then save the
             figure to the file of the file name `fname`.
     """
-    
     # np.sum(loss_history.loss_train, axis=1) is error-prone for arrays of varying lengths.
     # Handle irregular array sizes.
     loss_train = np.array([np.sum(loss) for loss in loss_history.loss_train])


### PR DESCRIPTION
The change to the new code was made after discovering that np.sum(loss_history.loss_train, axis=1) does not work when the number of arrays changes during the learning process of PDE. This issue arises because the original function assumes a regular 2D numpy array structure, which is not the case when the array sizes vary during training. The list comprehension approach is therefore used to sum each inner array individually, allowing effective handling of this irregular data structure. This solution is particularly suitable given the minimal impact on performance due to the small overall size of the data set((we store a loss every 1000 epochs, so the number of lists is not large).