### PR TITLE
Jax transform bug

### DIFF
--- a/deepxde/nn/jax/nn.py
+++ b/deepxde/nn/jax/nn.py
@@ -20,7 +20,7 @@ class NN(nn.Module):
             if isinstance(x, (list, tuple)):
                 return transform(x)
             if x.ndim == 1:
-                return transform(x.reshape(1, -1)).squeeze()
+                return transform(x.reshape(1, -1)).reshape(-1)
             return transform(x)
 
         self._input_transform = transform_handling_flat
@@ -36,7 +36,7 @@ class NN(nn.Module):
             if isinstance(inputs, (list, tuple)):
                 return transform(inputs, outputs)
             if inputs.ndim == 1:
-                return transform(inputs.reshape(1, -1), outputs.reshape(1, -1)).squeeze()
+                return transform(inputs.reshape(1, -1), outputs.reshape(1, -1)).reshape(-1)
             return transform(inputs, outputs)
 
         self._output_transform = transform_handling_flat

--- a/examples/pinn_forward/Helmholtz_Dirichlet_2d.py
+++ b/examples/pinn_forward/Helmholtz_Dirichlet_2d.py
@@ -1,4 +1,4 @@
-"""Backend supported: tensorflow.compat.v1, tensorflow, pytorch, paddle, jax"""
+"""Backend supported: tensorflow.compat.v1, tensorflow, pytorch, jax, paddle"""
 import deepxde as dde
 import numpy as np
 

--- a/examples/pinn_forward/Helmholtz_Dirichlet_2d.py
+++ b/examples/pinn_forward/Helmholtz_Dirichlet_2d.py
@@ -1,7 +1,6 @@
 """Backend supported: tensorflow.compat.v1, tensorflow, pytorch, paddle, jax"""
 import deepxde as dde
 import numpy as np
-import deepxde.backend as bkd
 
 # General parameters
 n = 2
@@ -13,10 +12,9 @@ iterations = 5000
 parameters = [1e-3, 3, 150, "sin"]
 
 # Define sine function
-sin = bkd.sin
+sin = dde.backend.sin
 
 learning_rate, num_dense_layers, num_dense_nodes, activation = parameters
-
 
 def pde(x, y):
     dy_xx = dde.grad.hessian(y, x, i=0, j=0)


### PR DESCRIPTION
The previous update to handle transform with Jax was not working to compute the Hessian.
In that case, the output of the Jacobian is reused to compute the Hessian. There was an index error because squeeze make a one element array 0D but we actually want to keep one dimension. Changing the reshape(-1) solved it :
```
function       |  x.shape
.squeeze:        (1,1) --> ()
.reshape(-1):    (1,1) --> (1,)
```
I also implemented Jax on Helmotz equation example