### PR TITLE
Use KDTree to implement PointSet and PointCloud more efficiently

### DIFF
--- a/deepxde/geometry/pointcloud.py
+++ b/deepxde/geometry/pointcloud.py
@@ -34,7 +34,7 @@ class PointCloud(Geometry):
                 self.boundary_normals = np.asarray(
                     boundary_normals, dtype=config.real(np)
                 )
-                self._boundary_normal_query = self._boundary_point_set.values_to_func(self.boundary_normals, default_value=None)
+                self._boundary_normal_query = self._boundary_point_set.values_to_func(self.boundary_normals)
         super().__init__(
             len(self.points[0]),
             (np.amin(all_points, axis=0), np.amax(all_points, axis=0)),

--- a/deepxde/utils/external.py
+++ b/deepxde/utils/external.py
@@ -38,7 +38,7 @@ class PointSet:
         distance = np.asarray(distance, self.points.dtype)
         return isclose(distance, 0)
 
-    def values_to_func(self, values, default_value=0):
+    def values_to_func(self, values, default_value=None):
         """Convert the pairs of points and values to a callable function.
 
         Args:


### PR DESCRIPTION
The brute-force matching algorithm in the `PointCloud` is extremely costly in both time and space complexity ( $O(mnk)$ ). When working with hundreds of thousands of points, my process runs for a long time and is often terminated by the OOM killer. Implementing the matching using SciPy's `KDTree` significantly reduces both memory usage and execution time.