### PR TITLE
Add PFNN class to jax backend

### DIFF
--- a/deepxde/backend/jax/tensor.py
+++ b/deepxde/backend/jax/tensor.py
@@ -1,4 +1,5 @@
 """jax backend implementation"""
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -61,6 +62,14 @@ def to_numpy(input_tensor):
     return np.asarray(input_tensor)
 
 
+def concat(values, axis):
+    return jnp.concatenate(values, axis=axis)
+
+
+def stack(values, axis):
+    return jnp.stack(values, axis=axis)
+
+
 def elu(x):
     return jax.nn.elu(x)
 
@@ -83,6 +92,10 @@ def silu(x):
 
 def sin(x):
     return jnp.sin(x)
+
+
+def cos(x):
+    return jnp.cos(x)
 
 
 def square(x):

--- a/deepxde/backend/jax/tensor.py
+++ b/deepxde/backend/jax/tensor.py
@@ -1,5 +1,4 @@
 """jax backend implementation"""
-
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -62,14 +61,6 @@ def to_numpy(input_tensor):
     return np.asarray(input_tensor)
 
 
-def concat(values, axis):
-    return jnp.concatenate(values, axis=axis)
-
-
-def stack(values, axis):
-    return jnp.stack(values, axis=axis)
-
-
 def elu(x):
     return jax.nn.elu(x)
 
@@ -92,10 +83,6 @@ def silu(x):
 
 def sin(x):
     return jnp.sin(x)
-
-
-def cos(x):
-    return jnp.cos(x)
 
 
 def square(x):

--- a/deepxde/nn/jax/__init__.py
+++ b/deepxde/nn/jax/__init__.py
@@ -1,6 +1,6 @@
 """Package for jax NN modules."""
 
-__all__ = ["PFNN", "FNN", "NN"]
+__all__ = ["FNN", "NN","PFNN"]
 
 from .fnn import FNN, PFNN
 from .nn import NN

--- a/deepxde/nn/jax/__init__.py
+++ b/deepxde/nn/jax/__init__.py
@@ -1,6 +1,6 @@
 """Package for jax NN modules."""
 
-__all__ = ["PFNN","FNN", "NN"]
+__all__ = ["PFNN", "FNN", "NN"]
 
 from .fnn import FNN, PFNN
 from .nn import NN

--- a/deepxde/nn/jax/__init__.py
+++ b/deepxde/nn/jax/__init__.py
@@ -1,6 +1,6 @@
 """Package for jax NN modules."""
 
-__all__ = ["FNN", "NN","PFNN"]
+__all__ = ["FNN", "NN", "PFNN"]
 
 from .fnn import FNN, PFNN
 from .nn import NN

--- a/deepxde/nn/jax/__init__.py
+++ b/deepxde/nn/jax/__init__.py
@@ -1,6 +1,6 @@
 """Package for jax NN modules."""
 
-__all__ = ["FNN", "NN"]
+__all__ = ["PFNN","FNN", "NN"]
 
-from .fnn import FNN
+from .fnn import FNN, PFNN
 from .nn import NN

--- a/deepxde/nn/jax/fnn.py
+++ b/deepxde/nn/jax/fnn.py
@@ -69,8 +69,8 @@ class PFNN(NN):
             an int layer, the output of each sub-layer will be concatenated and fed into
             the int layer. Two consecutive list layers must have the same length.
             If the last layer is a list, it specifies the output size for each subnetwork
-            before concatenation. If the last layer is an int preceded by a list layer,
-            layer_sizes[-1] must be equal to the number of subnetworks (=len(layer_sizes[-2])).
+            before concatenation. If the last layer is an int and preceded by a list layer,
+            the output size must be equal to the number of subnetworks (=len(layer_sizes[-2])).
     """
 
     layer_sizes: Any
@@ -118,7 +118,8 @@ class PFNN(NN):
                     raise ValueError(
                         "number of sub-networks should be the same between two consecutive list layers"
                     )
-                denses.append([make_dense(unit) for unit in curr_layer_size])
+                else:
+                    denses.append([make_dense(unit) for unit in curr_layer_size])
 
         if isinstance(self.layer_sizes[-1], int):
             if isinstance(self.layer_sizes[-2], (list, tuple)):
@@ -129,7 +130,8 @@ class PFNN(NN):
                     raise ValueError(
                         "if layer_sizes[-1] is an int and layer_sizes[-2] is a list, len(layer_sizes[-2]) must be equal to layer_sizes[-1]"
                     )
-                denses.append([make_dense(1) for _ in range(self.layer_sizes[-1])])
+                else:
+                    denses.append([make_dense(1) for _ in range(self.layer_sizes[-1])])
             else:
                 denses.append(make_dense(self.layer_sizes[-1]))
         else:

--- a/deepxde/nn/jax/fnn.py
+++ b/deepxde/nn/jax/fnn.py
@@ -57,6 +57,7 @@ class FNN(NN):
             x = self._output_transform(inputs, x)
         return x
 
+
 class PFNN(NN):
     """Parallel fully-connected network that uses independent sub-networks for each
     network output.
@@ -83,16 +84,27 @@ class PFNN(NN):
             raise ValueError("must specify input and output sizes")
         if not isinstance(self.layer_sizes[0], int):
             raise ValueError("input size must be integer")
-        
-        list_layer = [layer_size for layer_size in self.layer_sizes if isinstance(layer_size, (list,tuple))]
-        if not list_layer: # if there is only one subnetwork (=FNN)
+
+        list_layer = [
+            layer_size
+            for layer_size in self.layer_sizes
+            if isinstance(layer_size, (list, tuple))
+        ]
+        if not list_layer:  # if there is only one subnetwork (=FNN)
             n_subnetworks = 1
         else:
             n_subnetworks = len(list_layer[0])
             if not all(len(sublist) == n_subnetworks for sublist in list_layer):
-                raise ValueError("all layer_size lists must have the same length(=number of subnetworks)")
-            if isinstance(self.layer_sizes[-1], int) and n_subnetworks != self.layer_sizes[-1]:
-                raise ValueError("if output layer is an integer, it must be equal to the number of subnetworks")
+                raise ValueError(
+                    "all layer_size lists must have the same length(=number of subnetworks)"
+                )
+            if (
+                isinstance(self.layer_sizes[-1], int)
+                and n_subnetworks != self.layer_sizes[-1]
+            ):
+                raise ValueError(
+                    "if output layer is an integer, it must be equal to the number of subnetworks"
+                )
 
         self._activation = activations.get(self.activation)
         kernel_initializer = initializers.get(self.kernel_initializer)
@@ -106,20 +118,20 @@ class PFNN(NN):
             )
 
         denses = [
-            make_dense(unit)
-            if isinstance(unit, int)
-            else [
-                make_dense(unit[j])
-                for j in range(n_subnetworks)
-            ]
+            (
+                make_dense(unit)
+                if isinstance(unit, int)
+                else [make_dense(unit[j]) for j in range(n_subnetworks)]
+            )
             for unit in self.layer_sizes[1:-1]
         ]
 
-        if n_subnetworks == 1: # if there is only one subnetwork (=FNN), the output layer is a single dense layer
+        if n_subnetworks == 1:
+            # if there is only one subnetwork (=FNN), the output layer is a single dense layer
             denses.append(make_dense(self.layer_sizes[-1]))
         else:
             if isinstance(self.layer_sizes[-1], int):
-                # if output layer size is an int (=number of subnetworks) and there is more than one subnetwork, 
+                # if output layer size is an int (=number of subnetworks) and there is more than one subnetwork,
                 # all subnetworks have an output size of 1 and are then concatenated
                 denses.append([make_dense(1)] * n_subnetworks)
             else:
@@ -146,7 +158,7 @@ class PFNN(NN):
                 x = self._activation(layer(x))
 
         # concatenate subnetwork outputs
-        if isinstance(x, (list,tuple)):
+        if isinstance(x, (list, tuple)):
             if x[0].ndim == 1:
                 x = jnp.concatenate(x, axis=0)
             else:

--- a/deepxde/nn/jax/fnn.py
+++ b/deepxde/nn/jax/fnn.py
@@ -1,6 +1,7 @@
 from typing import Any, Callable
 
 import jax
+import jax.numpy as jnp
 from flax import linen as nn
 
 from .nn import NN
@@ -52,6 +53,94 @@ class FNN(NN):
                 else self._activation(linear(x))
             )
         x = self.denses[-1](x)
+        if self._output_transform is not None:
+            x = self._output_transform(inputs, x)
+        return x
+
+class PFNN(NN):
+    """Parallel fully-connected network that uses independent sub-networks for each
+    network output.
+
+    Args:
+        layer_sizes: A nested list that defines the architecture of the neural network
+            (how the layers are connected). If `layer_sizes[i]` is an int, it represents
+            one layer shared by all the outputs; if `layer_sizes[i]` is a list, it
+            represents `len(layer_sizes[i])` sub-layers, each of which is exclusively
+            used by one output. Note that `len(layer_sizes[i])` should equal the number
+            of outputs. Every number specifies the number of neurons in that layer.
+    """
+
+    layer_sizes: Any
+    activation: Any
+    kernel_initializer: Any
+
+    params: Any = None
+    _input_transform: Callable = None
+    _output_transform: Callable = None
+
+    def setup(self):
+        if len(self.layer_sizes) <= 1:
+            raise ValueError("must specify input and output sizes")
+        if not isinstance(self.layer_sizes[0], int):
+            raise ValueError("input size must be integer")
+        if not isinstance(self.layer_sizes[-1], int):
+            raise ValueError("output size must be integer")
+
+        n_output = self.layer_sizes[-1]
+
+        self._activation = activations.get(self.activation)
+        kernel_initializer = initializers.get(self.kernel_initializer)
+        initializer = jax.nn.initializers.zeros
+
+        def make_dense(unit):
+            return nn.Dense(
+                unit,
+                kernel_init=kernel_initializer,
+                bias_init=initializer,
+            )
+
+        denses = [
+            make_dense(unit)
+            if isinstance(unit, int)
+            else [
+                make_dense(unit[j])
+                for j in range(n_output)
+            ]
+            for unit in self.layer_sizes[1:-1]
+        ]
+
+        if any(isinstance(unit, (list, tuple)) for unit in self.layer_sizes):
+            denses.append([make_dense(1)] * n_output)
+        else:
+            denses.append(make_dense(n_output))
+
+        self.denses = denses #can't assign directly to self.denses because linen list attributes are converted to tuple, see https://github.com/google/flax/issues/524
+
+    def __call__(self, inputs, training=False):
+        x = inputs
+        if self._input_transform is not None:
+            x = self._input_transform(x)
+
+        for layer in self.denses[:-1]:
+            if isinstance(layer, (list, tuple)):
+                if isinstance(x, list):
+                    x = [self._activation(dense(x_)) for dense, x_ in zip(layer, x)]
+                else:
+                    x = [self._activation(dense(x)) for dense in layer]
+            elif isinstance(x, list):
+                x = [self._activation(layer(x_)) for x_ in x]
+            else:
+                x = self._activation(layer(x))
+
+        # output layers
+        if isinstance(x, list):
+            if x[0].ndim == 1:
+                x = jnp.concatenate([f(x_) for f, x_ in zip(self.denses[-1], x)], axis=0)
+            else:
+                x = jnp.concatenate([f(x_) for f, x_ in zip(self.denses[-1], x)], axis=1)
+        else:
+            x = self.denses[-1](x)
+
         if self._output_transform is not None:
             x = self._output_transform(inputs, x)
         return x

--- a/deepxde/nn/jax/fnn.py
+++ b/deepxde/nn/jax/fnn.py
@@ -114,7 +114,8 @@ class PFNN(NN):
         else:
             denses.append(make_dense(n_output))
 
-        self.denses = denses #can't assign directly to self.denses because linen list attributes are converted to tuple, see https://github.com/google/flax/issues/524
+        self.denses = denses  # can't assign directly to self.denses because linen list attributes are converted to tuple
+        # see https://github.com/google/flax/issues/524
 
     def __call__(self, inputs, training=False):
         x = inputs

--- a/deepxde/nn/jax/fnn.py
+++ b/deepxde/nn/jax/fnn.py
@@ -67,10 +67,12 @@ class PFNN(NN):
             (how the layers are connected). If `layer_sizes[i]` is an int, it represents
             one layer shared by all the outputs; if `layer_sizes[i]` is a list, it
             represents `len(layer_sizes[i])` sub-layers, each of which is exclusively
-            used by one output. Every layer_sizes[i] list must have the same length (= number of subnetworks).
-            If the last element of `layer_sizes` is an int (=number of output), it must be equal to the number
-            of subnetworks: all subnetworks have an output size of 1 and are then concatenated.
-            If the last element is a list, it specifies the output size for each subnetwork before concatenation.
+            used by one output. Every layer_sizes[i] list must have the same length 
+            (= number of subnetworks). If the last element of `layer_sizes` is an int 
+            (= output size), it must be equal to the number of subnetworks: all 
+            subnetworks have an output size of 1 and are then concatenated. If the last
+            element is a list, it specifies the output size for each subnetwork before 
+            concatenation.
     """
 
     layer_sizes: Any

--- a/deepxde/nn/jax/fnn.py
+++ b/deepxde/nn/jax/fnn.py
@@ -45,10 +45,7 @@ class FNN(NN):
     def __call__(self, inputs, training=False):
         x = inputs
         if self._input_transform is not None:
-            if x.ndim == 1:
-                x = self._input_transform(x.reshape(1, -1)).squeeze()
-            else:
-                x = self._input_transform(x)
+            x = self._input_transform(x)
         for j, linear in enumerate(self.denses[:-1]):
             x = (
                 self._activation[j](linear(x))
@@ -57,12 +54,7 @@ class FNN(NN):
             )
         x = self.denses[-1](x)
         if self._output_transform is not None:
-            if x.ndim == 1:
-                x = self._output_transform(
-                    inputs.reshape(1, -1), x.reshape(1, -1)
-                ).squeeze()
-            else:
-                x = self._output_transform(inputs, x)
+            x = self._output_transform(inputs, x)
         return x
 
 
@@ -152,10 +144,7 @@ class PFNN(NN):
     def __call__(self, inputs, training=False):
         x = inputs
         if self._input_transform is not None:
-            if x.ndim == 1:
-                x = self._input_transform(x.reshape(1, -1)).squeeze()
-            else:
-                x = self._input_transform(x)
+            x = self._input_transform(x)
 
         for layer in self.denses:
             if isinstance(layer, (list, tuple)):
@@ -176,10 +165,5 @@ class PFNN(NN):
                 x = jnp.concatenate(x, axis=1)
 
         if self._output_transform is not None:
-            if x.ndim == 1:
-                x = self._output_transform(
-                    inputs.reshape(1, -1), x.reshape(1, -1)
-                ).squeeze()
-            else:
-                x = self._output_transform(inputs, x).squeeze()
+            x = self._output_transform(inputs, x)
         return x

--- a/deepxde/nn/jax/fnn.py
+++ b/deepxde/nn/jax/fnn.py
@@ -69,8 +69,8 @@ class PFNN(NN):
             an int layer, the output of each sub-layer will be concatenated and fed into
             the int layer. Two consecutive list layers must have the same length.
             If the last layer is a list, it specifies the output size for each subnetwork
-            before concatenation. If the last layer is an int and preceded by a list layer,
-            the output size must be equal to the number of subnetworks (=len(layer_sizes[-2])).
+            before concatenation. If the last layer is an int preceded by a list layer,
+            layer_sizes[-1] must be equal to the number of subnetworks (=len(layer_sizes[-2])).
     """
 
     layer_sizes: Any
@@ -118,8 +118,7 @@ class PFNN(NN):
                     raise ValueError(
                         "number of sub-networks should be the same between two consecutive list layers"
                     )
-                else:
-                    denses.append([make_dense(unit) for unit in curr_layer_size])
+                denses.append([make_dense(unit) for unit in curr_layer_size])
 
         if isinstance(self.layer_sizes[-1], int):
             if isinstance(self.layer_sizes[-2], (list, tuple)):
@@ -130,8 +129,7 @@ class PFNN(NN):
                     raise ValueError(
                         "if layer_sizes[-1] is an int and layer_sizes[-2] is a list, len(layer_sizes[-2]) must be equal to layer_sizes[-1]"
                     )
-                else:
-                    denses.append([make_dense(1) for _ in range(self.layer_sizes[-1])])
+                denses.append([make_dense(1) for _ in range(self.layer_sizes[-1])])
             else:
                 denses.append(make_dense(self.layer_sizes[-1]))
         else:

--- a/deepxde/nn/jax/fnn.py
+++ b/deepxde/nn/jax/fnn.py
@@ -134,7 +134,7 @@ class PFNN(NN):
         if isinstance(self.layer_sizes[-1], int):
             # if output layer size is an int (=number of subnetworks),
             # all subnetworks have an output size of 1 and are then concatenated
-            denses.append([make_dense(1)] * n_subnetworks)
+            denses.append([make_dense(1) for _ in range(n_subnetworks)])
         else:
             # if the output layer size is a list, it specifies the output size for each subnetwork before concatenation
             denses.append([make_dense(unit) for unit in self.layer_sizes[-1]])

--- a/deepxde/nn/jax/fnn.py
+++ b/deepxde/nn/jax/fnn.py
@@ -85,13 +85,13 @@ class PFNN(NN):
             raise ValueError("input size must be integer")
         
         list_layer = [layer_size for layer_size in self.layer_sizes if isinstance(layer_size, (list,tuple))]
-        if not list_layer:
+        if not list_layer: # if there is only one subnetwork (=FNN)
             n_subnetworks = 1
         else:
             n_subnetworks = len(list_layer[0])
             if not all(len(sublist) == n_subnetworks for sublist in list_layer):
                 raise ValueError("all layer_size lists must have the same length(=number of subnetworks)")
-        if isinstance(self.layer_sizes[-1], int) and n_subnetworks != self.layer_sizes[-1]:
+            if isinstance(self.layer_sizes[-1], int) and n_subnetworks != self.layer_sizes[-1]:
                 raise ValueError("if output layer is an integer, it must be equal to the number of subnetworks")
 
         self._activation = activations.get(self.activation)

--- a/deepxde/nn/jax/fnn.py
+++ b/deepxde/nn/jax/fnn.py
@@ -67,11 +67,11 @@ class PFNN(NN):
             (how the layers are connected). If `layer_sizes[i]` is an int, it represents
             one layer shared by all the outputs; if `layer_sizes[i]` is a list, it
             represents `len(layer_sizes[i])` sub-layers, each of which is exclusively
-            used by one output. Every layer_sizes[i] list must have the same length 
-            (= number of subnetworks). If the last element of `layer_sizes` is an int 
-            preceded by a list, it must be equal to the number of subnetworks: all 
+            used by one output. Every layer_sizes[i] list must have the same length
+            (= number of subnetworks). If the last element of `layer_sizes` is an int
+            preceded by a list, it must be equal to the number of subnetworks: all
             subnetworks have an output size of 1 and are then concatenated. If the last
-            element is a list, it specifies the output size for each subnetwork before 
+            element is a list, it specifies the output size for each subnetwork before
             concatenation.
     """
 
@@ -143,7 +143,6 @@ class PFNN(NN):
         else:
             # if the output layer size is a list, it specifies the output size for each subnetwork before concatenation
             denses.append([make_dense(unit) for unit in self.layer_sizes[-1]])
-
 
         self.denses = denses  # can't assign directly to self.denses because linen list attributes are converted to tuple
         # see https://github.com/google/flax/issues/524

--- a/deepxde/nn/jax/fnn.py
+++ b/deepxde/nn/jax/fnn.py
@@ -59,18 +59,20 @@ class FNN(NN):
 
 
 class PFNN(NN):
-    """Parallel fully-connected network that can have multiple subnetworks.
+    """Parallel fully-connected network that uses independent sub-networks for each
+    network output.
 
     Args:
         layer_sizes: A nested list that defines the architecture of the neural network
             (how the layers are connected). If `layer_sizes[i]` is an int, it represents
             one layer shared by all the outputs; if `layer_sizes[i]` is a list, it
-            represents `len(layer_sizes[i])` sub-layers. If a list layer is followed by
-            an int layer, the output of each sub-layer will be concatenated and fed into
-            the int layer. Two consecutive list layers must have the same length.
-            If the last layer is a list, it specifies the output size for each subnetwork
-            before concatenation. If the last layer is an int and preceded by a list layer,
-            the output size must be equal to the number of subnetworks (=len(layer_sizes[-2])).
+            represents `len(layer_sizes[i])` sub-layers, each of which is exclusively
+            used by one output. Every layer_sizes[i] list must have the same length 
+            (= number of subnetworks). If the last element of `layer_sizes` is an int 
+            (= output size), it must be equal to the number of subnetworks: all 
+            subnetworks have an output size of 1 and are then concatenated. If the last
+            element is a list, it specifies the output size for each subnetwork before 
+            concatenation.
     """
 
     layer_sizes: Any
@@ -87,11 +89,26 @@ class PFNN(NN):
         if not isinstance(self.layer_sizes[0], int):
             raise ValueError("input size must be integer")
 
-        if not any(
-            isinstance(layer_size, (list, tuple)) for layer_size in self.layer_sizes
-        ):
+        list_layer = [
+            layer_size
+            for layer_size in self.layer_sizes
+            if isinstance(layer_size, (list, tuple))
+        ]
+        if not list_layer:  # if there is only one subnetwork (=FNN)
             raise ValueError(
                 "no list in layer_sizes, use FNN instead of PFNN for single subnetwork"
+            )
+        n_subnetworks = len(list_layer[0])
+        if not all(len(sublist) == n_subnetworks for sublist in list_layer):
+            raise ValueError(
+                "all layer_size lists must have the same length(=number of subnetworks)"
+            )
+        if (
+            isinstance(self.layer_sizes[-1], int)
+            and n_subnetworks != self.layer_sizes[-1]
+        ):
+            raise ValueError(
+                "if the last element of layer_sizes is an int, it must be equal to the number of subnetworks"
             )
 
         self._activation = activations.get(self.activation)
@@ -105,35 +122,19 @@ class PFNN(NN):
                 bias_init=initializer,
             )
 
-        denses = []
-        for i in range(1, len(self.layer_sizes) - 1):
-            prev_layer_size = self.layer_sizes[i - 1]
-            curr_layer_size = self.layer_sizes[i]
-            if isinstance(curr_layer_size, int):
-                denses.append(make_dense(curr_layer_size))
-            else:
-                if isinstance(prev_layer_size, (list, tuple)) and len(
-                    prev_layer_size
-                ) != len(curr_layer_size):
-                    raise ValueError(
-                        "number of sub-networks should be the same between two consecutive list layers"
-                    )
-                else:
-                    denses.append([make_dense(unit) for unit in curr_layer_size])
+        denses = [
+            (
+                make_dense(unit)
+                if isinstance(unit, int)
+                else [make_dense(unit[j]) for j in range(n_subnetworks)]
+            )
+            for unit in self.layer_sizes[1:-1]
+        ]
 
         if isinstance(self.layer_sizes[-1], int):
-            if isinstance(self.layer_sizes[-2], (list, tuple)):
-                # if output layer size is an int and the previous layer size is a list,
-                # the output size must be equal to the number of subnetworks (=len(layer_sizes[-2])),
-                # then all subnetworks have an output size of 1 and are then concatenated
-                if len(self.layer_sizes[-2]) != self.layer_sizes[-1]:
-                    raise ValueError(
-                        "if layer_sizes[-1] is an int and layer_sizes[-2] is a list, len(layer_sizes[-2]) must be equal to layer_sizes[-1]"
-                    )
-                else:
-                    denses.append([make_dense(1) for _ in range(self.layer_sizes[-1])])
-            else:
-                denses.append(make_dense(self.layer_sizes[-1]))
+            # if output layer size is an int (=number of subnetworks),
+            # all subnetworks have an output size of 1 and are then concatenated
+            denses.append([make_dense(1) for _ in range(n_subnetworks)])
         else:
             # if the output layer size is a list, it specifies the output size for each subnetwork before concatenation
             denses.append([make_dense(unit) for unit in self.layer_sizes[-1]])
@@ -152,28 +153,16 @@ class PFNN(NN):
                     x = [self._activation(dense(x_)) for dense, x_ in zip(layer, x)]
                 else:
                     x = [self._activation(dense(x)) for dense in layer]
+            elif isinstance(x, list):
+                x = [self._activation(layer(x_)) for x_ in x]
             else:
-                if isinstance(x, list):
-                    x = jnp.concatenate(x, axis=0 if x[0].ndim == 1 else 1)
                 x = self._activation(layer(x))
 
         # output layers
-        if isinstance(x, list):
-            if len(x) != len(self.denses[-1]):
-                raise ValueError(
-                    "number of sub-networks should be the same between two consecutive list layers"
-                )
-            x = jnp.concatenate(
-                [f(x_) for f, x_ in zip(self.denses[-1], x)],
-                axis=0 if x[0].ndim == 1 else 1,
-            )
+        if x[0].ndim == 1:
+            x = jnp.concatenate([f(x_) for f, x_ in zip(self.denses[-1], x)], axis=0)
         else:
-            if isinstance(self.denses[-1], (list, tuple)):
-                x = jnp.concatenate(
-                    [f(x) for f in self.denses[-1]], axis=0 if x.ndim == 1 else 1
-                )
-            else:
-                x = self.denses[-1](x)
+            x = jnp.concatenate([f(x_) for f, x_ in zip(self.denses[-1], x)], axis=1)
 
         if self._output_transform is not None:
             x = self._output_transform(inputs, x)

--- a/deepxde/nn/jax/fnn.py
+++ b/deepxde/nn/jax/fnn.py
@@ -45,7 +45,10 @@ class FNN(NN):
     def __call__(self, inputs, training=False):
         x = inputs
         if self._input_transform is not None:
-            x = self._input_transform(x)
+            if x.ndim == 1:
+                x = self._input_transform(x.reshape(1, -1)).squeeze()
+            else:
+                x = self._input_transform(x)
         for j, linear in enumerate(self.denses[:-1]):
             x = (
                 self._activation[j](linear(x))
@@ -54,7 +57,12 @@ class FNN(NN):
             )
         x = self.denses[-1](x)
         if self._output_transform is not None:
-            x = self._output_transform(inputs, x)
+            if x.ndim == 1:
+                x = self._output_transform(
+                    inputs.reshape(1, -1), x.reshape(1, -1)
+                ).squeeze()
+            else:
+                x = self._output_transform(inputs, x)
         return x
 
 
@@ -144,7 +152,10 @@ class PFNN(NN):
     def __call__(self, inputs, training=False):
         x = inputs
         if self._input_transform is not None:
-            x = self._input_transform(x)
+            if x.ndim == 1:
+                x = self._input_transform(x.reshape(1, -1)).squeeze()
+            else:
+                x = self._input_transform(x)
 
         for layer in self.denses:
             if isinstance(layer, (list, tuple)):
@@ -165,5 +176,10 @@ class PFNN(NN):
                 x = jnp.concatenate(x, axis=1)
 
         if self._output_transform is not None:
-            x = self._output_transform(inputs, x)
+            if x.ndim == 1:
+                x = self._output_transform(
+                    inputs.reshape(1, -1), x.reshape(1, -1)
+                ).squeeze()
+            else:
+                x = self._output_transform(inputs, x).squeeze()
         return x

--- a/examples/pinn_forward/elasticity_plate.py
+++ b/examples/pinn_forward/elasticity_plate.py
@@ -1,10 +1,9 @@
-"""Backend supported: pytorch, paddle, jax
+"""Backend supported: pytorch, jax, paddle
 
 Implementation of the linear elasticity 2D example in paper https://doi.org/10.1016/j.cma.2021.113741.
 References:
     https://github.com/sciann/sciann-applications/blob/master/SciANN-Elasticity/Elasticity-Forward.ipynb.
 """
-
 import deepxde as dde
 import numpy as np
 

--- a/examples/pinn_forward/elasticity_plate.py
+++ b/examples/pinn_forward/elasticity_plate.py
@@ -4,6 +4,7 @@ Implementation of the linear elasticity 2D example in paper https://doi.org/10.1
 References:
     https://github.com/sciann/sciann-applications/blob/master/SciANN-Elasticity/Elasticity-Forward.ipynb.
 """
+
 import deepxde as dde
 import numpy as np
 
@@ -112,11 +113,13 @@ def fy(x):
         + 6 * Q * mu * x[:, 1:2] ** 2 * sin(np.pi * x[:, 0:1])
     )
 
+
 def jacobian(f, x, i, j):
     if dde.backend.backend_name == "jax":
-        return dde.grad.jacobian(f, x, i=i, j=j)[0] # second element is the function used by jax to compute the gradients
+        return dde.grad.jacobian(f, x, i=i, j=j)[0]
     else:
         return dde.grad.jacobian(f, x, i=i, j=j)
+
 
 def pde(x, f):
     E_xx = jacobian(f, x, i=0, j=0)
@@ -136,13 +139,14 @@ def pde(x, f):
     momentum_y = Sxy_x + Syy_y - fy(x)
 
     if dde.backend.backend_name == "jax":
-        f = f[0] # f[1] is the function used by jax to compute the gradients
+        f = f[0]  # f[1] is the function used by jax to compute the gradients
 
     stress_x = S_xx - f[:, 2:3]
     stress_y = S_yy - f[:, 3:4]
     stress_xy = S_xy - f[:, 4:5]
 
     return [momentum_x, momentum_y, stress_x, stress_y, stress_xy]
+
 
 data = dde.data.PDE(
     geom,

--- a/examples/pinn_forward/elasticity_plate.py
+++ b/examples/pinn_forward/elasticity_plate.py
@@ -13,13 +13,23 @@ mu = 0.5
 Q = 4.0
 
 # Define function
-sin = dde.backend.sin
-cos = dde.backend.cos
-stack = dde.backend.stack
-pi = dde.backend.as_tensor(np.pi)
+if dde.backend.backend_name == "pytorch":
+    import torch
+
+    sin = torch.sin
+    cos = torch.cos
+elif dde.backend.backend_name == "paddle":
+    import paddle
+
+    sin = paddle.sin
+    cos = paddle.cos
+elif dde.backend.backend_name == "jax":
+    import jax.numpy as jnp
+
+    sin = jnp.sin
+    cos = jnp.cos
 
 geom = dde.geometry.Rectangle([0, 0], [1, 1])
-BC_type = ["hard", "soft"][0]
 
 
 def boundary_left(x, on_boundary):
@@ -57,7 +67,6 @@ def func(x):
     return np.hstack((ux, uy, Sxx, Syy, Sxy))
 
 
-# Soft Boundary Conditions
 ux_top_bc = dde.icbc.DirichletBC(geom, lambda x: 0, boundary_top, component=0)
 ux_bottom_bc = dde.icbc.DirichletBC(geom, lambda x: 0, boundary_bottom, component=0)
 uy_left_bc = dde.icbc.DirichletBC(geom, lambda x: 0, boundary_left, component=1)
@@ -71,18 +80,6 @@ syy_top_bc = dde.icbc.DirichletBC(
     boundary_top,
     component=3,
 )
-
-
-# Hard Boundary Conditions
-def hard_BC(x, f):
-
-    Ux = f[:, 0] * x[:, 1] * (1 - x[:, 1])
-    Uy = f[:, 1] * x[:, 0] * (1 - x[:, 0]) * x[:, 1]
-
-    Sxx = f[:, 2] * x[:, 0] * (1 - x[:, 0])
-    Syy = f[:, 3] * (1 - x[:, 1]) + (lmbd + 2 * mu) * Q * sin(pi * x[:, 0])
-    Sxy = f[:, 4]
-    return stack((Ux, Uy, Sxx, Syy, Sxy), axis=1)
 
 
 def fx(x):
@@ -151,10 +148,10 @@ def pde(x, f):
     return [momentum_x, momentum_y, stress_x, stress_y, stress_xy]
 
 
-if BC_type == "hard":
-    bcs = []
-else:
-    bcs = [
+data = dde.data.PDE(
+    geom,
+    pde,
+    [
         ux_top_bc,
         ux_bottom_bc,
         uy_left_bc,
@@ -163,12 +160,7 @@ else:
         sxx_left_bc,
         sxx_right_bc,
         syy_top_bc,
-    ]
-
-data = dde.data.PDE(
-    geom,
-    pde,
-    bcs,
+    ],
     num_domain=500,
     num_boundary=500,
     solution=func,
@@ -179,8 +171,6 @@ layers = [2, [40] * 5, [40] * 5, [40] * 5, [40] * 5, 5]
 activation = "tanh"
 initializer = "Glorot uniform"
 net = dde.nn.PFNN(layers, activation, initializer)
-if BC_type == "hard":
-    net.apply_output_transform(hard_BC)
 
 model = dde.Model(data, net)
 model.compile("adam", lr=0.001, metrics=["l2 relative error"])

--- a/examples/pinn_forward/elasticity_plate.py
+++ b/examples/pinn_forward/elasticity_plate.py
@@ -13,23 +13,13 @@ mu = 0.5
 Q = 4.0
 
 # Define function
-if dde.backend.backend_name == "pytorch":
-    import torch
-
-    sin = torch.sin
-    cos = torch.cos
-elif dde.backend.backend_name == "paddle":
-    import paddle
-
-    sin = paddle.sin
-    cos = paddle.cos
-elif dde.backend.backend_name == "jax":
-    import jax.numpy as jnp
-
-    sin = jnp.sin
-    cos = jnp.cos
+sin = dde.backend.sin
+cos = dde.backend.cos
+stack = dde.backend.stack
+pi = dde.backend.as_tensor(np.pi)
 
 geom = dde.geometry.Rectangle([0, 0], [1, 1])
+BC_type = ["hard", "soft"][0]
 
 
 def boundary_left(x, on_boundary):
@@ -67,6 +57,7 @@ def func(x):
     return np.hstack((ux, uy, Sxx, Syy, Sxy))
 
 
+# Soft Boundary Conditions
 ux_top_bc = dde.icbc.DirichletBC(geom, lambda x: 0, boundary_top, component=0)
 ux_bottom_bc = dde.icbc.DirichletBC(geom, lambda x: 0, boundary_bottom, component=0)
 uy_left_bc = dde.icbc.DirichletBC(geom, lambda x: 0, boundary_left, component=1)
@@ -80,6 +71,18 @@ syy_top_bc = dde.icbc.DirichletBC(
     boundary_top,
     component=3,
 )
+
+
+# Hard Boundary Conditions
+def hard_BC(x, f):
+
+    Ux = f[:, 0] * x[:, 1] * (1 - x[:, 1])
+    Uy = f[:, 1] * x[:, 0] * (1 - x[:, 0]) * x[:, 1]
+
+    Sxx = f[:, 2] * x[:, 0] * (1 - x[:, 0])
+    Syy = f[:, 3] * (1 - x[:, 1]) + (lmbd + 2 * mu) * Q * sin(pi * x[:, 0])
+    Sxy = f[:, 4]
+    return stack((Ux, Uy, Sxx, Syy, Sxy), axis=1)
 
 
 def fx(x):
@@ -148,10 +151,10 @@ def pde(x, f):
     return [momentum_x, momentum_y, stress_x, stress_y, stress_xy]
 
 
-data = dde.data.PDE(
-    geom,
-    pde,
-    [
+if BC_type == "hard":
+    bcs = []
+else:
+    bcs = [
         ux_top_bc,
         ux_bottom_bc,
         uy_left_bc,
@@ -160,7 +163,12 @@ data = dde.data.PDE(
         sxx_left_bc,
         sxx_right_bc,
         syy_top_bc,
-    ],
+    ]
+
+data = dde.data.PDE(
+    geom,
+    pde,
+    bcs,
     num_domain=500,
     num_boundary=500,
     solution=func,
@@ -171,6 +179,8 @@ layers = [2, [40] * 5, [40] * 5, [40] * 5, [40] * 5, 5]
 activation = "tanh"
 initializer = "Glorot uniform"
 net = dde.nn.PFNN(layers, activation, initializer)
+if BC_type == "hard":
+    net.apply_output_transform(hard_BC)
 
 model = dde.Model(data, net)
 model.compile("adam", lr=0.001, metrics=["l2 relative error"])


### PR DESCRIPTION
Implementation of PFNN in Jax backend.
There is a slight difference with other backends to allow "rejoin parallel subnetworks after splitting":
A unique shared layer can be applied to each subnetwork after splitting (example : layers = [2, [40] * 5, 40, [40] * 5, 5]
That's why I changed the last layer definition :
```
#jax
if any(isinstance(unit, (list, tuple)) for unit in self.layer_sizes):
    denses.append([make_dense(1)] * n_output)
else:
    denses.append(make_dense(n_output))
```
compare to tf:
```
#tensorflow
if isinstance(layer_sizes[-2], (list, tuple)):  # e.g. [3, 3, 3] -> 3
    self.denses.append(
        [
            tf.keras.layers.Dense(
                1,
                kernel_initializer=initializer,
                kernel_regularizer=self.regularizer,
            )
            for _ in range(n_output)
        ]
    )
else:
    self.denses.append(
        tf.keras.layers.Dense(
            n_output,
            kernel_initializer=initializer,
            kernel_regularizer=self.regularizer,
        )
    )
```
because currently in tf and pytorch backend, the only possible way of having layer_sizes[-2] not a list is to have no list at all in layer_sizes ("cannot rejoin parallel subnetworks after splitting")

The implementation is tested in the "elasticy_plate.py" example
