### PR TITLE
Multi-dimentional output strategy for DeepONet in PyTorch

### DIFF
--- a/deepxde/nn/deeponet_strategy.py
+++ b/deepxde/nn/deeponet_strategy.py
@@ -1,0 +1,172 @@
+from abc import ABC, abstractmethod
+
+
+class DeepONetStrategy(ABC):
+    """DeepONet building strategy.
+
+    See the section 3.1.6. in
+    L. Lu, X. Meng, S. Cai, Z. Mao, S. Goswami, Z. Zhang, & G. Karniadakis.
+    A comprehensive and fair comparison of two neural operators
+    (with practical extensions) based on FAIR data.
+    Computer Methods in Applied Mechanics and Engineering, 393, 114778, 2022.
+    """
+
+    def __init__(self, net):
+        self.net = net
+
+    @abstractmethod
+    def build(self, layer_sizes_branch, layer_sizes_trunk):
+        """Build branch and trunk nets."""
+
+    @abstractmethod
+    def call(self, x_func, x_loc, training=False):
+        """Forward pass."""
+
+
+class SingleOutputStrategy(DeepONetStrategy):
+    """Single output build strategy is the standard build method."""
+
+    def build(self, layer_sizes_branch, layer_sizes_trunk):
+        if layer_sizes_branch[-1] != layer_sizes_trunk[-1]:
+            raise AssertionError(
+                "Output sizes of branch net and trunk net do not match."
+            )
+        branch = self.net.build_branch_net(layer_sizes_branch)
+        trunk = self.net.build_trunk_net(layer_sizes_trunk)
+        return branch, trunk
+
+    def call(self, x_func, x_loc, training=False):
+        x_func = self.net.branch(x_func)
+        x_loc = self.net.activation_trunk(self.net.trunk(x_loc))
+        if x_func.shape[-1] != x_loc.shape[-1]:
+            raise AssertionError(
+                "Output sizes of branch net and trunk net do not match."
+            )
+        x = self.net.merge_branch_trunk(x_func, x_loc)
+        return x
+
+
+class IndependentStrategy(DeepONetStrategy):
+    """Directly use n independent DeepONets,
+    and each DeepONet outputs only one function.
+    """
+
+    def build(self, layer_sizes_branch, layer_sizes_trunk):
+        single_output_strategy = SingleOutputStrategy(self.net)
+        branch, trunk = [], []
+        for _ in range(self.net.num_outputs):
+            branch_, trunk_ = single_output_strategy.build(
+                layer_sizes_branch, layer_sizes_trunk
+            )
+            branch.append(branch_)
+            trunk.append(trunk_)
+        return branch, trunk
+
+    def call(self, x_func, x_loc, training=False):
+        xs = []
+        for i in range(self.net.num_outputs):
+            x_func_ = self.net.branch[i](x_func)
+            x_loc_ = self.net.activation_trunk(self.net.trunk[i](x_loc))
+            x = self.net.merge_branch_trunk(x_func_, x_loc_)
+            xs.append(x)
+        return self.net.concatenate_outputs(xs)
+
+
+class SplitBothStrategy(DeepONetStrategy):
+    """Split the outputs of both the branch net and the trunk net into n groups,
+    and then the kth group outputs the kth solution.
+
+    For example, if n = 2 and both the branch and trunk nets have 100 output neurons,
+    then the dot product between the first 50 neurons of
+    the branch and trunk nets generates the first function,
+    and the remaining 50 neurons generate the second function.
+    """
+
+    def build(self, layer_sizes_branch, layer_sizes_trunk):
+        if layer_sizes_branch[-1] != layer_sizes_trunk[-1]:
+            raise AssertionError(
+                "Output sizes of branch net and trunk net do not match."
+            )
+        if layer_sizes_branch[-1] % self.net.num_outputs != 0:
+            raise AssertionError(
+                f"Output size of the branch net is not evenly divisible by {self.net.num_outputs}."
+            )
+        single_output_strategy = SingleOutputStrategy(self.net)
+        return single_output_strategy.build(layer_sizes_branch, layer_sizes_trunk)
+
+    def call(self, x_func, x_loc, training=False):
+        x_func = self.net.branch(x_func)
+        x_loc = self.net.activation_trunk(self.net.trunk(x_loc))
+        # Split x_func and x_loc into respective outputs
+        shift = 0
+        size = x_func.shape[1] // self.net.num_outputs
+        xs = []
+        for _ in range(self.net.num_outputs):
+            x_func_ = x_func[:, shift : shift + size]
+            x_loc_ = x_loc[:, shift : shift + size]
+            x = self.net.merge_branch_trunk(x_func_, x_loc_)
+            xs.append(x)
+            shift += size
+        return self.net.concatenate_outputs(xs)
+
+
+class SplitBranchStrategy(DeepONetStrategy):
+    """Split the branch net and share the trunk net."""
+
+    def build(self, layer_sizes_branch, layer_sizes_trunk):
+        if layer_sizes_branch[-1] % self.net.num_outputs != 0:
+            raise AssertionError(
+                f"Output size of the branch net is not evenly divisible by {self.net.num_outputs}."
+            )
+        if layer_sizes_branch[-1] / self.net.num_outputs != layer_sizes_trunk[-1]:
+            raise AssertionError(
+                f"Output size of the trunk net does not equal to {layer_sizes_branch[-1] // self.net.num_outputs}."
+            )
+        return self.net.build_branch_net(layer_sizes_branch), self.net.build_trunk_net(
+            layer_sizes_trunk
+        )
+
+    def call(self, x_func, x_loc, training=False):
+        x_func = self.net.branch(x_func)
+        x_loc = self.net.activation_trunk(self.net.trunk(x_loc))
+        # Split x_func into respective outputs
+        shift = 0
+        size = x_loc.shape[1]
+        xs = []
+        for _ in range(self.net.num_outputs):
+            x_func_ = x_func[:, shift : shift + size]
+            x = self.net.merge_branch_trunk(x_func_, x_loc)
+            xs.append(x)
+            shift += size
+        return self.net.concatenate_outputs(xs)
+
+
+class SplitTrunkStrategy(DeepONetStrategy):
+    """Split the trunk net and share the branch net."""
+
+    def build(self, layer_sizes_branch, layer_sizes_trunk):
+        if layer_sizes_trunk[-1] % self.net.num_outputs != 0:
+            raise AssertionError(
+                f"Output size of the trunk net is not evenly divisible by {self.net.num_outputs}."
+            )
+        if layer_sizes_trunk[-1] / self.net.num_outputs != layer_sizes_branch[-1]:
+            raise AssertionError(
+                f"Output size of the branch net does not equal to {layer_sizes_trunk[-1] // self.net.num_outputs}."
+            )
+        return self.net.build_branch_net(layer_sizes_branch), self.net.build_trunk_net(
+            layer_sizes_trunk
+        )
+
+    def call(self, x_func, x_loc, training=False):
+        x_func = self.net.branch(x_func)
+        x_loc = self.net.activation_trunk(self.net.trunk(x_loc))
+        # Split x_loc into respective outputs
+        shift = 0
+        size = x_func.shape[1]
+        xs = []
+        for _ in range(self.net.num_outputs):
+            x_loc_ = x_loc[:, shift : shift + size]
+            x = self.net.merge_branch_trunk(x_func, x_loc_)
+            xs.append(x)
+            shift += size
+        return self.net.concatenate_outputs(xs)

--- a/deepxde/nn/deeponet_strategy.py
+++ b/deepxde/nn/deeponet_strategy.py
@@ -19,7 +19,7 @@ class DeepONetStrategy(ABC):
         """Build branch and trunk nets."""
 
     @abstractmethod
-    def call(self, x_func, x_loc, training=False):
+    def call(self, x_func, x_loc):
         """Forward pass."""
 
 
@@ -35,7 +35,7 @@ class SingleOutputStrategy(DeepONetStrategy):
         trunk = self.net.build_trunk_net(layer_sizes_trunk)
         return branch, trunk
 
-    def call(self, x_func, x_loc, training=False):
+    def call(self, x_func, x_loc):
         x_func = self.net.branch(x_func)
         x_loc = self.net.activation_trunk(self.net.trunk(x_loc))
         if x_func.shape[-1] != x_loc.shape[-1]:
@@ -62,7 +62,7 @@ class IndependentStrategy(DeepONetStrategy):
             trunk.append(trunk_)
         return branch, trunk
 
-    def call(self, x_func, x_loc, training=False):
+    def call(self, x_func, x_loc):
         xs = []
         for i in range(self.net.num_outputs):
             x_func_ = self.net.branch[i](x_func)
@@ -94,7 +94,7 @@ class SplitBothStrategy(DeepONetStrategy):
         single_output_strategy = SingleOutputStrategy(self.net)
         return single_output_strategy.build(layer_sizes_branch, layer_sizes_trunk)
 
-    def call(self, x_func, x_loc, training=False):
+    def call(self, x_func, x_loc):
         x_func = self.net.branch(x_func)
         x_loc = self.net.activation_trunk(self.net.trunk(x_loc))
         # Split x_func and x_loc into respective outputs
@@ -126,7 +126,7 @@ class SplitBranchStrategy(DeepONetStrategy):
             layer_sizes_trunk
         )
 
-    def call(self, x_func, x_loc, training=False):
+    def call(self, x_func, x_loc):
         x_func = self.net.branch(x_func)
         x_loc = self.net.activation_trunk(self.net.trunk(x_loc))
         # Split x_func into respective outputs
@@ -157,7 +157,7 @@ class SplitTrunkStrategy(DeepONetStrategy):
             layer_sizes_trunk
         )
 
-    def call(self, x_func, x_loc, training=False):
+    def call(self, x_func, x_loc):
         x_func = self.net.branch(x_func)
         x_loc = self.net.activation_trunk(self.net.trunk(x_loc))
         # Split x_loc into respective outputs

--- a/deepxde/nn/deeponet_strategy.py
+++ b/deepxde/nn/deeponet_strategy.py
@@ -42,7 +42,7 @@ class SingleOutputStrategy(DeepONetStrategy):
             raise AssertionError(
                 "Output sizes of branch net and trunk net do not match."
             )
-        x = self.net.merge_branch_trunk(x_func, x_loc)
+        x = self.net.merge_branch_trunk(x_func, x_loc, 0)
         return x
 
 
@@ -67,7 +67,7 @@ class IndependentStrategy(DeepONetStrategy):
         for i in range(self.net.num_outputs):
             x_func_ = self.net.branch[i](x_func)
             x_loc_ = self.net.activation_trunk(self.net.trunk[i](x_loc))
-            x = self.net.merge_branch_trunk(x_func_, x_loc_)
+            x = self.net.merge_branch_trunk(x_func_, x_loc_, i)
             xs.append(x)
         return self.net.concatenate_outputs(xs)
 
@@ -101,10 +101,10 @@ class SplitBothStrategy(DeepONetStrategy):
         shift = 0
         size = x_func.shape[1] // self.net.num_outputs
         xs = []
-        for _ in range(self.net.num_outputs):
+        for i in range(self.net.num_outputs):
             x_func_ = x_func[:, shift : shift + size]
             x_loc_ = x_loc[:, shift : shift + size]
-            x = self.net.merge_branch_trunk(x_func_, x_loc_)
+            x = self.net.merge_branch_trunk(x_func_, x_loc_, i)
             xs.append(x)
             shift += size
         return self.net.concatenate_outputs(xs)
@@ -133,9 +133,9 @@ class SplitBranchStrategy(DeepONetStrategy):
         shift = 0
         size = x_loc.shape[1]
         xs = []
-        for _ in range(self.net.num_outputs):
+        for i in range(self.net.num_outputs):
             x_func_ = x_func[:, shift : shift + size]
-            x = self.net.merge_branch_trunk(x_func_, x_loc)
+            x = self.net.merge_branch_trunk(x_func_, x_loc, i)
             xs.append(x)
             shift += size
         return self.net.concatenate_outputs(xs)
@@ -164,9 +164,9 @@ class SplitTrunkStrategy(DeepONetStrategy):
         shift = 0
         size = x_func.shape[1]
         xs = []
-        for _ in range(self.net.num_outputs):
+        for i in range(self.net.num_outputs):
             x_loc_ = x_loc[:, shift : shift + size]
-            x = self.net.merge_branch_trunk(x_func, x_loc_)
+            x = self.net.merge_branch_trunk(x_func, x_loc_, i)
             xs.append(x)
             shift += size
         return self.net.concatenate_outputs(xs)

--- a/deepxde/nn/pytorch/deeponet.py
+++ b/deepxde/nn/pytorch/deeponet.py
@@ -102,13 +102,12 @@ class DeepONet(NN):
         self.branch, self.trunk = self.multi_output_strategy.build(
             layer_sizes_branch, layer_sizes_trunk
         )
-
-        self.b = cycle(
-            [
-                torch.nn.parameter.Parameter(torch.tensor(0.0))
-                for _ in range(self.num_outputs)
-            ]
+        self.branch = torch.nn.ModuleList(self.branch)
+        self.trunk = torch.nn.ModuleList(self.trunk)
+        self.biases = torch.nn.ParameterList(
+            [torch.nn.Parameter(torch.tensor(0.0)) for _ in range(self.num_outputs)]
         )
+        self.b = cycle(range(self.num_outputs))
 
     def build_branch_net(self, layer_sizes_branch):
         # User-defined network
@@ -123,7 +122,7 @@ class DeepONet(NN):
     def merge_branch_trunk(self, x_func, x_loc):
         y = torch.einsum("bi,bi->b", x_func, x_loc)
         y = torch.unsqueeze(y, dim=1)
-        y += next(self.b)
+        y += self.biases[next(self.b)]
         return y
 
     @staticmethod
@@ -224,13 +223,12 @@ class DeepONetCartesianProd(NN):
         self.branch, self.trunk = self.multi_output_strategy.build(
             layer_sizes_branch, layer_sizes_trunk
         )
-
-        self.b = cycle(
-            [
-                torch.nn.parameter.Parameter(torch.tensor(0.0))
-                for _ in range(self.num_outputs)
-            ]
+        self.branch = torch.nn.ModuleList(self.branch)
+        self.trunk = torch.nn.ModuleList(self.trunk)
+        self.biases = torch.nn.ParameterList(
+            [torch.nn.Parameter(torch.tensor(0.0)) for _ in range(self.num_outputs)]
         )
+        self.b = cycle(range(self.num_outputs))
 
     def build_branch_net(self, layer_sizes_branch):
         # User-defined network
@@ -244,7 +242,7 @@ class DeepONetCartesianProd(NN):
 
     def merge_branch_trunk(self, x_func, x_loc):
         y = torch.einsum("bi,ni->bn", x_func, x_loc)
-        y += next(self.b)
+        y += self.biases[next(self.b)]
         return y
 
     @staticmethod

--- a/deepxde/nn/pytorch/deeponet.py
+++ b/deepxde/nn/pytorch/deeponet.py
@@ -68,7 +68,6 @@ class DeepONet(NN):
         kernel_initializer,
         num_outputs=1,
         multi_output_strategy=None,
-        regularization=None,
     ):
         super().__init__()
         if isinstance(activation, dict):
@@ -77,7 +76,6 @@ class DeepONet(NN):
         else:
             self.activation_branch = self.activation_trunk = activations.get(activation)
         self.kernel_initializer = kernel_initializer
-        self.regularization = regularization  # TODO: currently unused
 
         self.num_outputs = num_outputs
         if self.num_outputs == 1:
@@ -192,7 +190,6 @@ class DeepONetCartesianProd(NN):
         kernel_initializer,
         num_outputs=1,
         multi_output_strategy=None,
-        regularization=None,
     ):
         super().__init__()
         if isinstance(activation, dict):
@@ -201,7 +198,6 @@ class DeepONetCartesianProd(NN):
         else:
             self.activation_branch = self.activation_trunk = activations.get(activation)
         self.kernel_initializer = kernel_initializer
-        self.regularization = regularization  # TODO: currently unused
 
         self.num_outputs = num_outputs
         if self.num_outputs == 1:

--- a/deepxde/nn/pytorch/deeponet.py
+++ b/deepxde/nn/pytorch/deeponet.py
@@ -68,6 +68,7 @@ class DeepONet(NN):
         kernel_initializer,
         num_outputs=1,
         multi_output_strategy=None,
+        regularization=None,
     ):
         super().__init__()
         if isinstance(activation, dict):
@@ -76,6 +77,7 @@ class DeepONet(NN):
         else:
             self.activation_branch = self.activation_trunk = activations.get(activation)
         self.kernel_initializer = kernel_initializer
+        self.regularization = regularization  # TODO: currently unused
 
         self.num_outputs = num_outputs
         if self.num_outputs == 1:
@@ -190,6 +192,7 @@ class DeepONetCartesianProd(NN):
         kernel_initializer,
         num_outputs=1,
         multi_output_strategy=None,
+        regularization=None,
     ):
         super().__init__()
         if isinstance(activation, dict):
@@ -198,6 +201,7 @@ class DeepONetCartesianProd(NN):
         else:
             self.activation_branch = self.activation_trunk = activations.get(activation)
         self.kernel_initializer = kernel_initializer
+        self.regularization = regularization  # TODO: currently unused
 
         self.num_outputs = num_outputs
         if self.num_outputs == 1:
@@ -292,8 +296,10 @@ class PODDeepONet(NN):
         activation,
         kernel_initializer,
         layer_sizes_trunk=None,
+        regularization=None,
     ):
         super().__init__()
+        self.regularization = regularization  # TODO: currently unused
         self.pod_basis = torch.as_tensor(pod_basis, dtype=torch.float32)
         if isinstance(activation, dict):
             activation_branch = activation["branch"]

--- a/deepxde/nn/pytorch/deeponet.py
+++ b/deepxde/nn/pytorch/deeponet.py
@@ -13,7 +13,7 @@ from ..deeponet_strategy import (
     SplitTrunkStrategy,
 )
 from ... import config
-from ...backend import torch
+import torch
 
 
 class DeepONet(NN):
@@ -131,13 +131,13 @@ class DeepONet(NN):
     def concatenate_outputs(ys):
         return torch.concat(ys, dim=1)
 
-    def forward(self, inputs, training=False):
+    def forward(self, inputs):
         x_func = inputs[0]
         x_loc = inputs[1]
         # Trunk net input transform
         if self._input_transform is not None:
             x_loc = self._input_transform(x_loc)
-        x = self.multi_output_strategy.call(x_func, x_loc, training)
+        x = self.multi_output_strategy.call(x_func, x_loc)
         if self._output_transform is not None:
             x = self._output_transform(inputs, x)
         return x
@@ -253,13 +253,13 @@ class DeepONetCartesianProd(NN):
     def concatenate_outputs(ys):
         return torch.stack(ys, dim=2)
 
-    def forward(self, inputs, training=False):
+    def forward(self, inputs):
         x_func = inputs[0]
         x_loc = inputs[1]
         # Trunk net input transform
         if self._input_transform is not None:
             x_loc = self._input_transform(x_loc)
-        x = self.multi_output_strategy.call(x_func, x_loc, training)
+        x = self.multi_output_strategy.call(x_func, x_loc)
         if self._output_transform is not None:
             x = self._output_transform(inputs, x)
         return x
@@ -319,7 +319,7 @@ class PODDeepONet(NN):
             )
             self.b = torch.nn.parameter.Parameter(torch.tensor(0.0))
 
-    def forward(self, inputs, training=False):
+    def forward(self, inputs):
         x_func = inputs[0]
         x_loc = inputs[1]
 

--- a/deepxde/nn/pytorch/deeponet.py
+++ b/deepxde/nn/pytorch/deeponet.py
@@ -1,7 +1,5 @@
 __all__ = ["DeepONet", "DeepONetCartesianProd", "PODDeepONet"]
 
-from itertools import cycle
-
 import torch
 
 from .fnn import FNN
@@ -106,10 +104,9 @@ class DeepONet(NN):
             self.branch = torch.nn.ModuleList(self.branch)
         if isinstance(self.trunk, list):
             self.trunk = torch.nn.ModuleList(self.trunk)
-        self.biases = torch.nn.ParameterList(
+        self.b = torch.nn.ParameterList(
             [torch.nn.Parameter(torch.tensor(0.0)) for _ in range(self.num_outputs)]
         )
-        self.b = cycle(range(self.num_outputs))
 
     def build_branch_net(self, layer_sizes_branch):
         # User-defined network
@@ -121,10 +118,10 @@ class DeepONet(NN):
     def build_trunk_net(self, layer_sizes_trunk):
         return FNN(layer_sizes_trunk, self.activation_trunk, self.kernel_initializer)
 
-    def merge_branch_trunk(self, x_func, x_loc):
+    def merge_branch_trunk(self, x_func, x_loc, index):
         y = torch.einsum("bi,bi->b", x_func, x_loc)
         y = torch.unsqueeze(y, dim=1)
-        y += self.biases[next(self.b)]
+        y += self.b[index]
         return y
 
     @staticmethod
@@ -229,10 +226,9 @@ class DeepONetCartesianProd(NN):
             self.branch = torch.nn.ModuleList(self.branch)
         if isinstance(self.trunk, list):
             self.trunk = torch.nn.ModuleList(self.trunk)
-        self.biases = torch.nn.ParameterList(
+        self.b = torch.nn.ParameterList(
             [torch.nn.Parameter(torch.tensor(0.0)) for _ in range(self.num_outputs)]
         )
-        self.b = cycle(range(self.num_outputs))
 
     def build_branch_net(self, layer_sizes_branch):
         # User-defined network
@@ -244,9 +240,9 @@ class DeepONetCartesianProd(NN):
     def build_trunk_net(self, layer_sizes_trunk):
         return FNN(layer_sizes_trunk, self.activation_trunk, self.kernel_initializer)
 
-    def merge_branch_trunk(self, x_func, x_loc):
+    def merge_branch_trunk(self, x_func, x_loc, index):
         y = torch.einsum("bi,ni->bn", x_func, x_loc)
-        y += self.biases[next(self.b)]
+        y += self.b[index]
         return y
 
     @staticmethod

--- a/deepxde/nn/pytorch/deeponet.py
+++ b/deepxde/nn/pytorch/deeponet.py
@@ -1,24 +1,65 @@
-import torch
+__all__ = ["DeepONet", "DeepONetCartesianProd", "PODDeepONet"]
+
+from itertools import cycle
 
 from .fnn import FNN
 from .nn import NN
 from .. import activations
+from ... import config
+from ...backend import torch
+from ..deeponet_strategy import (
+    SingleOutputStrategy,
+    IndependentStrategy,
+    SplitBothStrategy,
+    SplitBranchStrategy,
+    SplitTrunkStrategy,
+)
 
 
 class DeepONet(NN):
     """Deep operator network.
 
+    `Lu et al. Learning nonlinear operators via DeepONet based on the universal
+    approximation theorem of operators. Nat Mach Intell, 2021.
+    <https://doi.org/10.1038/s42256-021-00302-5>`_
+
     Args:
         layer_sizes_branch: A list of integers as the width of a fully connected network,
             or `(dim, f)` where `dim` is the input dimension and `f` is a network
-            function. The width of the last layer in the branch and trunk net should be
-            equal.
+            function. The width of the last layer in the branch and trunk net
+            should be the same for all strategies except "split_branch" and "split_trunk".
         layer_sizes_trunk (list): A list of integers as the width of a fully connected
             network.
         activation: If `activation` is a ``string``, then the same activation is used in
             both trunk and branch nets. If `activation` is a ``dict``, then the trunk
             net uses the activation `activation["trunk"]`, and the branch net uses
             `activation["branch"]`.
+        num_outputs (integer): Number of outputs. In case of multiple outputs, i.e., `num_outputs` > 1,
+            `multi_output_strategy` below should be set.
+        multi_output_strategy (str or None): ``None``, "independent", "split_both", "split_branch" or
+            "split_trunk". It makes sense to set in case of multiple outputs.
+
+            - None
+            Classical implementation of DeepONet with a single output.
+            Cannot be used with `num_outputs` > 1.
+
+            - independent
+            Use `num_outputs` independent DeepONets, and each DeepONet outputs only
+            one function.
+
+            - split_both
+            Split the outputs of both the branch net and the trunk net into `num_outputs`
+            groups, and then the kth group outputs the kth solution.
+
+            - split_branch
+            Split the branch net and share the trunk net. The width of the last layer
+            in the branch net should be equal to the one in the trunk net multiplied
+            by the number of outputs.
+
+            - split_trunk
+            Split the trunk net and share the branch net. The width of the last layer
+            in the trunk net should be equal to the one in the branch net multiplied
+            by the number of outputs.
     """
 
     def __init__(
@@ -27,40 +68,75 @@ class DeepONet(NN):
         layer_sizes_trunk,
         activation,
         kernel_initializer,
+        num_outputs=1,
+        multi_output_strategy=None,
     ):
         super().__init__()
         if isinstance(activation, dict):
-            activation_branch = activations.get(activation["branch"])
+            self.activation_branch = activation["branch"]
             self.activation_trunk = activations.get(activation["trunk"])
         else:
-            activation_branch = self.activation_trunk = activations.get(activation)
-        if callable(layer_sizes_branch[1]):
-            # User-defined network
-            self.branch = layer_sizes_branch[1]
-        else:
-            # Fully connected network
-            self.branch = FNN(layer_sizes_branch, activation_branch, kernel_initializer)
-        self.trunk = FNN(layer_sizes_trunk, self.activation_trunk, kernel_initializer)
-        self.b = torch.nn.parameter.Parameter(torch.tensor(0.0))
+            self.activation_branch = self.activation_trunk = activations.get(activation)
+        self.kernel_initializer = kernel_initializer
 
-    def forward(self, inputs):
+        self.num_outputs = num_outputs
+        if self.num_outputs == 1:
+            if multi_output_strategy is not None:
+                raise ValueError(
+                    "num_outputs is set to 1, but multi_output_strategy is not None."
+                )
+        elif multi_output_strategy is None:
+            multi_output_strategy = "independent"
+            print(
+                f"Warning: There are {num_outputs} outputs, but no multi_output_strategy selected. "
+                'Use "independent" as the multi_output_strategy.'
+            )
+        self.multi_output_strategy = {
+            None: SingleOutputStrategy,
+            "independent": IndependentStrategy,
+            "split_both": SplitBothStrategy,
+            "split_branch": SplitBranchStrategy,
+            "split_trunk": SplitTrunkStrategy,
+        }[multi_output_strategy](self)
+
+        self.branch, self.trunk = self.multi_output_strategy.build(
+            layer_sizes_branch, layer_sizes_trunk
+        )
+
+        self.b = cycle(
+            [
+                torch.nn.parameter.Parameter(torch.tensor(0.0))
+                for _ in range(self.num_outputs)
+            ]
+        )
+
+    def build_branch_net(self, layer_sizes_branch):
+        # User-defined network
+        if callable(layer_sizes_branch[1]):
+            return layer_sizes_branch[1]
+        # Fully connected network
+        return FNN(layer_sizes_branch, self.activation_branch, self.kernel_initializer)
+
+    def build_trunk_net(self, layer_sizes_trunk):
+        return FNN(layer_sizes_trunk, self.activation_trunk, self.kernel_initializer)
+
+    def merge_branch_trunk(self, x_func, x_loc):
+        y = torch.einsum("bi,bi->b", x_func, x_loc)
+        y = torch.unsqueeze(y, dim=1)
+        y += next(self.b)
+        return y
+
+    @staticmethod
+    def concatenate_outputs(ys):
+        return torch.concat(ys, dim=1)
+
+    def forward(self, inputs, training=False):
         x_func = inputs[0]
         x_loc = inputs[1]
-        # Branch net to encode the input function
-        x_func = self.branch(x_func)
-        # Trunk net to encode the domain of the output function
+        # Trunk net input transform
         if self._input_transform is not None:
             x_loc = self._input_transform(x_loc)
-        x_loc = self.activation_trunk(self.trunk(x_loc))
-        # Dot product
-        if x_func.shape[-1] != x_loc.shape[-1]:
-            raise AssertionError(
-                "Output sizes of branch net and trunk net do not match."
-            )
-        x = torch.einsum("bi,bi->b", x_func, x_loc)
-        x = torch.unsqueeze(x, 1)
-        # Add bias
-        x += self.b
+        x = self.multi_output_strategy.call(x_func, x_loc, training)
         if self._output_transform is not None:
             x = self._output_transform(inputs, x)
         return x
@@ -72,14 +148,40 @@ class DeepONetCartesianProd(NN):
     Args:
         layer_sizes_branch: A list of integers as the width of a fully connected network,
             or `(dim, f)` where `dim` is the input dimension and `f` is a network
-            function. The width of the last layer in the branch and trunk net should be
-            equal.
+            function. The width of the last layer in the branch and trunk net
+            should be the same for all strategies except "split_branch" and "split_trunk".
         layer_sizes_trunk (list): A list of integers as the width of a fully connected
             network.
         activation: If `activation` is a ``string``, then the same activation is used in
             both trunk and branch nets. If `activation` is a ``dict``, then the trunk
             net uses the activation `activation["trunk"]`, and the branch net uses
             `activation["branch"]`.
+        num_outputs (integer): Number of outputs. In case of multiple outputs, i.e., `num_outputs` > 1,
+            `multi_output_strategy` below should be set.
+        multi_output_strategy (str or None): ``None``, "independent", "split_both", "split_branch" or
+            "split_trunk". It makes sense to set in case of multiple outputs.
+
+            - None
+            Classical implementation of DeepONet with a single output.
+            Cannot be used with `num_outputs` > 1.
+
+            - independent
+            Use `num_outputs` independent DeepONets, and each DeepONet outputs only
+            one function.
+
+            - split_both
+            Split the outputs of both the branch net and the trunk net into `num_outputs`
+            groups, and then the kth group outputs the kth solution.
+
+            - split_branch
+            Split the branch net and share the trunk net. The width of the last layer
+            in the branch net should be equal to the one in the trunk net multiplied
+            by the number of outputs.
+
+            - split_trunk
+            Split the trunk net and share the branch net. The width of the last layer
+            in the trunk net should be equal to the one in the branch net multiplied
+            by the number of outputs.
     """
 
     def __init__(
@@ -88,42 +190,74 @@ class DeepONetCartesianProd(NN):
         layer_sizes_trunk,
         activation,
         kernel_initializer,
-        regularization=None,
+        num_outputs=1,
+        multi_output_strategy=None,
     ):
         super().__init__()
         if isinstance(activation, dict):
-            activation_branch = activations.get(activation["branch"])
+            self.activation_branch = activation["branch"]
             self.activation_trunk = activations.get(activation["trunk"])
         else:
-            activation_branch = self.activation_trunk = activations.get(activation)
-        if callable(layer_sizes_branch[1]):
-            # User-defined network
-            self.branch = layer_sizes_branch[1]
-        else:
-            # Fully connected network
-            self.branch = FNN(layer_sizes_branch, activation_branch, kernel_initializer)
-        self.trunk = FNN(layer_sizes_trunk, self.activation_trunk, kernel_initializer)
-        self.b = torch.nn.parameter.Parameter(torch.tensor(0.0))
-        self.regularizer = regularization
+            self.activation_branch = self.activation_trunk = activations.get(activation)
+        self.kernel_initializer = kernel_initializer
 
-    def forward(self, inputs):
+        self.num_outputs = num_outputs
+        if self.num_outputs == 1:
+            if multi_output_strategy is not None:
+                raise ValueError(
+                    "num_outputs is set to 1, but multi_output_strategy is not None."
+                )
+        elif multi_output_strategy is None:
+            multi_output_strategy = "independent"
+            print(
+                f"Warning: There are {num_outputs} outputs, but no multi_output_strategy selected. "
+                'Use "independent" as the multi_output_strategy.'
+            )
+        self.multi_output_strategy = {
+            None: SingleOutputStrategy,
+            "independent": IndependentStrategy,
+            "split_both": SplitBothStrategy,
+            "split_branch": SplitBranchStrategy,
+            "split_trunk": SplitTrunkStrategy,
+        }[multi_output_strategy](self)
+
+        self.branch, self.trunk = self.multi_output_strategy.build(
+            layer_sizes_branch, layer_sizes_trunk
+        )
+
+        self.b = cycle(
+            [
+                torch.nn.parameter.Parameter(torch.tensor(0.0))
+                for _ in range(self.num_outputs)
+            ]
+        )
+
+    def build_branch_net(self, layer_sizes_branch):
+        # User-defined network
+        if callable(layer_sizes_branch[1]):
+            return layer_sizes_branch[1]
+        # Fully connected network
+        return FNN(layer_sizes_branch, self.activation_branch, self.kernel_initializer)
+
+    def build_trunk_net(self, layer_sizes_trunk):
+        return FNN(layer_sizes_trunk, self.activation_trunk, self.kernel_initializer)
+
+    def merge_branch_trunk(self, x_func, x_loc):
+        y = torch.einsum("bi,ni->bn", x_func, x_loc)
+        y += next(self.b)
+        return y
+
+    @staticmethod
+    def concatenate_outputs(ys):
+        return torch.stack(ys, dim=2)
+
+    def forward(self, inputs, training=False):
         x_func = inputs[0]
         x_loc = inputs[1]
-        # Branch net to encode the input function
-        x_func = self.branch(x_func)
-        # Trunk net to encode the domain of the output function
+        # Trunk net input transform
         if self._input_transform is not None:
             x_loc = self._input_transform(x_loc)
-        x_loc = self.activation_trunk(self.trunk(x_loc))
-        # Dot product
-        if x_func.shape[-1] != x_loc.shape[-1]:
-            raise AssertionError(
-                "Output sizes of branch net and trunk net do not match."
-            )
-        x = torch.einsum("bi,ni->bn", x_func, x_loc)
-        # Add bias
-        x += self.b
-
+        x = self.multi_output_strategy.call(x_func, x_loc, training)
         if self._output_transform is not None:
             x = self._output_transform(inputs, x)
         return x
@@ -160,42 +294,46 @@ class PODDeepONet(NN):
         activation,
         kernel_initializer,
         layer_sizes_trunk=None,
-        regularization=None,
     ):
         super().__init__()
+        self.pod_basis = torch.as_tensor(pod_basis, dtype=torch.float32)
         if isinstance(activation, dict):
-            activation_branch = activations.get(activation["branch"])
+            activation_branch = activation["branch"]
             self.activation_trunk = activations.get(activation["trunk"])
         else:
             activation_branch = self.activation_trunk = activations.get(activation)
 
-        self.pod_basis = torch.as_tensor(pod_basis, dtype=torch.float32)
         if callable(layer_sizes_branch[1]):
             # User-defined network
             self.branch = layer_sizes_branch[1]
         else:
             # Fully connected network
             self.branch = FNN(layer_sizes_branch, activation_branch, kernel_initializer)
+
         self.trunk = None
         if layer_sizes_trunk is not None:
             self.trunk = FNN(
                 layer_sizes_trunk, self.activation_trunk, kernel_initializer
             )
             self.b = torch.nn.parameter.Parameter(torch.tensor(0.0))
-        self.regularizer = regularization
 
-    def forward(self, inputs):
+    def forward(self, inputs, training=False):
         x_func = inputs[0]
         x_loc = inputs[1]
 
+        # Branch net to encode the input function
         x_func = self.branch(x_func)
+        # Trunk net to encode the domain of the output function
         if self.trunk is None:
             # POD only
             x = torch.einsum("bi,ni->bn", x_func, self.pod_basis)
         else:
             x_loc = self.activation_trunk(self.trunk(x_loc))
-            x = torch.einsum("bi,ni->bn", x_func, torch.cat((self.pod_basis, x_loc), 1))
+            x = torch.einsum(
+                "bi,ni->bn", x_func, torch.concat((self.pod_basis, x_loc), 1)
+            )
             x += self.b
+
         if self._output_transform is not None:
             x = self._output_transform(inputs, x)
         return x

--- a/deepxde/nn/pytorch/deeponet.py
+++ b/deepxde/nn/pytorch/deeponet.py
@@ -2,6 +2,8 @@ __all__ = ["DeepONet", "DeepONetCartesianProd", "PODDeepONet"]
 
 from itertools import cycle
 
+import torch
+
 from .fnn import FNN
 from .nn import NN
 from .. import activations
@@ -12,8 +14,6 @@ from ..deeponet_strategy import (
     SplitBranchStrategy,
     SplitTrunkStrategy,
 )
-from ... import config
-import torch
 
 
 class DeepONet(NN):

--- a/deepxde/nn/pytorch/deeponet.py
+++ b/deepxde/nn/pytorch/deeponet.py
@@ -102,8 +102,10 @@ class DeepONet(NN):
         self.branch, self.trunk = self.multi_output_strategy.build(
             layer_sizes_branch, layer_sizes_trunk
         )
-        self.branch = torch.nn.ModuleList(self.branch)
-        self.trunk = torch.nn.ModuleList(self.trunk)
+        if isinstance(self.branch, list):
+            self.branch = torch.nn.ModuleList(self.branch)
+        if isinstance(self.trunk, list):
+            self.trunk = torch.nn.ModuleList(self.trunk)
         self.biases = torch.nn.ParameterList(
             [torch.nn.Parameter(torch.tensor(0.0)) for _ in range(self.num_outputs)]
         )
@@ -223,8 +225,10 @@ class DeepONetCartesianProd(NN):
         self.branch, self.trunk = self.multi_output_strategy.build(
             layer_sizes_branch, layer_sizes_trunk
         )
-        self.branch = torch.nn.ModuleList(self.branch)
-        self.trunk = torch.nn.ModuleList(self.trunk)
+        if isinstance(self.branch, list):
+            self.branch = torch.nn.ModuleList(self.branch)
+        if isinstance(self.trunk, list):
+            self.trunk = torch.nn.ModuleList(self.trunk)
         self.biases = torch.nn.ParameterList(
             [torch.nn.Parameter(torch.tensor(0.0)) for _ in range(self.num_outputs)]
         )

--- a/deepxde/nn/pytorch/deeponet.py
+++ b/deepxde/nn/pytorch/deeponet.py
@@ -5,8 +5,6 @@ from itertools import cycle
 from .fnn import FNN
 from .nn import NN
 from .. import activations
-from ... import config
-from ...backend import torch
 from ..deeponet_strategy import (
     SingleOutputStrategy,
     IndependentStrategy,
@@ -14,6 +12,8 @@ from ..deeponet_strategy import (
     SplitBranchStrategy,
     SplitTrunkStrategy,
 )
+from ... import config
+from ...backend import torch
 
 
 class DeepONet(NN):

--- a/deepxde/nn/tensorflow/deeponet.py
+++ b/deepxde/nn/tensorflow/deeponet.py
@@ -1,6 +1,5 @@
 __all__ = ["DeepONet", "DeepONetCartesianProd", "PODDeepONet"]
 
-from abc import ABC, abstractmethod
 from itertools import cycle
 
 from .fnn import FNN
@@ -8,177 +7,13 @@ from .nn import NN
 from .. import activations
 from ... import config
 from ...backend import tf
-
-
-class DeepONetStrategy(ABC):
-    """DeepONet building strategy.
-
-    See the section 3.1.6. in
-    L. Lu, X. Meng, S. Cai, Z. Mao, S. Goswami, Z. Zhang, & G. Karniadakis.
-    A comprehensive and fair comparison of two neural operators
-    (with practical extensions) based on FAIR data.
-    Computer Methods in Applied Mechanics and Engineering, 393, 114778, 2022.
-    """
-
-    def __init__(self, net):
-        self.net = net
-
-    @abstractmethod
-    def build(self, layer_sizes_branch, layer_sizes_trunk):
-        """Build branch and trunk nets."""
-
-    @abstractmethod
-    def call(self, x_func, x_loc, training=False):
-        """Forward pass."""
-
-
-class SingleOutputStrategy(DeepONetStrategy):
-    """Single output build strategy is the standard build method."""
-
-    def build(self, layer_sizes_branch, layer_sizes_trunk):
-        if layer_sizes_branch[-1] != layer_sizes_trunk[-1]:
-            raise AssertionError(
-                "Output sizes of branch net and trunk net do not match."
-            )
-        branch = self.net.build_branch_net(layer_sizes_branch)
-        trunk = self.net.build_trunk_net(layer_sizes_trunk)
-        return branch, trunk
-
-    def call(self, x_func, x_loc, training=False):
-        x_func = self.net.branch(x_func)
-        x_loc = self.net.activation_trunk(self.net.trunk(x_loc))
-        if x_func.shape[-1] != x_loc.shape[-1]:
-            raise AssertionError(
-                "Output sizes of branch net and trunk net do not match."
-            )
-        x = self.net.merge_branch_trunk(x_func, x_loc)
-        return x
-
-
-class IndependentStrategy(DeepONetStrategy):
-    """Directly use n independent DeepONets,
-    and each DeepONet outputs only one function.
-    """
-
-    def build(self, layer_sizes_branch, layer_sizes_trunk):
-        single_output_strategy = SingleOutputStrategy(self.net)
-        branch, trunk = [], []
-        for _ in range(self.net.num_outputs):
-            branch_, trunk_ = single_output_strategy.build(
-                layer_sizes_branch, layer_sizes_trunk
-            )
-            branch.append(branch_)
-            trunk.append(trunk_)
-        return branch, trunk
-
-    def call(self, x_func, x_loc, training=False):
-        xs = []
-        for i in range(self.net.num_outputs):
-            x_func_ = self.net.branch[i](x_func)
-            x_loc_ = self.net.activation_trunk(self.net.trunk[i](x_loc))
-            x = self.net.merge_branch_trunk(x_func_, x_loc_)
-            xs.append(x)
-        return self.net.concatenate_outputs(xs)
-
-
-class SplitBothStrategy(DeepONetStrategy):
-    """Split the outputs of both the branch net and the trunk net into n groups,
-    and then the kth group outputs the kth solution.
-
-    For example, if n = 2 and both the branch and trunk nets have 100 output neurons,
-    then the dot product between the first 50 neurons of
-    the branch and trunk nets generates the first function,
-    and the remaining 50 neurons generate the second function.
-    """
-
-    def build(self, layer_sizes_branch, layer_sizes_trunk):
-        if layer_sizes_branch[-1] != layer_sizes_trunk[-1]:
-            raise AssertionError(
-                "Output sizes of branch net and trunk net do not match."
-            )
-        if layer_sizes_branch[-1] % self.net.num_outputs != 0:
-            raise AssertionError(
-                f"Output size of the branch net is not evenly divisible by {self.net.num_outputs}."
-            )
-        single_output_strategy = SingleOutputStrategy(self.net)
-        return single_output_strategy.build(layer_sizes_branch, layer_sizes_trunk)
-
-    def call(self, x_func, x_loc, training=False):
-        x_func = self.net.branch(x_func)
-        x_loc = self.net.activation_trunk(self.net.trunk(x_loc))
-        # Split x_func and x_loc into respective outputs
-        shift = 0
-        size = x_func.shape[1] // self.net.num_outputs
-        xs = []
-        for _ in range(self.net.num_outputs):
-            x_func_ = x_func[:, shift : shift + size]
-            x_loc_ = x_loc[:, shift : shift + size]
-            x = self.net.merge_branch_trunk(x_func_, x_loc_)
-            xs.append(x)
-            shift += size
-        return self.net.concatenate_outputs(xs)
-
-
-class SplitBranchStrategy(DeepONetStrategy):
-    """Split the branch net and share the trunk net."""
-
-    def build(self, layer_sizes_branch, layer_sizes_trunk):
-        if layer_sizes_branch[-1] % self.net.num_outputs != 0:
-            raise AssertionError(
-                f"Output size of the branch net is not evenly divisible by {self.net.num_outputs}."
-            )
-        if layer_sizes_branch[-1] / self.net.num_outputs != layer_sizes_trunk[-1]:
-            raise AssertionError(
-                f"Output size of the trunk net does not equal to {layer_sizes_branch[-1] // self.net.num_outputs}."
-            )
-        return self.net.build_branch_net(layer_sizes_branch), self.net.build_trunk_net(
-            layer_sizes_trunk
-        )
-
-    def call(self, x_func, x_loc, training=False):
-        x_func = self.net.branch(x_func)
-        x_loc = self.net.activation_trunk(self.net.trunk(x_loc))
-        # Split x_func into respective outputs
-        shift = 0
-        size = x_loc.shape[1]
-        xs = []
-        for _ in range(self.net.num_outputs):
-            x_func_ = x_func[:, shift : shift + size]
-            x = self.net.merge_branch_trunk(x_func_, x_loc)
-            xs.append(x)
-            shift += size
-        return self.net.concatenate_outputs(xs)
-
-
-class SplitTrunkStrategy(DeepONetStrategy):
-    """Split the trunk net and share the branch net."""
-
-    def build(self, layer_sizes_branch, layer_sizes_trunk):
-        if layer_sizes_trunk[-1] % self.net.num_outputs != 0:
-            raise AssertionError(
-                f"Output size of the trunk net is not evenly divisible by {self.net.num_outputs}."
-            )
-        if layer_sizes_trunk[-1] / self.net.num_outputs != layer_sizes_branch[-1]:
-            raise AssertionError(
-                f"Output size of the branch net does not equal to {layer_sizes_trunk[-1] // self.net.num_outputs}."
-            )
-        return self.net.build_branch_net(layer_sizes_branch), self.net.build_trunk_net(
-            layer_sizes_trunk
-        )
-
-    def call(self, x_func, x_loc, training=False):
-        x_func = self.net.branch(x_func)
-        x_loc = self.net.activation_trunk(self.net.trunk(x_loc))
-        # Split x_loc into respective outputs
-        shift = 0
-        size = x_func.shape[1]
-        xs = []
-        for _ in range(self.net.num_outputs):
-            x_loc_ = x_loc[:, shift : shift + size]
-            x = self.net.merge_branch_trunk(x_func, x_loc_)
-            xs.append(x)
-            shift += size
-        return self.net.concatenate_outputs(xs)
+from ..deeponet_strategy import (
+    SingleOutputStrategy,
+    IndependentStrategy,
+    SplitBothStrategy,
+    SplitBranchStrategy,
+    SplitTrunkStrategy,
+)
 
 
 class DeepONet(NN):

--- a/deepxde/nn/tensorflow/deeponet.py
+++ b/deepxde/nn/tensorflow/deeponet.py
@@ -1,7 +1,5 @@
 __all__ = ["DeepONet", "DeepONetCartesianProd", "PODDeepONet"]
 
-from itertools import cycle
-
 from .fnn import FNN
 from .nn import NN
 from .. import activations
@@ -105,12 +103,10 @@ class DeepONet(NN):
             layer_sizes_branch, layer_sizes_trunk
         )
 
-        self.b = cycle(
-            [
-                tf.Variable(tf.zeros(1, dtype=config.real(tf)))
-                for _ in range(self.num_outputs)
-            ]
-        )
+        self.b = [
+            tf.Variable(tf.zeros(1, dtype=config.real(tf)))
+            for _ in range(self.num_outputs)
+        ]
 
     def build_branch_net(self, layer_sizes_branch):
         # User-defined network
@@ -132,10 +128,10 @@ class DeepONet(NN):
             regularization=self.regularization,
         )
 
-    def merge_branch_trunk(self, x_func, x_loc):
+    def merge_branch_trunk(self, x_func, x_loc, index):
         y = tf.einsum("bi,bi->b", x_func, x_loc)
         y = tf.expand_dims(y, axis=1)
-        y += next(self.b)
+        y += self.b[index]
         return y
 
     @staticmethod
@@ -239,12 +235,10 @@ class DeepONetCartesianProd(NN):
             layer_sizes_branch, layer_sizes_trunk
         )
 
-        self.b = cycle(
-            [
-                tf.Variable(tf.zeros(1, dtype=config.real(tf)))
-                for _ in range(self.num_outputs)
-            ]
-        )
+        self.b = [
+            tf.Variable(tf.zeros(1, dtype=config.real(tf)))
+            for _ in range(self.num_outputs)
+        ]
 
     def build_branch_net(self, layer_sizes_branch):
         # User-defined network
@@ -266,9 +260,9 @@ class DeepONetCartesianProd(NN):
             regularization=self.regularization,
         )
 
-    def merge_branch_trunk(self, x_func, x_loc):
+    def merge_branch_trunk(self, x_func, x_loc, index):
         y = tf.einsum("bi,ni->bn", x_func, x_loc)
-        y += next(self.b)
+        y += self.b[index]
         return y
 
     @staticmethod

--- a/deepxde/nn/tensorflow/deeponet.py
+++ b/deepxde/nn/tensorflow/deeponet.py
@@ -148,7 +148,7 @@ class DeepONet(NN):
         # Trunk net input transform
         if self._input_transform is not None:
             x_loc = self._input_transform(x_loc)
-        x = self.multi_output_strategy.call(x_func, x_loc, training)
+        x = self.multi_output_strategy.call(x_func, x_loc)
         if self._output_transform is not None:
             x = self._output_transform(inputs, x)
         return x
@@ -281,7 +281,7 @@ class DeepONetCartesianProd(NN):
         # Trunk net input transform
         if self._input_transform is not None:
             x_loc = self._input_transform(x_loc)
-        x = self.multi_output_strategy.call(x_func, x_loc, training)
+        x = self.multi_output_strategy.call(x_func, x_loc)
         if self._output_transform is not None:
             x = self._output_transform(inputs, x)
         return x

--- a/deepxde/nn/tensorflow/deeponet.py
+++ b/deepxde/nn/tensorflow/deeponet.py
@@ -5,8 +5,6 @@ from itertools import cycle
 from .fnn import FNN
 from .nn import NN
 from .. import activations
-from ... import config
-from ...backend import tf
 from ..deeponet_strategy import (
     SingleOutputStrategy,
     IndependentStrategy,
@@ -14,6 +12,8 @@ from ..deeponet_strategy import (
     SplitBranchStrategy,
     SplitTrunkStrategy,
 )
+from ... import config
+from ...backend import tf
 
 
 class DeepONet(NN):


### PR DESCRIPTION
# How this was done

I made it in two steps:
1) moving the strategy classes from `tensorflow`'s `deeponet.py` to a separate file `deeponet_strategy.py` so that all backends can share it
2) adding strategeis to `pytorch` and `paddle` following the same way (with few synatx adaptions). Changes for `paddle` comes only after this PR is merged.

# Remaining Issue
I noted that in `call(self, x_func, x_loc, training=False)` of `DeepONetStrategy`, the argument `training` is completely unused. It is kept in this PR because I don't know if it serves some other purpose. I suggest removal of it.

# Tests
A file `test_strat.py` (renamed to `test_start.txt` for uploading) is attached in this description. It tests all the model classes (`DeepONet`, `DeepONetCartesianProd`, `PODDeepONet`) and strategy settings (single, independent, split both, split branch, split trunk), making sure that the forward pass yields the correct output shape. To reproduce the tests, put this file under the top directory and run

```bash
DDE_BACKEND=tensorflow python test_strat.py 
DDE_BACKEND=pytorch python test_strat.py 
DDE_BACKEND=paddle python test_strat.py
```

And you should see no errors.

[test_strat.txt](https://github.com/lululxvi/deepxde/files/13999388/test_strat.txt)