### PR TITLE
Add l1 and l1+l2 regularizers for PyTorch backend

### DIFF
--- a/deepxde/model.py
+++ b/deepxde/model.py
@@ -339,24 +339,22 @@ class Model:
                 )
             weight_decay = self.net.regularizer[1]
 
-        if weight_decay == 0:
-            if self.opt_name == "adamw":
-                raise ValueError("AdamW optimizer requires non-zero weight decay")
+        if self.opt_name in ["L-BFGS", "L-BFGS-B"]:
             optimizer_params = (
                 list(self.net.parameters()) + self.external_trainable_variables
             )
         else:
-            if self.opt_name in ["L-BFGS", "L-BFGS-B"]:
-                raise ValueError(
-                    f"{self.opt_name} optimizer doesn't support weight_decay > 0"
-                )
             optimizer_params = [
-                {"params": self.net.parameters(), "weight_decay": weight_decay},
+                {"params": self.net.parameters()},
                 {"params": self.external_trainable_variables, "weight_decay": 0},
             ]
 
         self.opt, self.lr_scheduler = optimizers.get(
-            optimizer_params, self.opt_name, learning_rate=lr, decay=decay
+            optimizer_params,
+            self.opt_name,
+            learning_rate=lr,
+            decay=decay,
+            weight_decay=weight_decay,
         )
 
         def train_step(inputs, targets, auxiliary_vars):

--- a/deepxde/model.py
+++ b/deepxde/model.py
@@ -342,6 +342,7 @@ class Model:
 
         optimizer_params = self.net.parameters()
         if self.external_trainable_variables:
+            # L-BFGS doesn't support per-parameter options.
             if self.opt_name in ["L-BFGS", "L-BFGS-B"]:
                 optimizer_params = (
                     list(optimizer_params) + self.external_trainable_variables

--- a/deepxde/model.py
+++ b/deepxde/model.py
@@ -340,20 +340,22 @@ class Model:
                 )
             weight_decay = self.net.regularizer[1]
 
-        if self.opt_name in ["L-BFGS", "L-BFGS-B"]:
-            optimizer_params = (
-                list(self.net.parameters()) + self.external_trainable_variables
-            )
-            if weight_decay > 0:
-                print(
-                    "Warning: L2 regularization will also be applied to external_trainable_variables. "
-                    "Ensure this is intended behavior."
+        optimizer_params = self.net.parameters()
+        if self.external_trainable_variables:
+            if self.opt_name in ["L-BFGS", "L-BFGS-B"]:
+                optimizer_params = (
+                    list(optimizer_params) + self.external_trainable_variables
                 )
-        else:
-            optimizer_params = [
-                {"params": self.net.parameters()},
-                {"params": self.external_trainable_variables, "weight_decay": 0},
-            ]
+                if weight_decay > 0:
+                    print(
+                        "Warning: L2 regularization will also be applied to external_trainable_variables. "
+                        "Ensure this is intended behavior."
+                    )
+            else:
+                optimizer_params = [
+                    {"params": optimizer_params},
+                    {"params": self.external_trainable_variables, "weight_decay": 0},
+                ]
 
         self.opt, self.lr_scheduler = optimizers.get(
             optimizer_params,

--- a/deepxde/model.py
+++ b/deepxde/model.py
@@ -112,9 +112,11 @@ class Model:
                 weighted by the `loss_weights` coefficients.
             external_trainable_variables: A trainable ``dde.Variable`` object or a list
                 of trainable ``dde.Variable`` objects. The unknown parameters in the
-                physics systems that need to be recovered. If the backend is
-                tensorflow.compat.v1, `external_trainable_variables` is ignored, and all
-                trainable ``dde.Variable`` objects are automatically collected.
+                physics systems that need to be recovered. Regularization will not be
+                applied to these variables. If the backend is tensorflow.compat.v1,
+                `external_trainable_variables` is ignored, and all trainable ``dde.Variable``
+                objects are automatically collected.
+
             verbose (Integer): Controls the verbosity of the compile process.
         """
         if verbose > 0 and config.rank == 0:

--- a/deepxde/model.py
+++ b/deepxde/model.py
@@ -116,7 +116,6 @@ class Model:
                 applied to these variables. If the backend is tensorflow.compat.v1,
                 `external_trainable_variables` is ignored, and all trainable ``dde.Variable``
                 objects are automatically collected.
-
             verbose (Integer): Controls the verbosity of the compile process.
         """
         if verbose > 0 and config.rank == 0:
@@ -345,6 +344,11 @@ class Model:
             optimizer_params = (
                 list(self.net.parameters()) + self.external_trainable_variables
             )
+            if weight_decay > 0:
+                print(
+                    "Warning: L2 regularization will also be applied to external_trainable_variables. "
+                    "Ensure this is intended behavior."
+                )
         else:
             optimizer_params = [
                 {"params": self.net.parameters()},

--- a/deepxde/optimizers/pytorch/optimizers.py
+++ b/deepxde/optimizers/pytorch/optimizers.py
@@ -9,14 +9,12 @@ def is_external_optimizer(optimizer):
     return optimizer in ["L-BFGS", "L-BFGS-B"]
 
 
-def get(params, optimizer, learning_rate=None, decay=None, weight_decay=0):
+def get(params, optimizer, learning_rate=None, decay=None):
     """Retrieves an Optimizer instance."""
     # Custom Optimizer
     if isinstance(optimizer, torch.optim.Optimizer):
         optim = optimizer
     elif optimizer in ["L-BFGS", "L-BFGS-B"]:
-        if weight_decay > 0:
-            raise ValueError("L-BFGS optimizer doesn't support weight_decay > 0")
         if learning_rate is not None or decay is not None:
             print("Warning: learning rate is ignored for {}".format(optimizer))
         optim = torch.optim.LBFGS(
@@ -33,21 +31,13 @@ def get(params, optimizer, learning_rate=None, decay=None, weight_decay=0):
         if learning_rate is None:
             raise ValueError("No learning rate for {}.".format(optimizer))
         if optimizer == "sgd":
-            optim = torch.optim.SGD(params, lr=learning_rate, weight_decay=weight_decay)
+            optim = torch.optim.SGD(params, lr=learning_rate)
         elif optimizer == "rmsprop":
-            optim = torch.optim.RMSprop(
-                params, lr=learning_rate, weight_decay=weight_decay
-            )
+            optim = torch.optim.RMSprop(params, lr=learning_rate)
         elif optimizer == "adam":
-            optim = torch.optim.Adam(
-                params, lr=learning_rate, weight_decay=weight_decay
-            )
+            optim = torch.optim.Adam(params, lr=learning_rate)
         elif optimizer == "adamw":
-            if weight_decay == 0:
-                raise ValueError("AdamW optimizer requires non-zero weight decay")
-            optim = torch.optim.AdamW(
-                params, lr=learning_rate, weight_decay=weight_decay
-            )
+            optim = torch.optim.AdamW(params, lr=learning_rate)
         else:
             raise NotImplementedError(
                 f"{optimizer} to be implemented for backend pytorch."

--- a/deepxde/optimizers/pytorch/optimizers.py
+++ b/deepxde/optimizers/pytorch/optimizers.py
@@ -9,12 +9,14 @@ def is_external_optimizer(optimizer):
     return optimizer in ["L-BFGS", "L-BFGS-B"]
 
 
-def get(params, optimizer, learning_rate=None, decay=None):
+def get(params, optimizer, learning_rate=None, decay=None, weight_decay=0):
     """Retrieves an Optimizer instance."""
     # Custom Optimizer
     if isinstance(optimizer, torch.optim.Optimizer):
         optim = optimizer
     elif optimizer in ["L-BFGS", "L-BFGS-B"]:
+        if weight_decay > 0:
+            raise ValueError("L-BFGS optimizer doesn't support weight_decay > 0")
         if learning_rate is not None or decay is not None:
             print("Warning: learning rate is ignored for {}".format(optimizer))
         optim = torch.optim.LBFGS(
@@ -31,13 +33,21 @@ def get(params, optimizer, learning_rate=None, decay=None):
         if learning_rate is None:
             raise ValueError("No learning rate for {}.".format(optimizer))
         if optimizer == "sgd":
-            optim = torch.optim.SGD(params, lr=learning_rate)
+            optim = torch.optim.SGD(params, lr=learning_rate, weight_decay=weight_decay)
         elif optimizer == "rmsprop":
-            optim = torch.optim.RMSprop(params, lr=learning_rate)
+            optim = torch.optim.RMSprop(
+                params, lr=learning_rate, weight_decay=weight_decay
+            )
         elif optimizer == "adam":
-            optim = torch.optim.Adam(params, lr=learning_rate)
+            optim = torch.optim.Adam(
+                params, lr=learning_rate, weight_decay=weight_decay
+            )
         elif optimizer == "adamw":
-            optim = torch.optim.AdamW(params, lr=learning_rate)
+            if weight_decay == 0:
+                raise ValueError("AdamW optimizer requires non-zero weight decay")
+            optim = torch.optim.AdamW(
+                params, lr=learning_rate, weight_decay=weight_decay
+            )
         else:
             raise NotImplementedError(
                 f"{optimizer} to be implemented for backend pytorch."


### PR DESCRIPTION
L1 regularizer is added. Not quite sure about the line:
```
l1_loss = torch.sum(torch.stack([torch.sum(p.abs()) for p in trainable_variables]))
```
Perhaps regularization should not be applied to `self.external_trainable_variables`? Then it must be like:
```
l1_loss = torch.sum(torch.stack([torch.sum(p.abs()) for p in self.net.parameters()]))
```
However, in current l2 regularization `trainable_variables` (both `self.net.parameters()` and `self.external_trainable_variables`) are used.