### PR TITLE
Jax transform

### DIFF
--- a/deepxde/backend/jax/tensor.py
+++ b/deepxde/backend/jax/tensor.py
@@ -61,14 +61,6 @@ def to_numpy(input_tensor):
     return np.asarray(input_tensor)
 
 
-def concat(values, axis):
-    return jnp.concatenate(values, axis=axis)
-
-
-def stack(values, axis):
-    return jnp.stack(values, axis=axis)
-
-
 def elu(x):
     return jax.nn.elu(x)
 
@@ -91,10 +83,6 @@ def silu(x):
 
 def sin(x):
     return jnp.sin(x)
-
-
-def cos(x):
-    return jnp.cos(x)
 
 
 def square(x):

--- a/deepxde/backend/jax/tensor.py
+++ b/deepxde/backend/jax/tensor.py
@@ -61,6 +61,14 @@ def to_numpy(input_tensor):
     return np.asarray(input_tensor)
 
 
+def concat(values, axis):
+    return jnp.concatenate(values, axis=axis)
+
+
+def stack(values, axis):
+    return jnp.stack(values, axis=axis)
+
+
 def elu(x):
     return jax.nn.elu(x)
 
@@ -83,6 +91,10 @@ def silu(x):
 
 def sin(x):
     return jnp.sin(x)
+
+
+def cos(x):
+    return jnp.cos(x)
 
 
 def square(x):

--- a/deepxde/nn/jax/fnn.py
+++ b/deepxde/nn/jax/fnn.py
@@ -45,7 +45,10 @@ class FNN(NN):
     def __call__(self, inputs, training=False):
         x = inputs
         if self._input_transform is not None:
-            x = self._input_transform(x)
+            if x.ndim == 1:
+                x = self._input_transform(x.reshape(1, -1)).squeeze()
+            else:
+                x = self._input_transform(x)
         for j, linear in enumerate(self.denses[:-1]):
             x = (
                 self._activation[j](linear(x))
@@ -54,7 +57,12 @@ class FNN(NN):
             )
         x = self.denses[-1](x)
         if self._output_transform is not None:
-            x = self._output_transform(inputs, x)
+            if x.ndim == 1:
+                x = self._output_transform(
+                    inputs.reshape(1, -1), x.reshape(1, -1)
+                ).squeeze()
+            else:
+                x = self._output_transform(inputs, x)
         return x
 
 
@@ -150,7 +158,10 @@ class PFNN(NN):
     def __call__(self, inputs, training=False):
         x = inputs
         if self._input_transform is not None:
-            x = self._input_transform(x)
+            if x.ndim == 1:
+                x = self._input_transform(x.reshape(1, -1)).squeeze()
+            else:
+                x = self._input_transform(x)
 
         for layer in self.denses[:-1]:
             if isinstance(layer, (list, tuple)):
@@ -173,5 +184,10 @@ class PFNN(NN):
             x = self.denses[-1](x)
 
         if self._output_transform is not None:
-            x = self._output_transform(inputs, x)
+            if x.ndim == 1:
+                x = self._output_transform(
+                    inputs.reshape(1, -1), x.reshape(1, -1)
+                ).squeeze()
+            else:
+                x = self._output_transform(inputs, x)
         return x

--- a/deepxde/nn/jax/fnn.py
+++ b/deepxde/nn/jax/fnn.py
@@ -45,10 +45,7 @@ class FNN(NN):
     def __call__(self, inputs, training=False):
         x = inputs
         if self._input_transform is not None:
-            if x.ndim == 1:
-                x = self._input_transform(x.reshape(1, -1)).squeeze()
-            else:
-                x = self._input_transform(x)
+            x = self._input_transform(x)
         for j, linear in enumerate(self.denses[:-1]):
             x = (
                 self._activation[j](linear(x))
@@ -57,12 +54,7 @@ class FNN(NN):
             )
         x = self.denses[-1](x)
         if self._output_transform is not None:
-            if x.ndim == 1:
-                x = self._output_transform(
-                    inputs.reshape(1, -1), x.reshape(1, -1)
-                ).squeeze()
-            else:
-                x = self._output_transform(inputs, x)
+            x = self._output_transform(inputs, x)
         return x
 
 
@@ -158,10 +150,7 @@ class PFNN(NN):
     def __call__(self, inputs, training=False):
         x = inputs
         if self._input_transform is not None:
-            if x.ndim == 1:
-                x = self._input_transform(x.reshape(1, -1)).squeeze()
-            else:
-                x = self._input_transform(x)
+            x = self._input_transform(x)
 
         for layer in self.denses[:-1]:
             if isinstance(layer, (list, tuple)):
@@ -184,10 +173,5 @@ class PFNN(NN):
             x = self.denses[-1](x)
 
         if self._output_transform is not None:
-            if x.ndim == 1:
-                x = self._output_transform(
-                    inputs.reshape(1, -1), x.reshape(1, -1)
-                ).squeeze()
-            else:
-                x = self._output_transform(inputs, x)
+            x = self._output_transform(inputs, x)
         return x

--- a/deepxde/nn/jax/nn.py
+++ b/deepxde/nn/jax/nn.py
@@ -30,13 +30,13 @@ class NN(nn.Module):
         outputs = transform(inputs, outputs).
         """
 
-        def transform_handling_flat(inputs, x):
+        def transform_handling_flat(inputs, outputs):
             """Handle inputs of shape (n,)"""
             # TODO: Support tuple or list inputs.
-            if isinstance(x, (list, tuple)):
-                return transform(inputs, x)
-            if x.ndim == 1:
-                return transform(inputs.reshape(1, -1), x.reshape(1, -1)).squeeze()
-            return transform(inputs, x)
+            if isinstance(inputs, (list, tuple)):
+                return transform(inputs, outputs)
+            if inputs.ndim == 1:
+                return transform(inputs.reshape(1, -1), outputs.reshape(1, -1)).squeeze()
+            return transform(inputs, outputs)
 
         self._output_transform = transform_handling_flat

--- a/deepxde/nn/jax/nn.py
+++ b/deepxde/nn/jax/nn.py
@@ -16,6 +16,9 @@ class NN(nn.Module):
 
         def transform_handling_flat(x):
             """Handle inputs of shape (n,)"""
+            # TODO: Support tuple or list inputs.
+            if isinstance(x, (list, tuple)):
+                return transform(x)
             if x.ndim == 1:
                 return transform(x.reshape(1, -1)).squeeze()
             return transform(x)
@@ -29,6 +32,9 @@ class NN(nn.Module):
 
         def transform_handling_flat(inputs, x):
             """Handle inputs of shape (n,)"""
+            # TODO: Support tuple or list inputs.
+            if isinstance(x, (list, tuple)):
+                return transform(inputs, x)
             if x.ndim == 1:
                 return transform(inputs.reshape(1, -1), x.reshape(1, -1)).squeeze()
             return transform(inputs, x)

--- a/deepxde/nn/jax/nn.py
+++ b/deepxde/nn/jax/nn.py
@@ -13,10 +13,24 @@ class NN(nn.Module):
         """Compute the features by appling a transform to the network inputs, i.e.,
         features = transform(inputs). Then, outputs = network(features).
         """
-        self._input_transform = transform
+
+        def transform_handling_flat(x):
+            """Handle inputs of shape (n,)"""
+            if x.ndim == 1:
+                return transform(x.reshape(1, -1)).squeeze()
+            return transform(x)
+
+        self._input_transform = transform_handling_flat
 
     def apply_output_transform(self, transform):
         """Apply a transform to the network outputs, i.e.,
         outputs = transform(inputs, outputs).
         """
-        self._output_transform = transform
+
+        def transform_handling_flat(inputs, x):
+            """Handle inputs of shape (n,)"""
+            if x.ndim == 1:
+                return transform(inputs.reshape(1, -1), x.reshape(1, -1)).squeeze()
+            return transform(inputs, x)
+
+        self._output_transform = transform_handling_flat

--- a/examples/pinn_forward/elasticity_plate.py
+++ b/examples/pinn_forward/elasticity_plate.py
@@ -74,7 +74,6 @@ syy_top_bc = dde.icbc.DirichletBC(
 
 # Hard Boundary Conditions
 def hard_BC(x, f):
-
     Ux = f[:, 0] * x[:, 1] * (1 - x[:, 1])
     Uy = f[:, 1] * x[:, 0] * (1 - x[:, 0]) * x[:, 1]
 

--- a/examples/pinn_forward/elasticity_plate.py
+++ b/examples/pinn_forward/elasticity_plate.py
@@ -11,11 +11,10 @@ lmbd = 1.0
 mu = 0.5
 Q = 4.0
 
-# Define function
+# Define functions
 sin = dde.backend.sin
 cos = dde.backend.cos
 stack = dde.backend.stack
-pi = dde.backend.as_tensor(np.pi)
 
 geom = dde.geometry.Rectangle([0, 0], [1, 1])
 BC_type = ["hard", "soft"][0]
@@ -78,7 +77,7 @@ def hard_BC(x, f):
     Uy = f[:, 1] * x[:, 0] * (1 - x[:, 0]) * x[:, 1]
 
     Sxx = f[:, 2] * x[:, 0] * (1 - x[:, 0])
-    Syy = f[:, 3] * (1 - x[:, 1]) + (lmbd + 2 * mu) * Q * sin(pi * x[:, 0])
+    Syy = f[:, 3] * (1 - x[:, 1]) + (lmbd + 2 * mu) * Q * sin(np.pi * x[:, 0])
     Sxy = f[:, 4]
     return stack((Ux, Uy, Sxx, Syy, Sxy), axis=1)
 


### PR DESCRIPTION
As explained in https://github.com/lululxvi/deepxde/pull/1671

There was a problem with output/input transform in jax.
Because it calculates gradients in a pointwise fashion, the input that passes through the network for the gradient calculation is of size (n_input,) so it generated an error when trying to access x[:,i] or f[:,i] in the input/output transformation.
Adding reshape(1,-1) before and squeeze() after solved it.

I also added hard BC support for elasticity plate example