### PR TITLE
change np.Inf to np.inf to be compatible with the newest version of numpy>2.0

### DIFF
--- a/deepxde/callbacks.py
+++ b/deepxde/callbacks.py
@@ -137,7 +137,7 @@ class ModelCheckpoint(Callback):
         self.monitor = monitor
         self.monitor_op = np.less
         self.epochs_since_last_save = 0
-        self.best = np.Inf
+        self.best = np.inf
 
     def on_epoch_end(self):
         self.epochs_since_last_save += 1
@@ -221,7 +221,7 @@ class EarlyStopping(Callback):
         if self.baseline is not None:
             self.best = self.baseline
         else:
-            self.best = np.Inf if self.monitor_op == np.less else -np.Inf
+            self.best = np.inf if self.monitor_op == np.less else -np.inf
 
     def on_epoch_end(self):
         if self.model.train_state.epoch < self.start_from_epoch:


### PR DESCRIPTION
see the [release note](https://numpy.org/devdocs/release/2.0.0-notes.html) of numpy: Alias `np.Inf` has been removed. Use `np.inf` instead.
