### PR TITLE
Backend paddle: allow enable prim to support more brands of chips and hardware devices

### DIFF
--- a/deepxde/backend/paddle/__init__.py
+++ b/deepxde/backend/paddle/__init__.py
@@ -1,1 +1,17 @@
+import os
+
 from .tensor import *  # pylint: disable=redefined-builtin
+
+# enable prim if specified
+enable_prim_value = os.getenv("PRIM")
+enable_prim = enable_prim_value.lower() in ['1', 'true', 'yes', 'on'] if enable_prim_value else False
+if enable_prim:
+    # Mostly for compiler running with dy2st.
+    from paddle.framework import core
+
+    core.set_prim_eager_enabled(True)
+    # The following protected member access is required.
+    # There is no alternative public API available now.
+    # pylint: disable=protected-access
+    core._set_prim_all_enabled(True)
+    print("Prim mode is enabled.")


### PR DESCRIPTION
’prim‘ is a function in the paddle framework. 

This PR add a part of code which allow users to enable prim mode by using 'PRIM=1'. If enable it, the entire command become 'PRIM=1 DDE_BACKEND=paddle python fractional_diffusion_1d.py'.

Brief introduction of prim：
There are many operators in the framework, some of them are complex(coarse-grained), like ‘log_softmax’, some of them are simple(fine-grained), like 'max'/'sum'/'sub'.
In short, 'prim' represents the process of decomposing the coarse-grained operator fine-grained operators.
Take 'log_softmax' as an example, the running process before decomposing is 'input->op(log_softmax)->output' and after decomposing is 'input->op(max)->op(sub)->op(exp)->op(sum)->op(log)->op(sub)->output'(The backward process will also be modified accordingly).

**For details, please see the comments in this PR.**

<img width="107" alt="image" src="https://github.com/user-attachments/assets/652faabc-ba4d-4dc8-baec-4302ae3f344a" />
