### PR TITLE
fixed fnn constructor for pytorch to add regularization

### DIFF
--- a/deepxde/nn/pytorch/fnn.py
+++ b/deepxde/nn/pytorch/fnn.py
@@ -23,6 +23,7 @@ class FNN(NN):
             self.activation = activations.get(activation)
         initializer = initializers.get(kernel_initializer)
         initializer_zero = initializers.get("zeros")
+        self.regularizer = regularization
 
         self.linears = torch.nn.ModuleList()
         for i in range(1, len(layer_sizes)):
@@ -33,9 +34,6 @@ class FNN(NN):
             )
             initializer(self.linears[-1].weight)
             initializer_zero(self.linears[-1].bias)
-        self.regularizer = regularization
-        # currently list with two components: regularization type, weight decay
-        # currently supports l2 regularization
 
     def forward(self, inputs):
         x = inputs

--- a/deepxde/nn/pytorch/fnn.py
+++ b/deepxde/nn/pytorch/fnn.py
@@ -9,7 +9,7 @@ from ... import config
 class FNN(NN):
     """Fully-connected neural network."""
 
-    def __init__(self, layer_sizes, activation, kernel_initializer):
+    def __init__(self, layer_sizes, activation, kernel_initializer, regularization=None):
         super().__init__()
         if isinstance(activation, list):
             if not (len(layer_sizes) - 1) == len(activation):
@@ -31,7 +31,9 @@ class FNN(NN):
             )
             initializer(self.linears[-1].weight)
             initializer_zero(self.linears[-1].bias)
-
+        self.regularizer=regularization
+        # currently list with two components: regularization type, weight decay
+        # currently supports l2 regularization
     def forward(self, inputs):
         x = inputs
         if self._input_transform is not None:

--- a/deepxde/nn/pytorch/fnn.py
+++ b/deepxde/nn/pytorch/fnn.py
@@ -9,7 +9,9 @@ from ... import config
 class FNN(NN):
     """Fully-connected neural network."""
 
-    def __init__(self, layer_sizes, activation, kernel_initializer, regularization=None):
+    def __init__(
+        self, layer_sizes, activation, kernel_initializer, regularization=None
+    ):
         super().__init__()
         if isinstance(activation, list):
             if not (len(layer_sizes) - 1) == len(activation):
@@ -31,9 +33,10 @@ class FNN(NN):
             )
             initializer(self.linears[-1].weight)
             initializer_zero(self.linears[-1].bias)
-        self.regularizer=regularization
+        self.regularizer = regularization
         # currently list with two components: regularization type, weight decay
         # currently supports l2 regularization
+
     def forward(self, inputs):
         x = inputs
         if self._input_transform is not None:


### PR DESCRIPTION
I had previously mentioned in a github issue ([https://github.com/lululxvi/deepxde/issues/1703](url)) that the FNN constructor for the PyTorch backend did not have regularization.

I have implemented regularization in the FNN constructor and tested it on a basic function approximation demo.