### PR TITLE
PyTorch: specify weights_only for torch.load()

### DIFF
--- a/deepxde/model.py
+++ b/deepxde/model.py
@@ -1137,9 +1137,9 @@ class Model:
             self.net.load_weights(save_path)
         elif backend_name == "pytorch":
             if device is not None:
-                checkpoint = torch.load(save_path, map_location=torch.device(device))
+                checkpoint = torch.load(save_path, map_location=torch.device(device), weights_only=True)
             else:
-                checkpoint = torch.load(save_path)
+                checkpoint = torch.load(save_path, weights_only=True)
             self.net.load_state_dict(checkpoint["model_state_dict"])
             self.opt.load_state_dict(checkpoint["optimizer_state_dict"])
         elif backend_name == "paddle":


### PR DESCRIPTION
It makes sense to specify parameter `weights_only` for `torch.load` explicitly. The default value has changed from False to True in the latest version (2.6).