### PR TITLE
[Update] Change version of TF

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ All the components of DeepXDE are loosely coupled, and thus DeepXDE is well-stru
 DeepXDE requires one of the following backend-specific dependencies to be installed:
 
 - TensorFlow 1.x: [TensorFlow](https://www.tensorflow.org)>=2.7.0
-- TensorFlow 2.x: [TensorFlow](https://www.tensorflow.org)>=2.2.0, [TensorFlow Probability](https://www.tensorflow.org/probability)>=0.10.0
+- TensorFlow 2.x: [TensorFlow](https://www.tensorflow.org)>=2.3.0, [TensorFlow Probability](https://www.tensorflow.org/probability)>=0.10.0
 - PyTorch: [PyTorch](https://pytorch.org)>=1.9.0
 - JAX: [JAX](https://jax.readthedocs.io), [Flax](https://flax.readthedocs.io), [Optax](https://optax.readthedocs.io)
 - PaddlePaddle: [PaddlePaddle](https://www.paddlepaddle.org.cn/en)>=2.6.0

--- a/deepxde/backend/tensorflow/tensor.py
+++ b/deepxde/backend/tensorflow/tensor.py
@@ -5,8 +5,8 @@ import tensorflow as tf
 import tensorflow_probability as tfp
 
 
-if Version(tf.__version__) < Version("2.2.0"):
-    raise RuntimeError("DeepXDE requires TensorFlow>=2.2.0.")
+if Version(tf.__version__) < Version("2.3.0"):
+    raise RuntimeError("DeepXDE requires TensorFlow>=2.3.0.")
 if Version(tfp.__version__) < Version("0.10.0"):
     raise RuntimeError("DeepXDE requires TensorFlow Probability>=0.10.0.")
 

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -7,7 +7,7 @@ Installation
 DeepXDE requires one of the following backend-specific dependencies to be installed:
 
 - TensorFlow 1.x: `TensorFlow <https://www.tensorflow.org>`_>=2.7.0
-- TensorFlow 2.x: `TensorFlow <https://www.tensorflow.org>`_>=2.2.0, `TensorFlow Probability <https://www.tensorflow.org/probability>`_>=0.10.0
+- TensorFlow 2.x: `TensorFlow <https://www.tensorflow.org>`_>=2.3.0, `TensorFlow Probability <https://www.tensorflow.org/probability>`_>=0.10.0
 - PyTorch: `PyTorch <https://pytorch.org>`_>=1.9.0
 - JAX: `JAX <https://jax.readthedocs.io>`_, `Flax <https://flax.readthedocs.io>`_, `Optax <https://optax.readthedocs.io>`_
 - PaddlePaddle: `PaddlePaddle <https://www.paddlepaddle.org.cn/en>`_>=2.6.0
@@ -96,7 +96,7 @@ Here is a comparison between different backends:
 TensorFlow 1.x backend
 ``````````````````````
 
-Export ``DDE_BACKEND`` as ``tensorflow.compat.v1`` to specify TensorFlow 1.x backend. The required TensorFlow version is 2.2.0 or later. Essentially, TensorFlow 1.x backend uses the API `tensorflow.compat.v1 <https://www.tensorflow.org/api_docs/python/tf/compat/v1>`_ in TensorFlow 2.x and disables the eager execution:
+Export ``DDE_BACKEND`` as ``tensorflow.compat.v1`` to specify TensorFlow 1.x backend. The required TensorFlow version is 2.3.0 or later. Essentially, TensorFlow 1.x backend uses the API `tensorflow.compat.v1 <https://www.tensorflow.org/api_docs/python/tf/compat/v1>`_ in TensorFlow 2.x and disables the eager execution:
 
 .. code:: python
 
@@ -108,7 +108,7 @@ In addition, DeepXDE will set ``TF_FORCE_GPU_ALLOW_GROWTH`` to ``true`` to preve
 TensorFlow 2.x backend
 ``````````````````````
 
-Export ``DDE_BACKEND`` as ``tensorflow`` to specify TensorFlow 2.x backend. The required TensorFlow version is 2.2.0 or later. In addition, DeepXDE will set ``TF_FORCE_GPU_ALLOW_GROWTH`` to ``true`` to prevent TensorFlow take over the whole GPU memory.
+Export ``DDE_BACKEND`` as ``tensorflow`` to specify TensorFlow 2.x backend. The required TensorFlow version is 2.3.0 or later. In addition, DeepXDE will set ``TF_FORCE_GPU_ALLOW_GROWTH`` to ``true`` to prevent TensorFlow take over the whole GPU memory.
 
 PyTorch backend
 ```````````````

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -96,7 +96,7 @@ Here is a comparison between different backends:
 TensorFlow 1.x backend
 ``````````````````````
 
-Export ``DDE_BACKEND`` as ``tensorflow.compat.v1`` to specify TensorFlow 1.x backend. The required TensorFlow version is 2.3.0 or later. Essentially, TensorFlow 1.x backend uses the API `tensorflow.compat.v1 <https://www.tensorflow.org/api_docs/python/tf/compat/v1>`_ in TensorFlow 2.x and disables the eager execution:
+Export ``DDE_BACKEND`` as ``tensorflow.compat.v1`` to specify TensorFlow 1.x backend. Essentially, TensorFlow 1.x backend uses the API `tensorflow.compat.v1 <https://www.tensorflow.org/api_docs/python/tf/compat/v1>`_ in TensorFlow 2.x and disables the eager execution:
 
 .. code:: python
 
@@ -108,12 +108,12 @@ In addition, DeepXDE will set ``TF_FORCE_GPU_ALLOW_GROWTH`` to ``true`` to preve
 TensorFlow 2.x backend
 ``````````````````````
 
-Export ``DDE_BACKEND`` as ``tensorflow`` to specify TensorFlow 2.x backend. The required TensorFlow version is 2.3.0 or later. In addition, DeepXDE will set ``TF_FORCE_GPU_ALLOW_GROWTH`` to ``true`` to prevent TensorFlow take over the whole GPU memory.
+Export ``DDE_BACKEND`` as ``tensorflow`` to specify TensorFlow 2.x backend. In addition, DeepXDE will set ``TF_FORCE_GPU_ALLOW_GROWTH`` to ``true`` to prevent TensorFlow take over the whole GPU memory.
 
 PyTorch backend
 ```````````````
 
-Export ``DDE_BACKEND`` as ``pytorch`` to specify PyTorch backend. The required PyTorch version is 1.9.0 or later. In addition, if GPU is available, DeepXDE will set  the default tensor type to cuda, so that all the tensors will be created on GPU as default:
+Export ``DDE_BACKEND`` as ``pytorch`` to specify PyTorch backend. In addition, if GPU is available, DeepXDE will set  the default tensor type to cuda, so that all the tensors will be created on GPU as default:
 
 .. code:: python
 


### PR DESCRIPTION
Updated version for TF to 2.3.0. Could do in the future of using the version number as an external variable and have it pop up, but right now it's not that many places. 

Note that #1783 would conflict with this PR and keep the version down to 2.2.0. 