### PR TITLE
Fix bug in PDEOperatorCartesianProd

### DIFF
--- a/deepxde/data/pde_operator.py
+++ b/deepxde/data/pde_operator.py
@@ -307,7 +307,7 @@ class PDEOperatorCartesianProd(Data):
 
         losses_bc = zip(*losses_bc)
         losses_bc = [bkd.reduce_mean(bkd.stack(loss, 0)) for loss in losses_bc]
-        losses.append(losses_bc)
+        losses += losses_bc
         return losses
 
     def losses_train(self, targets, outputs, loss_fn, inputs, model, aux=None):


### PR DESCRIPTION
Running operator examples with PyTorch backend throws an error shown below:

```
Using backend: pytorch
Other supported backends: tensorflow.compat.v1, tensorflow, jax, paddle.
paddle supports more examples now and is recommended.
Compiling model...
'compile' took 0.816340 s

Training model...

Traceback (most recent call last):
  File ".../deepxde/examples/operator/poisson_1d_pideeponet.py", line 61, in <module>
    model.train()
  File ".../deepxde/deepxde/utils/internal.py", line 22, in wrapper
    result = f(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^
  File ".../deepxde/deepxde/model.py", line 673, in train
    self._test(verbose=verbose)
  File ".../deepxde/deepxde/model.py", line 866, in _test
    ) = self._outputs_losses(
        ^^^^^^^^^^^^^^^^^^^^^
  File ".../deepxde/deepxde/model.py", line 579, in _outputs_losses
    outs = outputs_losses(inputs, targets, auxiliary_vars)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../deepxde/deepxde/model.py", line 325, in outputs_losses_train
    return outputs_losses(
           ^^^^^^^^^^^^^^^
  File ".../deepxde/deepxde/model.py", line 316, in outputs_losses
    losses = torch.stack(losses)
             ^^^^^^^^^^^^^^^^^^^
TypeError: expected Tensor as element 1 in argument 0, but got list
```

This change ensures that the `losses` variable is a compatible type for `torch.stack`.