### PR TITLE
Backend paddle: switch default line_search_fn of L-BFGS to 'strong_wolfe'

### DIFF
--- a/deepxde/model.py
+++ b/deepxde/model.py
@@ -777,7 +777,7 @@ class Model:
             )
 
             n_iter = self.opt.state_dict()["state"][0]["n_iter"]
-            if prev_n_iter == n_iter:
+            if prev_n_iter == n_iter - 1:
                 # Converged
                 break
 
@@ -809,7 +809,7 @@ class Model:
             )
 
             n_iter = self.opt.state_dict()["state"]["n_iter"]
-            if prev_n_iter == n_iter:
+            if prev_n_iter == n_iter - 1:
                 # Converged
                 break
 

--- a/deepxde/optimizers/paddle/optimizers.py
+++ b/deepxde/optimizers/paddle/optimizers.py
@@ -34,7 +34,7 @@ def get(params, optimizer, learning_rate=None, decay=None):
             tolerance_grad=LBFGS_options["gtol"],
             tolerance_change=LBFGS_options["ftol"],
             history_size=LBFGS_options["maxcor"],
-            line_search_fn=None,
+            line_search_fn=("strong_wolfe" if LBFGS_options["maxls"] > 0 else None),
             parameters=params,
         )
         return optim


### PR DESCRIPTION
1. switch default line_search_fn of L-BFGS to 'strong_wolfe'
2. 'n_iter' in the L-BFGS of paddle and torch will be increased by one at the beginning. Therefore, the original code cannot achieve the expected effect of exiting after training converges because 'prev_n_iter' always equal to 'n_iter - 1' in that line of code. Fixed it in the PR (by the way, for backend torch).