### PR TITLE
Change np.product to np.prod

### DIFF
--- a/deepxde/optimizers/tensorflow/tfp_optimizer.py
+++ b/deepxde/optimizers/tensorflow/tfp_optimizer.py
@@ -48,7 +48,7 @@ class LossAndFlatGradient:
         self.indices = []  # stitch indices
         self.partitions = []  # partition indices
         for i, shape in enumerate(self.shapes):
-            n = np.product(shape)
+            n = np.prod(shape)
             self.indices.append(
                 tf.reshape(tf.range(count, count + n, dtype=tf.int32), shape)
             )

--- a/deepxde/optimizers/tensorflow_compat_v1/tfp_optimizer.py
+++ b/deepxde/optimizers/tensorflow_compat_v1/tfp_optimizer.py
@@ -37,7 +37,7 @@ class LossAndFlatGradient:
         self.indices = []  # stitch indices
         self.partitions = []  # partition indices
         for i, shape in enumerate(self.shapes):
-            n = np.product(shape)
+            n = np.prod(shape)
             self.indices.append(
                 tf.reshape(tf.range(count, count + n, dtype=tf.int32), shape)
             )


### PR DESCRIPTION
np.product was deprecated in NumPy 1.25.0 and was removed in NumPy 2.0.