### PR TITLE
Add Paddle backend support to poisson_1d_pideeponet and heat_sample

### DIFF
--- a/examples/operator/poisson_1d_pideeponet.py
+++ b/examples/operator/poisson_1d_pideeponet.py
@@ -1,4 +1,4 @@
-"""Backend supported: tensorflow.compat.v1, tensorflow, pytorch"""
+"""Backend supported: tensorflow.compat.v1, tensorflow, pytorch, paddle"""
 import deepxde as dde
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/pinn_forward/heat_resample.py
+++ b/examples/pinn_forward/heat_resample.py
@@ -1,4 +1,4 @@
-"""Backend supported: tensorflow.compat.v1, tensorflow, pytorch"""
+"""Backend supported: tensorflow.compat.v1, tensorflow, pytorch, paddle"""
 import deepxde as dde
 import numpy as np
 


### PR DESCRIPTION
Support `poisson_1d_pideeponet` and `heat_resample` with paddle backend.


pytorch:
![image](https://github.com/user-attachments/assets/b1ad5063-afac-4218-8712-ee013a16c36e)
![image](https://github.com/user-attachments/assets/b3426fd8-6ea1-412b-ad82-b03e1f0f0937)

paddle:
![image](https://github.com/user-attachments/assets/32a807cc-4a34-4437-8af2-235c6c4879b6)
![image](https://github.com/user-attachments/assets/406f55b9-6255-4660-8cae-65ae9b9819df)

