### PR TITLE
Fix a bug in quadruple.py

### DIFF
--- a/deepxde/data/quadruple.py
+++ b/deepxde/data/quadruple.py
@@ -94,7 +94,7 @@ class QuadrupleCartesianProd(Data):
             self.train_x[0][indices_branch],
             self.train_x[1][indices_branch],
             self.train_x[2][indices_trunk],
-        ), self.train_y[indices_branch, indices_trunk]
+        ), self.train_y[indices_branch][:, indices_trunk]
 
     def test(self):
         return self.test_x, self.test_y


### PR DESCRIPTION
This is a small bug I found in QuadrupleCartesianProd class though it's unusual to use this part. When indexing with multidimensional index arrays, the arrays should have the same shape. See https://numpy.org/doc/stable/user/basics.indexing.html. 