### PR TITLE
Fix for PyTorch MPS support

### DIFF
--- a/deepxde/backend/pytorch/tensor.py
+++ b/deepxde/backend/pytorch/tensor.py
@@ -22,14 +22,16 @@ if torch.cuda.is_available():
         torch.set_default_tensor_type(torch.cuda.FloatTensor)
 elif torch.backends.mps.is_available():
     fallback_device = torch.get_default_device()
-    torch.set_default_device("mps")
     
     # As of March 2025, the macOS X-based GitHub Actions building environment sees
     # the MPS GPU, but cannot access it. So, a try-except workaround is applied.
     try:
         # A temporary trick to evade the Pytorch optimizer bug on MPS GPUs
         # See https://github.com/pytorch/pytorch/issues/149184
+        # As for May 2025, it must go before the default device change
         torch._dynamo.disable()
+        
+        torch.set_default_device("mps")
         
         # If the Pytorch optimizer bug is fixed and the line above is removed,
         # the following code will perform a simple check of the MPS GPU


### PR DESCRIPTION
Hello.

This is a fix for setting the default PyTorch device to be MPS.
**Before**: first `torch.set_default_device("mps")`, then `torch._dynamo.disable()`.
**Now**: vice versa.

Some tensor operations occur during "torch._dynamo.disable()" (which is used to cope with [the PyTorch optimizer bug](https://github.com/pytorch/pytorch/issues/149184)), which may lead to crash if the default device has already been set to MPS.

I apologize: for the previous MPS pull request I could not test the code well enough. I had no Apple Silicon device, so I asked one person to check the code sequence for me, and probably a misunderstanding happened. This time I received an M4 MacBook and tested everything by myself.

