### PR TITLE
add verbose to dde.model.train and dde.model.compile

### DIFF
--- a/deepxde/utils/internal.py
+++ b/deepxde/utils/internal.py
@@ -18,15 +18,13 @@ def timing(f):
 
     @wraps(f)
     def wrapper(*args, **kwargs):
+        ts = timeit.default_timer()
+        result = f(*args, **kwargs)
+        te = timeit.default_timer()
         verbose = kwargs.get('verbose', 1)
         if verbose > 0 and config.rank == 0:
-            ts = timeit.default_timer()
-            result = f(*args, **kwargs)
-            te = timeit.default_timer()
             print("%r took %f s\n" % (f.__name__, te - ts))
             sys.stdout.flush()
-        else:
-            result = f(*args, **kwargs)
         return result
 
     return wrapper

--- a/deepxde/utils/internal.py
+++ b/deepxde/utils/internal.py
@@ -18,10 +18,11 @@ def timing(f):
 
     @wraps(f)
     def wrapper(*args, **kwargs):
+        verbose = kwargs.get('verbose', 1)
         ts = timeit.default_timer()
         result = f(*args, **kwargs)
         te = timeit.default_timer()
-        if config.rank == 0:
+        if verbose > 0 and config.rank == 0:
             print("%r took %f s\n" % (f.__name__, te - ts))
             sys.stdout.flush()
         return result

--- a/deepxde/utils/internal.py
+++ b/deepxde/utils/internal.py
@@ -19,12 +19,14 @@ def timing(f):
     @wraps(f)
     def wrapper(*args, **kwargs):
         verbose = kwargs.get('verbose', 1)
-        ts = timeit.default_timer()
-        result = f(*args, **kwargs)
-        te = timeit.default_timer()
         if verbose > 0 and config.rank == 0:
+            ts = timeit.default_timer()
+            result = f(*args, **kwargs)
+            te = timeit.default_timer()
             print("%r took %f s\n" % (f.__name__, te - ts))
             sys.stdout.flush()
+        else:
+            result = f(*args, **kwargs)
         return result
 
     return wrapper


### PR DESCRIPTION
## Purpose

This pull request aims to add a verbose parameter to the dde.model.train() and dde.model.compile() methods. This addition allows users to control the verbosity of these methods, which is important in federated learning.

## Changes Made

1. Set the optional values of verbose to be 0 or 1.

 - This is the same with the verbose in other parts of deepxde and make it possible for future extensions of adding verbose=2.

2. Added the verbose parameter to train() and compile().

 - The verbose parameter is added to both dde.model.train() and dde.model.compile().
 - Default is verbose=1, without any changes to the original methods.
 - Setting verbose=0 will silent all outputs.

3. Read verbose parameter in the decorator utils.timing.

 - When verbose=0 is passed to utils.timing, it will no longer print the timing information.
 - Default is verbose=1 which prevents affecting other methods using the decorator utils.timing.

4. Added verbose parameter in model._test()

 - When verbose=0, there should be no output, including test loss. So, display.training_display() in model._test() is disabled when verbose = 0.

5. Disable display.training_display() in TensorFlow v1 compatibility mode.

 - This is modified to be disabled when verbose=0.

## Test

Example used: https://deepxde.readthedocs.io/en/latest/demos/pinn_forward/ode.system.html.

Backend tested: pytorch, jax, paddle.

Problem: The new verbose feature works well overall. But there are thousands of output like "I1106 13:10:16.057708 3995094848 kernel_dispatch.h:102] Get BackendSet from tensor" when using paddle as the backend. This problem also occurs when using the original deepxde, before any changes.

## Notes

Maybe we could disable timeit.default_timer() in the utils.timing() when verbose=0.