### PR TITLE
Update index.rst to include a link to an introductory course

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ DeepXDE
 
 DeepXDE supports five tensor libraries as backends: TensorFlow 1.x (``tensorflow.compat.v1`` in TensorFlow 2.x), TensorFlow 2.x, PyTorch, JAX, and PaddlePaddle. For how to select one, see `Working with different backends <https://deepxde.readthedocs.io/en/latest/user/installation.html#working-with-different-backends>`_.
 
-**Documentation**: `ReadTheDocs <https://deepxde.readthedocs.io/>`_
+**Documentation**: `ReadTheDocs <https://deepxde.readthedocs.io>`_
 
 .. image:: images/pinn.png
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ DeepXDE
 
 DeepXDE supports five tensor libraries as backends: TensorFlow 1.x (``tensorflow.compat.v1`` in TensorFlow 2.x), TensorFlow 2.x, PyTorch, JAX, and PaddlePaddle. For how to select one, see `Working with different backends <https://deepxde.readthedocs.io/en/latest/user/installation.html#working-with-different-backends>`_.
 
-**Documentation**: `ReadTheDocs <https://deepxde.readthedocs.io/>`_
+**Documentation**: `ReadTheDocs <https://deepxde.readthedocs.io/>`_ , `An introductory course to PINNs and DeepONet <https://github.com/fperiago/pinn_deeponet_for_beginners>`_.
 
 .. image:: images/pinn.png
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ DeepXDE
 
 DeepXDE supports five tensor libraries as backends: TensorFlow 1.x (``tensorflow.compat.v1`` in TensorFlow 2.x), TensorFlow 2.x, PyTorch, JAX, and PaddlePaddle. For how to select one, see `Working with different backends <https://deepxde.readthedocs.io/en/latest/user/installation.html#working-with-different-backends>`_.
 
-**Documentation**: `ReadTheDocs <https://deepxde.readthedocs.io/>`_ , `An introductory course to PINNs and DeepONet <https://github.com/fperiago/pinn_deeponet_for_beginners>`_.
+**Documentation**: `ReadTheDocs <https://deepxde.readthedocs.io/>`_
 
 .. image:: images/pinn.png
 

--- a/docs/user/research.rst
+++ b/docs/user/research.rst
@@ -654,4 +654,4 @@ Multi-fidelity NN
 Tutorial
 --------
 
-#. `An introductory course to PINNs and DeepONet <https://github.com/fperiago/pinn_deeponet_for_beginners>`
+#. `An introductory course to PINNs and DeepONet <https://github.com/fperiago/pinn_deeponet_for_beginners>`_

--- a/docs/user/research.rst
+++ b/docs/user/research.rst
@@ -650,3 +650,8 @@ Multi-fidelity NN
 
 #. L\. Lu, M. Dao, P. Kumar, U. Ramamurty, G. Karniadakis, & S. Suresh. `Extraction of mechanical properties of materials through deep learning from instrumented indentation <https://doi.org/10.1073/pnas.1922210117>`_. *Proceedings of the National Academy of Sciences*, 117(13), 7052--7062, 2020.
 #. X\. Meng, & G. Karniadakis. `A composite neural network that learns from multi-fidelity data: Application to function approximation and inverse PDE problems <https://doi.org/10.1016/j.jcp.2019.109020>`_. *Journal of Computational Physics*, 401, 109020, 2020.
+
+Tutorial
+--------
+
+#. `An introductory course to PINNs and DeepONet <https://github.com/fperiago/pinn_deeponet_for_beginners>`


### PR DESCRIPTION
I included a link to an introductory course on PINNs and DeepONet on the Documentation  section on index.rst. 