### PR TITLE
Added support for JAX for Neumann and Robin BC

### DIFF
--- a/deepxde/gradients/gradients_reverse.py
+++ b/deepxde/gradients/gradients_reverse.py
@@ -23,9 +23,7 @@ class JacobianReverse(Jacobian):
         elif backend_name == "jax":
             ndim_y = bkd.ndim(self.ys[0])
         if ndim_y == 3:
-            raise NotImplementedError(
-                "Reverse-mode autodiff doesn't support 3D output"
-            )
+            raise NotImplementedError("Reverse-mode autodiff doesn't support 3D output")
 
         # Compute J[i, :]
         if i not in self.J:
@@ -138,6 +136,8 @@ class Hessians:
             key = (id(ys[0]), id(xs), component)
         if key not in self.Hs:
             self.Hs[key] = Hessian(ys, xs, component=component)
+        if backend_name == "jax":
+            return self.Hs[key](i, j)[0]
         return self.Hs[key](i, j)
 
     def clear(self):


### PR DESCRIPTION
I made a few modifications in `gradients_reserve.py` and `boundary_conditions.py` to enable out-of-the-box support for JAX, at least for the example `deepxde/examples/pinn_forward/Poisson_Neumann_1d.py`. 

I have tested the changes on a few examples, and it seems to work for without issues for both PyTorch and JAX, but the testing has not been exhaustive.