### PR TITLE
[Update] Update regularizers so it is backwards compatabile

### DIFF
--- a/deepxde/nn/regularizers.py
+++ b/deepxde/nn/regularizers.py
@@ -7,11 +7,11 @@ def get(identifier):
         return None
     name, scales = identifier[0].lower(), identifier[1:]
     return (
-        tf.keras.regularizers.L1(l1=scales[0])
+        tf.keras.regularizers.l1(scales[0])
         if name == "l1"
-        else tf.keras.regularizers.L2(l2=scales[0])
+        else tf.keras.regularizers.l2(scales[0])
         if name == "l2"
-        else tf.keras.regularizers.L1L2(l1=scales[0], l2=scales[1])
-        if name in ("l1+l2", "l1l2")
+        else tf.keras.regularizers.l1_l2(scales[0], scales[1])
+        if name in ("l1+l2", "l1l2", "l1_l2")
         else None
     )


### PR DESCRIPTION
Regularizers supported in tf v2.2.0:

![image](https://github.com/lululxvi/deepxde/assets/54725025/c7d22014-6ee3-4f7e-bbf2-7f5b0c6ba99f)

Keeping it like this (lowercase and without explicitly calling the argument name) maintains backwards compatibility and doesn't need to be upgraded to tf v2.3.0 and up.