### PR TITLE
Backend paddle: adding the type conversion of mf data to support examples in directory 'function'

### DIFF
--- a/deepxde/data/mf.py
+++ b/deepxde/data/mf.py
@@ -38,14 +38,14 @@ class MfFunc(Data):
                     self.geom.uniform_points(self.num_lo, True),
                     self.geom.uniform_points(self.num_hi, True),
                 )
-            ).astype(config.real(np))
+            )
         else:
             self.X_train = np.vstack(
                 (
                     self.geom.random_points(self.num_lo, random=self.dist_train),
                     self.geom.random_points(self.num_hi, random=self.dist_train),
                 )
-            ).astype(config.real(np))
+            )
         y_lo_train = self.func_lo(self.X_train)
         y_hi_train = self.func_hi(self.X_train)
         self.y_train = [y_lo_train, y_hi_train]
@@ -53,9 +53,7 @@ class MfFunc(Data):
 
     @run_if_any_none("X_test", "y_test")
     def test(self):
-        self.X_test = self.geom.uniform_points(self.num_test, True).astype(
-            config.real(np)
-        )
+        self.X_test = self.geom.uniform_points(self.num_test, True)
         y_lo_test = self.func_lo(self.X_test)
         y_hi_test = self.func_hi(self.X_test)
         self.y_test = [y_lo_test, y_hi_test]

--- a/deepxde/data/mf.py
+++ b/deepxde/data/mf.py
@@ -1,7 +1,8 @@
 import numpy as np
 
 from .data import Data
-from ..backend import tf
+from .. import backend as bkd
+from .. import config
 from ..utils import run_if_any_none, standardize
 
 
@@ -116,7 +117,7 @@ class MfDataSet(Data):
         return [loss_lo, loss_hi]
 
     def losses_test(self, targets, outputs, loss_fn, inputs, model, aux=None):
-        return [0, loss_fn(targets[1], outputs[1])]
+        return [bkd.as_tensor(0, dtype=config.real(bkd.lib)), loss_fn(targets[1], outputs[1])]
 
     @run_if_any_none("X_train", "y_train")
     def train_next_batch(self, batch_size=None):

--- a/deepxde/data/mf.py
+++ b/deepxde/data/mf.py
@@ -38,14 +38,14 @@ class MfFunc(Data):
                     self.geom.uniform_points(self.num_lo, True),
                     self.geom.uniform_points(self.num_hi, True),
                 )
-            )
+            ).astype(config.real(np))
         else:
             self.X_train = np.vstack(
                 (
                     self.geom.random_points(self.num_lo, random=self.dist_train),
                     self.geom.random_points(self.num_hi, random=self.dist_train),
                 )
-            )
+            ).astype(config.real(np))
         y_lo_train = self.func_lo(self.X_train)
         y_hi_train = self.func_hi(self.X_train)
         self.y_train = [y_lo_train, y_hi_train]
@@ -53,7 +53,9 @@ class MfFunc(Data):
 
     @run_if_any_none("X_test", "y_test")
     def test(self):
-        self.X_test = self.geom.uniform_points(self.num_test, True)
+        self.X_test = self.geom.uniform_points(self.num_test, True).astype(
+            config.real(np)
+        )
         y_lo_test = self.func_lo(self.X_test)
         y_hi_test = self.func_hi(self.X_test)
         self.y_test = [y_lo_test, y_hi_test]
@@ -84,20 +86,20 @@ class MfDataSet(Data):
         standardize=False,
     ):
         if X_lo_train is not None:
-            self.X_lo_train = X_lo_train
-            self.X_hi_train = X_hi_train
-            self.y_lo_train = y_lo_train
-            self.y_hi_train = y_hi_train
-            self.X_hi_test = X_hi_test
-            self.y_hi_test = y_hi_test
+            self.X_lo_train = X_lo_train.astype(config.real(np))
+            self.X_hi_train = X_hi_train.astype(config.real(np))
+            self.y_lo_train = y_lo_train.astype(config.real(np))
+            self.y_hi_train = y_hi_train.astype(config.real(np))
+            self.X_hi_test = X_hi_test.astype(config.real(np))
+            self.y_hi_test = y_hi_test.astype(config.real(np))
         elif fname_lo_train is not None:
-            data = np.loadtxt(fname_lo_train)
+            data = np.loadtxt(fname_lo_train).astype(config.real(np))
             self.X_lo_train = data[:, col_x]
             self.y_lo_train = data[:, col_y]
-            data = np.loadtxt(fname_hi_train)
+            data = np.loadtxt(fname_hi_train).astype(config.real(np))
             self.X_hi_train = data[:, col_x]
             self.y_hi_train = data[:, col_y]
-            data = np.loadtxt(fname_hi_test)
+            data = np.loadtxt(fname_hi_test).astype(config.real(np))
             self.X_hi_test = data[:, col_x]
             self.y_hi_test = data[:, col_y]
         else:
@@ -117,7 +119,10 @@ class MfDataSet(Data):
         return [loss_lo, loss_hi]
 
     def losses_test(self, targets, outputs, loss_fn, inputs, model, aux=None):
-        return [bkd.as_tensor(0, dtype=config.real(bkd.lib)), loss_fn(targets[1], outputs[1])]
+        return [
+            bkd.as_tensor(0, dtype=config.real(bkd.lib)),
+            loss_fn(targets[1], outputs[1]),
+        ]
 
     @run_if_any_none("X_train", "y_train")
     def train_next_batch(self, batch_size=None):

--- a/examples/function/func_uncertainty.py
+++ b/examples/function/func_uncertainty.py
@@ -1,4 +1,4 @@
-"""Backend supported: tensorflow.compat.v1, tensorflow"""
+"""Backend supported: tensorflow.compat.v1, tensorflow, paddle"""
 import deepxde as dde
 import numpy as np
 

--- a/examples/function/mf_dataset.py
+++ b/examples/function/mf_dataset.py
@@ -1,4 +1,4 @@
-"""Backend supported: tensorflow.compat.v1"""
+"""Backend supported: tensorflow.compat.v1, paddle"""
 import deepxde as dde
 
 

--- a/examples/function/mf_func.py
+++ b/examples/function/mf_func.py
@@ -1,4 +1,4 @@
-"""Backend supported: tensorflow.compat.v1"""
+"""Backend supported: tensorflow.compat.v1, paddle"""
 import deepxde as dde
 import numpy as np
 


### PR DESCRIPTION
1. support examples in examples/function/
2. comparison of results(tf vs paddle) in https://github.com/lululxvi/deepxde/pull/1893