### PR TITLE
[Fix] TF Backend Regularization fix.

### DIFF
--- a/deepxde/model.py
+++ b/deepxde/model.py
@@ -1043,7 +1043,7 @@ class Model:
                 save_path += ".ckpt"
                 self.saver.save(self.sess, save_path)
             elif backend_name == "tensorflow":
-                save_path += ".weights.h5"
+                save_path += ".ckpt"
                 self.net.save_weights(save_path)
             elif backend_name == "pytorch":
                 save_path += ".pt"

--- a/deepxde/model.py
+++ b/deepxde/model.py
@@ -1031,7 +1031,8 @@ class Model:
         Returns:
             string: Path where model is saved.
         """
-        # TODO: backend tensorflow
+        # TODO: Add assertions OR test the ending
+        #       Right now it seems kind of weird.
         save_path = f"{save_path}-{self.train_state.epoch}"
         if protocol == "pickle":
             save_path += ".pkl"
@@ -1042,7 +1043,7 @@ class Model:
                 save_path += ".ckpt"
                 self.saver.save(self.sess, save_path)
             elif backend_name == "tensorflow":
-                save_path += ".ckpt"
+                save_path += ".weights.h5"
                 self.net.save_weights(save_path)
             elif backend_name == "pytorch":
                 save_path += ".pt"

--- a/deepxde/model.py
+++ b/deepxde/model.py
@@ -1031,8 +1031,7 @@ class Model:
         Returns:
             string: Path where model is saved.
         """
-        # TODO: Add assertions OR test the ending
-        #       Right now it seems kind of weird.
+        # TODO: backend tensorflow
         save_path = f"{save_path}-{self.train_state.epoch}"
         if protocol == "pickle":
             save_path += ".pkl"

--- a/deepxde/nn/regularizers.py
+++ b/deepxde/nn/regularizers.py
@@ -5,13 +5,13 @@ def get(identifier):
     # TODO: other backends
     if identifier is None:
         return None
-    name, scales = identifier[0], identifier[1:]
+    name, scales = identifier[0].lower(), identifier[1:]
     return (
         tf.keras.regularizers.L1(l1=scales[0])
-        if name == "l1" or name == "L1"
+        if name == "l1"
         else tf.keras.regularizers.L2(l2=scales[0])
-        if name == "l2" or name == "L2"
+        if name == "l2"
         else tf.keras.regularizers.L1L2(l1=scales[0], l2=scales[1])
-        if name == "l1+l2" or name == "L1L2"
+        if name == "l1+l2" or name == "l1l2"
         else None
     )

--- a/deepxde/nn/regularizers.py
+++ b/deepxde/nn/regularizers.py
@@ -7,9 +7,9 @@ def get(identifier):
         return None
     name, scales = identifier[0], identifier[1:]
     return (
-        tf.keras.regularizers.l1(l=scales[0])
+        tf.keras.regularizers.l1(l1=scales[0])
         if name == "l1"
-        else tf.keras.regularizers.l2(l=scales[0])
+        else tf.keras.regularizers.l2(l2=scales[0])
         if name == "l2"
         else tf.keras.regularizers.l1_l2(l1=scales[0], l2=scales[1])
         if name == "l1+l2"

--- a/deepxde/nn/regularizers.py
+++ b/deepxde/nn/regularizers.py
@@ -7,11 +7,11 @@ def get(identifier):
         return None
     name, scales = identifier[0], identifier[1:]
     return (
-        tf.keras.regularizers.l1(l1=scales[0])
-        if name == "l1"
-        else tf.keras.regularizers.l2(l2=scales[0])
-        if name == "l2"
-        else tf.keras.regularizers.l1_l2(l1=scales[0], l2=scales[1])
-        if name == "l1+l2"
+        tf.keras.regularizers.L1(l1=scales[0])
+        if name == "l1" or name == "L1"
+        else tf.keras.regularizers.L2(l2=scales[0])
+        if name == "l2" or name == "L2"
+        else tf.keras.regularizers.L1L2(l1=scales[0], l2=scales[1])
+        if name == "l1+l2" or name == "L1L2"
         else None
     )

--- a/deepxde/nn/regularizers.py
+++ b/deepxde/nn/regularizers.py
@@ -12,6 +12,6 @@ def get(identifier):
         else tf.keras.regularizers.L2(l2=scales[0])
         if name == "l2"
         else tf.keras.regularizers.L1L2(l1=scales[0], l2=scales[1])
-        if name == "l1+l2" or name == "l1l2"
+        if name in ("l1+l2", "l1l2")
         else None
     )


### PR DESCRIPTION
# TF Regularization

Check the [docs](https://www.tensorflow.org/api_docs/python/tf/keras/regularizers/L1) and the argument for `tf.keras.regualizers.l1/l2` is of the form `l1`/`l2` instead of just `l` in the current version. Without it this breaks:

```python
net = dde.maps.PFNN(
    network,
    "swish",
    "Glorot normal",
    regularization=["l2", 1e-8]
)
```

Specifically it gives you the error:

```python
TypeError: L1.__init__() got an unexpected keyword argument 'l'
```

As of right now, the following works instead:

```python
net = dde.maps.PFNN(
    network,
    "swish",
    "Glorot normal",
    regularization=["l1+l2", 1e-8, 1e-8]
)
```

But merging would allow for each one to be used on their own. 