### PR TITLE
[Fix] Convert loss_weights as same dtype of stacked losses

### DIFF
--- a/deepxde/model.py
+++ b/deepxde/model.py
@@ -473,7 +473,7 @@ class Model:
             losses = paddle.stack(losses, axis=0)
             # Weighted losses
             if self.loss_weights is not None:
-                losses *= paddle.to_tensor(self.loss_weights)
+                losses *= paddle.to_tensor(self.loss_weights, dtype=losses.dtype)
             # Clear cached Jacobians and Hessians.
             grad.clear()
             return outputs_, losses


### PR DESCRIPTION
As descripted in <https://github.com/PaddlePaddle/Paddle/pull/63842>, `dtype` should be explicitly specified to float(16/32), or error will be raised. So setting `dtype` as same as stacked loss seems fine.

![image](https://github.com/lululxvi/deepxde/assets/23737287/45cc9862-51af-4ad4-94f4-7f1bfd4b57a1)

https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/guides/advanced/auto_type_promotion_cn.html#sanfeijiangdeyinshileixingtishengshiyongfangfashuoming