### PR TITLE
Add Apple MPS GPU support

### DIFF
--- a/deepxde/backend/pytorch/tensor.py
+++ b/deepxde/backend/pytorch/tensor.py
@@ -20,6 +20,9 @@ if torch.cuda.is_available():
         torch.set_default_device("cuda")
     else:
         torch.set_default_tensor_type(torch.cuda.FloatTensor)
+elif torch.backends.mps.is_available():
+    torch.set_default_device("mps")
+    torch._dynamo.disable()  # A temporary trick to evade the Pytorch MPS bug (https://github.com/pytorch/pytorch/issues/149184)
 
 
 lib = torch


### PR DESCRIPTION
There is a Pytorch bug that occurs when an optimizer is created for a network which is on an MPS GPU (https://github.com/pytorch/pytorch/issues/149184), thus a trick to avoid it is needed.