### PR TITLE
ZCS code migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ docs/_build/
 
 # setuptools_scm
 deepxde/_version.py
+
+# PyCharm
+.idea/

--- a/deepxde/__init__.py
+++ b/deepxde/__init__.py
@@ -9,7 +9,7 @@ __all__ = [
     "utils",
     "Model",
     "Variable",
-    "zcs"
+    "zcs",
 ]
 
 try:
@@ -27,6 +27,7 @@ from . import gradients as grad
 from . import icbc
 from . import nn
 from . import utils
+from . import zcs
 
 from .backend import Variable
 from .model import Model
@@ -45,6 +46,3 @@ from .icbc import (
 )
 
 maps = nn
-
-# zcs
-from . import zcs

--- a/deepxde/__init__.py
+++ b/deepxde/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     "utils",
     "Model",
     "Variable",
+    "zcs"
 ]
 
 try:
@@ -44,3 +45,6 @@ from .icbc import (
 )
 
 maps = nn
+
+# zcs
+from . import zcs

--- a/deepxde/zcs/__init__.py
+++ b/deepxde/zcs/__init__.py
@@ -1,3 +1,9 @@
+__all__ = [
+    "LazyGrad",
+    "Model",
+    "PDEOperatorCartesianProd",
+]
+
 from .gradient import LazyGrad
 from .model import Model
 from .operator import PDEOperatorCartesianProd

--- a/deepxde/zcs/__init__.py
+++ b/deepxde/zcs/__init__.py
@@ -1,0 +1,3 @@
+from .gradient import LazyGrad
+from .model import Model
+from .operator import PDEOperatorCartesianProd

--- a/deepxde/zcs/__init__.py
+++ b/deepxde/zcs/__init__.py
@@ -1,3 +1,8 @@
+"""Enhancing the performance of DeepONets using Zero Coordinate Shift.
+
+Reference: https://arxiv.org/abs/2311.00860
+"""
+
 __all__ = [
     "LazyGrad",
     "Model",

--- a/deepxde/zcs/gradient.py
+++ b/deepxde/zcs/gradient.py
@@ -1,0 +1,92 @@
+"""
+Gradients for ZCS
+"""
+
+from typing import Tuple
+
+import numpy as np
+from deepxde.backend import backend_name, tf, torch, paddle  # noqa
+
+
+class LazyGrad:
+    """
+    Gradients for ZCS with lazy evaluation.
+    """
+
+    def __init__(self, zcs_parameters, u):
+        self.zcs_parameters = zcs_parameters
+        self.n_dims = len(zcs_parameters['leaves'])
+
+        # create tensor $a_{ij}$
+        if backend_name == 'pytorch':
+            self.a = torch.ones_like(u).requires_grad_()
+        elif backend_name == 'paddle':
+            self.a = paddle.ones_like(u)  # noqa
+            self.a.stop_gradient = False
+        elif backend_name == 'tensorflow':
+            self.a = tf.Variable(tf.ones_like(u), trainable=True)
+        else:
+            raise NotImplementedError(f"ZCS is not implemented for backend {backend_name}")
+
+        # omega
+        if backend_name == 'tensorflow':
+            self.a_tape = tf.GradientTape(persistent=True, watch_accessed_variables=False)
+            with self.a_tape:  # z_tape is already watching
+                self.a_tape.watch(self.a)
+                omega = tf.math.reduce_sum(u * self.a)
+        else:
+            omega = (u * self.a).sum()
+
+        # cached lower-order derivatives of omega
+        self.cached_omega_grads = {
+            # the only initial element is omega itself, with all orders being zero
+            (0,) * self.n_dims: omega
+        }
+
+    def grad_wrt_z(self, y, z):
+        if backend_name == 'pytorch':
+            return torch.autograd.grad(y, z, create_graph=True)[0]
+        elif backend_name == 'paddle':
+            return paddle.grad(y, z, create_graph=True)[0]  # noqa
+        elif backend_name == 'tensorflow':
+            with self.a_tape:  # z_tape is already watching
+                return self.zcs_parameters['tape'].gradient(y, z)
+        else:
+            raise NotImplementedError(f"ZCS is not implemented for backend {backend_name}")
+
+    def grad_wrt_a(self, y):
+        if backend_name == 'pytorch':
+            return torch.autograd.grad(y, self.a, create_graph=True)[0]
+        elif backend_name == 'paddle':
+            return paddle.grad(y, self.a, create_graph=True)[0]  # noqa
+        elif backend_name == 'tensorflow':
+            # no need to watch here because we don't need higher-orders w.r.t. a
+            return self.a_tape.gradient(y, self.a)
+        else:
+            raise NotImplementedError(f"ZCS is not implemented for backend {backend_name}")
+
+    def compute(self, required_orders: Tuple[int, ...]):
+        if required_orders in self.cached_omega_grads.keys():
+            # derivative w.r.t. a
+            return self.grad_wrt_a(self.cached_omega_grads[required_orders])
+
+        # find the start
+        orders = np.array(required_orders)
+        exists = np.array(list(self.cached_omega_grads.keys()))
+        diffs = orders[None, :] - exists
+        # existing orders no greater than target element-wise
+        avail_indices = np.where(diffs.min(axis=1) >= 0)[0]
+        # start from the closet
+        start_index = np.argmin(diffs[avail_indices].sum(axis=1))
+        start_orders = exists[avail_indices][start_index]
+
+        # dim loop
+        for i, zi in enumerate(self.zcs_parameters['leaves']):
+            # order loop
+            while start_orders[i] != required_orders[i]:
+                omega_grad = self.grad_wrt_z(self.cached_omega_grads[tuple(start_orders)], zi)
+                start_orders[i] += 1
+                self.cached_omega_grads[tuple(start_orders)] = omega_grad
+
+        # derivative w.r.t. a
+        return self.grad_wrt_a(self.cached_omega_grads[required_orders])

--- a/deepxde/zcs/gradient.py
+++ b/deepxde/zcs/gradient.py
@@ -49,27 +49,25 @@ class LazyGrad:
         if backend_name == "tensorflow":
             with self.a_tape:  # z_tape is already watching
                 return self.zcs_parameters["tape"].gradient(y, z)
-        elif backend_name == "pytorch":
+        if backend_name == "pytorch":
             return torch.autograd.grad(y, z, create_graph=True)[0]
-        elif backend_name == "paddle":
+        if backend_name == "paddle":
             return paddle.grad(y, z, create_graph=True)[0]  # noqa
-        else:
-            raise NotImplementedError(
-                f"ZCS is not implemented for backend {backend_name}"
-            )
+        raise NotImplementedError(
+            f"ZCS is not implemented for backend {backend_name}"
+        )
 
     def grad_wrt_a(self, y):
         if backend_name == "tensorflow":
             # no need to watch here because we don't need higher-orders w.r.t. a
             return self.a_tape.gradient(y, self.a)
-        elif backend_name == "pytorch":
+        if backend_name == "pytorch":
             return torch.autograd.grad(y, self.a, create_graph=True)[0]
-        elif backend_name == "paddle":
+        if backend_name == "paddle":
             return paddle.grad(y, self.a, create_graph=True)[0]  # noqa
-        else:
-            raise NotImplementedError(
-                f"ZCS is not implemented for backend {backend_name}"
-            )
+        raise NotImplementedError(
+            f"ZCS is not implemented for backend {backend_name}"
+        )
 
     def compute(self, required_orders: Tuple[int, ...]):
         if required_orders in self.cached_omega_grads.keys():

--- a/deepxde/zcs/gradient.py
+++ b/deepxde/zcs/gradient.py
@@ -8,7 +8,7 @@ from ..backend import backend_name, tf, torch, paddle  # noqa
 
 
 class LazyGrad:
-    """Gradients for ZCS with lazy evaluation"""
+    """Gradients for ZCS with lazy evaluation."""
 
     def __init__(self, zcs_parameters, u):
         self.zcs_parameters = zcs_parameters

--- a/deepxde/zcs/gradient.py
+++ b/deepxde/zcs/gradient.py
@@ -15,22 +15,26 @@ class LazyGrad:
 
     def __init__(self, zcs_parameters, u):
         self.zcs_parameters = zcs_parameters
-        self.n_dims = len(zcs_parameters['leaves'])
+        self.n_dims = len(zcs_parameters["leaves"])
 
         # create tensor $a_{ij}$
-        if backend_name == 'pytorch':
+        if backend_name == "pytorch":
             self.a = torch.ones_like(u).requires_grad_()
-        elif backend_name == 'paddle':
+        elif backend_name == "paddle":
             self.a = paddle.ones_like(u)  # noqa
             self.a.stop_gradient = False
-        elif backend_name == 'tensorflow':
+        elif backend_name == "tensorflow":
             self.a = tf.Variable(tf.ones_like(u), trainable=True)
         else:
-            raise NotImplementedError(f"ZCS is not implemented for backend {backend_name}")
+            raise NotImplementedError(
+                f"ZCS is not implemented for backend {backend_name}"
+            )
 
         # omega
-        if backend_name == 'tensorflow':
-            self.a_tape = tf.GradientTape(persistent=True, watch_accessed_variables=False)
+        if backend_name == "tensorflow":
+            self.a_tape = tf.GradientTape(
+                persistent=True, watch_accessed_variables=False
+            )
             with self.a_tape:  # z_tape is already watching
                 self.a_tape.watch(self.a)
                 omega = tf.math.reduce_sum(u * self.a)
@@ -40,30 +44,35 @@ class LazyGrad:
         # cached lower-order derivatives of omega
         self.cached_omega_grads = {
             # the only initial element is omega itself, with all orders being zero
-            (0,) * self.n_dims: omega
+            (0,)
+            * self.n_dims: omega
         }
 
     def grad_wrt_z(self, y, z):
-        if backend_name == 'pytorch':
+        if backend_name == "pytorch":
             return torch.autograd.grad(y, z, create_graph=True)[0]
-        elif backend_name == 'paddle':
+        elif backend_name == "paddle":
             return paddle.grad(y, z, create_graph=True)[0]  # noqa
-        elif backend_name == 'tensorflow':
+        elif backend_name == "tensorflow":
             with self.a_tape:  # z_tape is already watching
-                return self.zcs_parameters['tape'].gradient(y, z)
+                return self.zcs_parameters["tape"].gradient(y, z)
         else:
-            raise NotImplementedError(f"ZCS is not implemented for backend {backend_name}")
+            raise NotImplementedError(
+                f"ZCS is not implemented for backend {backend_name}"
+            )
 
     def grad_wrt_a(self, y):
-        if backend_name == 'pytorch':
+        if backend_name == "pytorch":
             return torch.autograd.grad(y, self.a, create_graph=True)[0]
-        elif backend_name == 'paddle':
+        elif backend_name == "paddle":
             return paddle.grad(y, self.a, create_graph=True)[0]  # noqa
-        elif backend_name == 'tensorflow':
+        elif backend_name == "tensorflow":
             # no need to watch here because we don't need higher-orders w.r.t. a
             return self.a_tape.gradient(y, self.a)
         else:
-            raise NotImplementedError(f"ZCS is not implemented for backend {backend_name}")
+            raise NotImplementedError(
+                f"ZCS is not implemented for backend {backend_name}"
+            )
 
     def compute(self, required_orders: Tuple[int, ...]):
         if required_orders in self.cached_omega_grads.keys():
@@ -81,10 +90,12 @@ class LazyGrad:
         start_orders = exists[avail_indices][start_index]
 
         # dim loop
-        for i, zi in enumerate(self.zcs_parameters['leaves']):
+        for i, zi in enumerate(self.zcs_parameters["leaves"]):
             # order loop
             while start_orders[i] != required_orders[i]:
-                omega_grad = self.grad_wrt_z(self.cached_omega_grads[tuple(start_orders)], zi)
+                omega_grad = self.grad_wrt_z(
+                    self.cached_omega_grads[tuple(start_orders)], zi
+                )
                 start_orders[i] += 1
                 self.cached_omega_grads[tuple(start_orders)] = omega_grad
 

--- a/deepxde/zcs/model.py
+++ b/deepxde/zcs/model.py
@@ -1,8 +1,8 @@
 """Model extension for ZCS support"""
 
-from ..model import Model as BaseModel
 from .. import gradients as grad
-from ..backend import tf, torch, paddle  # noqa
+from ..backend import tf, torch, paddle # noqa
+from ..model import Model as BaseModel
 
 
 class Model(BaseModel):

--- a/deepxde/zcs/model.py
+++ b/deepxde/zcs/model.py
@@ -1,0 +1,304 @@
+"""
+Model extension for ZCS support
+"""
+
+import deepxde as dde
+import deepxde.gradients as grad
+from deepxde import optimizers
+from deepxde.backend import tf, torch, paddle  # noqa
+
+
+class Model(dde.Model):
+    """
+    Derived `Model` class for ZCS support.
+    """
+
+    def __init__(self, data, net):
+        super().__init__(data, net)
+        # store ZCS parameters, sent to user for PDE calculation
+        self.zcs_parameters = None
+
+    def _compile_tensorflow_compat_v1(self, lr, loss_fn, decay):
+        """ tensorflow.compat.v1 """
+        raise NotImplementedError("ZCS is not implemented for backend tensorflow.compat.v1")
+
+    def _compile_tensorflow(self, lr, loss_fn, decay):
+        """ tensorflow """
+        super()._compile_tensorflow(lr, loss_fn, decay)
+
+        def process_inputs_zcs(inputs):
+            # get inputs
+            branch_inputs, trunk_inputs = inputs
+
+            # convert to tensors with grad disabled
+            branch_inputs = tf.constant(branch_inputs)
+            trunk_inputs = tf.constant(trunk_inputs)
+
+            # create ZCS scalars
+            n_dim_crds = trunk_inputs.shape[1]
+            zcs_scalars = [tf.Variable(0., trainable=True)
+                           for _ in range(n_dim_crds)]
+
+            # add ZCS to truck inputs
+            # from now until loss must be taped
+            with tf.GradientTape(persistent=True, watch_accessed_variables=False) as tape:
+                for z in zcs_scalars:
+                    tape.watch(z)
+                zcs_vector = tf.stack(zcs_scalars)
+                trunk_inputs = trunk_inputs + zcs_vector[None, :]
+
+            # return inputs and ZCS parameters
+            return (branch_inputs, trunk_inputs), {'leaves': zcs_scalars, 'tape': tape}
+
+        def outputs_losses_zcs(training, inputs, targets, auxiliary_vars, losses_fn):
+            # aux
+            self.net.auxiliary_vars = auxiliary_vars
+
+            # inputs
+            inputs, self.zcs_parameters = process_inputs_zcs(inputs)
+
+            # forward and loss must be taped
+            with self.zcs_parameters['tape']:
+                # forward
+                outputs_ = self.net(inputs, training=training)
+
+                # losses
+                if targets is not None:
+                    targets = tf.constant(targets)
+                losses = losses_fn(targets, outputs_, loss_fn, inputs, self)
+                if not isinstance(losses, list):
+                    losses = [losses]
+
+            # regularization
+            if self.net.regularizer is not None:
+                losses += [tf.math.reduce_sum(self.net.losses)]
+            losses = tf.convert_to_tensor(losses)
+
+            # weighted
+            if self.loss_weights is not None:
+                losses *= self.loss_weights
+            return outputs_, losses
+
+        def outputs_losses_train_zcs(inputs, targets, auxiliary_vars):
+            return outputs_losses_zcs(
+                True, inputs, targets, auxiliary_vars, self.data.losses_train
+            )
+
+        def outputs_losses_test_zcs(inputs, targets, auxiliary_vars):
+            return outputs_losses_zcs(
+                False, inputs, targets, auxiliary_vars, self.data.losses_test
+            )
+
+        # base class used a temporary variable
+        self.opt = optimizers.get(self.opt_name, learning_rate=lr, decay=decay)  # noqa
+
+        def train_step_zcs(inputs, targets, auxiliary_vars):
+            with tf.GradientTape() as tape:
+                losses = outputs_losses_train_zcs(inputs, targets, auxiliary_vars)[1]
+                total_loss = tf.math.reduce_sum(losses)
+            trainable_variables = (
+                    self.net.trainable_variables + self.external_trainable_variables
+            )
+            grads = tape.gradient(total_loss, trainable_variables)
+            self.opt.apply_gradients(zip(grads, trainable_variables))
+
+        def train_step_tfp_zcs(
+                inputs, targets, auxiliary_vars, previous_optimizer_results=None
+        ):
+            def build_loss():
+                losses = outputs_losses_train_zcs(inputs, targets, auxiliary_vars)[1]
+                return tf.math.reduce_sum(losses)
+
+            trainable_variables = (
+                    self.net.trainable_variables + self.external_trainable_variables
+            )
+            return self.opt(trainable_variables, build_loss, previous_optimizer_results)
+
+        # overwrite callables
+        self.outputs_losses_train = outputs_losses_train_zcs
+        self.outputs_losses_test = outputs_losses_test_zcs
+        self.train_step = (
+            train_step_zcs
+            if not optimizers.is_external_optimizer(self.opt_name)  # noqa
+            else train_step_tfp_zcs
+        )
+
+    def _compile_pytorch(self, lr, loss_fn, decay):
+        """ pytorch """
+        super()._compile_pytorch(lr, loss_fn, decay)
+
+        def process_inputs_zcs(inputs):
+            # get inputs
+            branch_inputs, trunk_inputs = inputs
+
+            # convert to tensors with grad disabled
+            branch_inputs = torch.as_tensor(branch_inputs)
+            trunk_inputs = torch.as_tensor(trunk_inputs)
+
+            # create ZCS scalars
+            n_dim_crds = trunk_inputs.shape[1]
+            zcs_scalars = [torch.as_tensor(0.).requires_grad_()
+                           for _ in range(n_dim_crds)]
+
+            # add ZCS to truck inputs
+            zcs_vector = torch.stack(zcs_scalars)
+            trunk_inputs = trunk_inputs + zcs_vector[None, :]
+
+            # return inputs and ZCS scalars
+            return (branch_inputs, trunk_inputs), {'leaves': zcs_scalars}
+
+        def outputs_losses_zcs(training, inputs, targets, auxiliary_vars, losses_fn):
+            # aux
+            self.net.auxiliary_vars = None
+            if auxiliary_vars is not None:
+                self.net.auxiliary_vars = torch.as_tensor(auxiliary_vars)
+
+            # inputs
+            inputs, self.zcs_parameters = process_inputs_zcs(inputs)
+
+            # forward
+            self.net.train(mode=training)
+            outputs_ = self.net(inputs)
+
+            # losses
+            if targets is not None:
+                targets = torch.as_tensor(targets)
+            losses = losses_fn(targets, outputs_, loss_fn, inputs, self)
+            if not isinstance(losses, list):
+                losses = [losses]
+            losses = torch.stack(losses)
+
+            # TODO: regularization
+
+            # weighted
+            if self.loss_weights is not None:
+                losses *= torch.as_tensor(self.loss_weights)
+
+            # clear cached gradients (actually not used with ZCS)
+            grad.clear()
+            return outputs_, losses
+
+        def outputs_losses_train_zcs(inputs, targets, auxiliary_vars):
+            return outputs_losses_zcs(
+                True, inputs, targets, auxiliary_vars, self.data.losses_train
+            )
+
+        def outputs_losses_test_zcs(inputs, targets, auxiliary_vars):
+            return outputs_losses_zcs(
+                False, inputs, targets, auxiliary_vars, self.data.losses_test
+            )
+
+        def train_step_zcs(inputs, targets, auxiliary_vars):
+            def closure():
+                losses = outputs_losses_train_zcs(inputs, targets, auxiliary_vars)[1]
+                total_loss = torch.sum(losses)
+                self.opt.zero_grad()
+                total_loss.backward()
+                return total_loss
+
+            self.opt.step(closure)
+            if self.lr_scheduler is not None:
+                self.lr_scheduler.step()
+
+        # overwrite callables
+        self.outputs_losses_train = outputs_losses_train_zcs
+        self.outputs_losses_test = outputs_losses_test_zcs
+        self.train_step = train_step_zcs
+
+    def _compile_jax(self, lr, loss_fn, decay):
+        """ jax """
+        raise NotImplementedError("ZCS is not implemented for backend jax")
+
+    def _compile_paddle(self, lr, loss_fn, decay):
+        """ paddle """
+        super()._compile_paddle(lr, loss_fn, decay)
+
+        def process_inputs_zcs(inputs):
+            # get inputs
+            branch_inputs, trunk_inputs = inputs
+
+            # convert to tensors with grad disabled
+            branch_inputs = paddle.to_tensor(branch_inputs, stop_gradient=True)  # noqa
+            trunk_inputs = paddle.to_tensor(trunk_inputs, stop_gradient=True)  # noqa
+
+            # create ZCS scalars
+            n_dim_crds = trunk_inputs.shape[1]
+            zcs_scalars = [paddle.to_tensor(0., stop_gradient=False)  # noqa
+                           for _ in range(n_dim_crds)]
+
+            # add ZCS to truck inputs
+            zcs_vector = paddle.concat([paddle.tile(z, 1) for z in zcs_scalars], axis=0)  # noqa
+            trunk_inputs = trunk_inputs + zcs_vector[None, :]
+
+            # return inputs and ZCS scalars
+            return (branch_inputs, trunk_inputs), {'leaves': zcs_scalars}
+
+        def outputs_losses_zcs(training, inputs, targets, auxiliary_vars, losses_fn):
+            # aux
+            self.net.auxiliary_vars = auxiliary_vars
+
+            # inputs
+            inputs, self.zcs_parameters = process_inputs_zcs(inputs)
+
+            # forward
+            if training:
+                self.net.train()
+            else:
+                self.net.eval()
+            outputs_ = self.net(inputs)
+
+            # losses
+            if targets is not None:
+                targets = paddle.to_tensor(targets)  # noqa
+            losses = losses_fn(targets, outputs_, loss_fn, inputs, self)
+            if not isinstance(losses, list):
+                losses = [losses]
+            losses = paddle.stack(losses, axis=0)
+
+            # TODO: regularization
+
+            # weighted
+            if self.loss_weights is not None:
+                losses *= paddle.to_tensor(self.loss_weights)  # noqa
+
+            # clear cached gradients (actually not used with ZCS)
+            grad.clear()
+            return outputs_, losses
+
+        def outputs_losses_train_zcs(inputs, targets, auxiliary_vars):
+            return outputs_losses_zcs(
+                True, inputs, targets, auxiliary_vars, self.data.losses_train
+            )
+
+        def outputs_losses_test_zcs(inputs, targets, auxiliary_vars):
+            return outputs_losses_zcs(
+                False, inputs, targets, auxiliary_vars, self.data.losses_test
+            )
+
+        def train_step_zcs(inputs, targets, auxiliary_vars):
+            losses = outputs_losses_train_zcs(inputs, targets, auxiliary_vars)[1]
+            total_loss = paddle.sum(losses)  # noqa
+            total_loss.backward()
+            self.opt.step()
+            self.opt.clear_grad()
+            if self.lr_scheduler is not None:
+                self.lr_scheduler.step()
+
+        def train_step_lbfgs_zcs(inputs, targets, auxiliary_vars):
+            def closure():
+                losses = outputs_losses_train_zcs(inputs, targets, auxiliary_vars)[1]
+                total_loss = paddle.sum(losses)  # noqa
+                self.opt.clear_grad()
+                total_loss.backward()
+                return total_loss
+
+            self.opt.step(closure)
+
+        # overwrite callables
+        self.outputs_losses_train = outputs_losses_train_zcs
+        self.outputs_losses_test = outputs_losses_test_zcs
+        self.train_step = (
+            train_step_zcs
+            if not optimizers.is_external_optimizer(self.opt_name)  # noqa
+            else train_step_lbfgs_zcs
+        )

--- a/deepxde/zcs/model.py
+++ b/deepxde/zcs/model.py
@@ -1,12 +1,11 @@
 """Model extension for ZCS support"""
 
-import deepxde as dde
-import deepxde.gradients as grad
-from deepxde import optimizers
-from deepxde.backend import tf, torch, paddle  # noqa
+from ..model import Model as BaseModel
+from .. import gradients as grad
+from ..backend import tf, torch, paddle  # noqa
 
 
-class Model(dde.Model):
+class Model(BaseModel):
     """Derived `Model` class for ZCS support."""
 
     def __init__(self, data, net):

--- a/deepxde/zcs/model.py
+++ b/deepxde/zcs/model.py
@@ -7,7 +7,7 @@ from deepxde.backend import tf, torch, paddle  # noqa
 
 
 class Model(dde.Model):
-    """Derived `Model` class for ZCS support"""
+    """Derived `Model` class for ZCS support."""
 
     def __init__(self, data, net):
         super().__init__(data, net)

--- a/deepxde/zcs/model.py
+++ b/deepxde/zcs/model.py
@@ -1,6 +1,4 @@
-"""
-Model extension for ZCS support
-"""
+"""Model extension for ZCS support"""
 
 import deepxde as dde
 import deepxde.gradients as grad
@@ -9,9 +7,7 @@ from deepxde.backend import tf, torch, paddle  # noqa
 
 
 class Model(dde.Model):
-    """
-    Derived `Model` class for ZCS support.
-    """
+    """Derived `Model` class for ZCS support"""
 
     def __init__(self, data, net):
         super().__init__(data, net)

--- a/deepxde/zcs/operator.py
+++ b/deepxde/zcs/operator.py
@@ -1,15 +1,11 @@
-"""
-PDE operator extensions for ZCS support
-"""
+"""PDE operator extensions for ZCS support"""
 
 import deepxde as dde
 import numpy as np
 
 
 class PDEOperatorCartesianProd(dde.data.PDEOperatorCartesianProd):
-    """
-    Derived `PDEOperatorCartesianProd` class for ZCS support.
-    """
+    """Derived `PDEOperatorCartesianProd` class for ZCS support"""
 
     def _losses(self, outputs, loss_fn, inputs, model, num_func):
         bkd = dde.backend

--- a/deepxde/zcs/operator.py
+++ b/deepxde/zcs/operator.py
@@ -1,0 +1,48 @@
+"""
+PDE operator extensions for ZCS support
+"""
+
+import deepxde as dde
+import numpy as np
+
+
+class PDEOperatorCartesianProd(dde.data.PDEOperatorCartesianProd):
+    """
+    Derived `PDEOperatorCartesianProd` class for ZCS support.
+    """
+
+    def _losses(self, outputs, loss_fn, inputs, model, num_func):
+        bkd = dde.backend
+
+        # PDE
+        f = []
+        if self.pde.pde is not None:
+            f = self.pde.pde(model.zcs_parameters, outputs, model.net.auxiliary_vars)
+            if not isinstance(f, (list, tuple)):
+                f = [f]
+        bcs_start = np.cumsum([0] + self.pde.num_bcs)
+        error_f = [fi[:, bcs_start[-1]:] for fi in f]
+        losses = [loss_fn(bkd.zeros_like(error), error) for error in error_f]  # noqa
+
+        # BC
+        for k, bc in enumerate(self.pde.bcs):
+            beg, end = bcs_start[k], bcs_start[k + 1]
+            error_k = []
+            # NOTE: this loop over functions can also be avoided if we implement collective ic/bc
+            for i in range(num_func):
+                output_i = outputs[i]
+                if bkd.ndim(output_i) == 1:  # noqa
+                    output_i = output_i[:, None]
+                error_ki = bc.error(
+                    self.train_x[1],
+                    inputs[1],
+                    output_i,
+                    beg,
+                    end,
+                    aux_var=model.net.auxiliary_vars[i][:, None],
+                )
+                error_k.append(error_ki)
+            error_k = bkd.stack(error_k, axis=0)  # noqa
+            loss_k = loss_fn(bkd.zeros_like(error_k), error_k)  # noqa
+            losses.append(loss_k)
+        return losses

--- a/deepxde/zcs/operator.py
+++ b/deepxde/zcs/operator.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from ..backend import backend as bkd
+from .. import backend as bkd
 from ..data import PDEOperatorCartesianProd as BasePDEOperatorCartesianProd
 
 

--- a/deepxde/zcs/operator.py
+++ b/deepxde/zcs/operator.py
@@ -21,7 +21,7 @@ class PDEOperatorCartesianProd(dde.data.PDEOperatorCartesianProd):
             if not isinstance(f, (list, tuple)):
                 f = [f]
         bcs_start = np.cumsum([0] + self.pde.num_bcs)
-        error_f = [fi[:, bcs_start[-1]:] for fi in f]
+        error_f = [fi[:, bcs_start[-1] :] for fi in f]
         losses = [loss_fn(bkd.zeros_like(error), error) for error in error_f]  # noqa
 
         # BC

--- a/deepxde/zcs/operator.py
+++ b/deepxde/zcs/operator.py
@@ -5,7 +5,7 @@ import numpy as np
 
 
 class PDEOperatorCartesianProd(dde.data.PDEOperatorCartesianProd):
-    """Derived `PDEOperatorCartesianProd` class for ZCS support"""
+    """Derived `PDEOperatorCartesianProd` class for ZCS support."""
 
     def _losses(self, outputs, loss_fn, inputs, model, num_func):
         bkd = dde.backend

--- a/deepxde/zcs/operator.py
+++ b/deepxde/zcs/operator.py
@@ -1,15 +1,15 @@
 """PDE operator extensions for ZCS support"""
 
-import deepxde as dde
 import numpy as np
 
+from ..backend import backend as bkd
+from ..data import PDEOperatorCartesianProd as BasePDEOperatorCartesianProd
 
-class PDEOperatorCartesianProd(dde.data.PDEOperatorCartesianProd):
+
+class PDEOperatorCartesianProd(BasePDEOperatorCartesianProd):
     """Derived `PDEOperatorCartesianProd` class for ZCS support."""
 
     def _losses(self, outputs, loss_fn, inputs, model, num_func):
-        bkd = dde.backend
-
         # PDE
         f = []
         if self.pde.pde is not None:


### PR DESCRIPTION
This PR creates module `deepxde.zcs` to support ZCS on tensorflow, pytorch and paddle backends (tf.compact.v1 not supported). Codes are tested on all examples and on both CPU and GPU with outstanding performance improvements confirmed. Examples and docs will be added in the next PR, as discusssed.

Non-local changes only include updating the top-level `__init__.py`.