### PR TITLE
Add math support to DeepXDE docs, fixing worst offenders in deepxde.data.fpde

### DIFF
--- a/deepxde/data/fpde.py
+++ b/deepxde/data/fpde.py
@@ -57,7 +57,7 @@ class FPDE(PDE):
     * $\theta$ is the differentiation direction vector.
 
     The solution $u(x)$ is assumed to be identically zero in the boundary and 
-    exterior of the domain. When $D = 1$, the constant simplifies to: 
+    exterior of the domain. When $D = 1$, the constant simplifies to
     $$C(\alpha, D) = \frac{1}{2 \cos(\alpha \pi / 2)}$$
 
     .. note::

--- a/deepxde/data/fpde.py
+++ b/deepxde/data/fpde.py
@@ -48,11 +48,9 @@ class FPDE(PDE):
     r"""Fractional PDE solver.
 
     The $D$-dimensional fractional Laplacian of order $\alpha/2$ ($1 < \alpha < 2$) 
-    is defined as:
-
+    is defined as
     $$(-\Delta)^{\alpha/2} u(x) = C(\alpha, D) \int_{\|\theta\|=1} D_{\theta}^\alpha u(x) \, d\theta$$
-
-    where:
+    where
 
     * $C(\alpha, D) = \frac{\Gamma((1-\alpha)/2) \Gamma((D+\alpha)/2)}{2 \pi^{(D+1)/2}}$
     * $D_{\theta}^\alpha$ is the Riemann-Liouville directional fractional derivative.
@@ -63,7 +61,6 @@ class FPDE(PDE):
     $$C(\alpha, D) = \frac{1}{2 \cos(\alpha \pi / 2)}$$
 
     .. note::
-
         This solver does not consider $C(\alpha, D)$ in the fractional Laplacian, 
         and only discretizes $\int_{\|\theta\|=1} D_{\theta}^\alpha u(x) \, d\theta$. 
         The derivative $D_{\theta}^\alpha$ is approximated by the 
@@ -213,11 +210,9 @@ class TimeFPDE(FPDE):
     r"""Time-dependent fractional PDE solver.
 
     The $D$-dimensional fractional Laplacian of order $\alpha/2$ ($1 < \alpha < 2$) 
-    is defined as:
-
+    is defined as
     $$(-\Delta)^{\alpha/2} u(x) = C(\alpha, D) \int_{\|\theta\|=1} D_{\theta}^\alpha u(x) \, d\theta$$
-
-    where:
+    where
 
     * $C(\alpha, D) = \frac{\Gamma((1-\alpha)/2) \Gamma((D+\alpha)/2)}{2 \pi^{(D+1)/2}}$
     * $D_{\theta}^\alpha$ is the Riemann-Liouville directional fractional derivative.
@@ -225,7 +220,7 @@ class TimeFPDE(FPDE):
     * The solution $u(x)$ is assumed to be identically zero in the boundary and 
     exterior of the domain.
 
-    When $D = 1$, the constant simplifies to: 
+    When $D = 1$, the constant simplifies to
     $$C(\alpha, D) = \frac{1}{2 \cos(\alpha \pi / 2)}$$
 
     .. note::

--- a/deepxde/data/fpde.py
+++ b/deepxde/data/fpde.py
@@ -227,7 +227,7 @@ class TimeFPDE(FPDE):
     .. note::
         This solver **does not consider** $C(\alpha, D)$ in the fractional 
         Laplacian calculation. It only discretizes the integral $\int_{\|\theta\|=1} D_{\theta}^\alpha u(x) \, d\theta$, 
-        where $D_{\theta}^\alpha$ is approximated by the **Grünwald-Letnikov** formula.
+        where $D_{\theta}^\alpha$ is approximated by the Grünwald-Letnikov formula.
     """
 
     def __init__(

--- a/deepxde/data/fpde.py
+++ b/deepxde/data/fpde.py
@@ -47,24 +47,28 @@ class Scheme:
 class FPDE(PDE):
     r"""Fractional PDE solver.
 
-    D-dimensional fractional Laplacian of order alpha/2 (1 < alpha < 2) is defined as:
-    (-Delta)^(alpha/2) u(x) = C(alpha, D) \int_{||theta||=1} D_theta^alpha u(x) d theta,
-    where C(alpha, D) = gamma((1-alpha)/2) * gamma((D+alpha)/2) / (2 pi^((D+1)/2)),
-    D_theta^alpha is the Riemann-Liouville directional fractional derivative,
-    and theta is the differentiation direction vector.
-    The solution u(x) is assumed to be identically zero in the boundary and exterior of the domain.
-    When D = 1, C(alpha, D) = 1 / (2 cos(alpha * pi / 2)).
+    The $D$-dimensional fractional Laplacian of order $\alpha/2$ ($1 < \alpha < 2$) 
+    is defined as:
 
-    This solver does not consider C(alpha, D) in the fractional Laplacian,
-    and only discretizes \int_{||theta||=1} D_theta^alpha u(x) d theta.
-    D_theta^alpha is approximated by Grunwald-Letnikov formula.
+    $$(-\Delta)^{\alpha/2} u(x) = C(\alpha, D) \int_{\|\theta\|=1} D_{\theta}^\alpha u(x) \, d\theta$$
 
-    References:
-        `G. Pang, L. Lu, & G. E. Karniadakis. fPINNs: Fractional physics-informed neural
-        networks. SIAM Journal on Scientific Computing, 41(4), A2603--A2626, 2019
-        <https://doi.org/10.1137/18M1229845>`_.
+    where:
+
+    * $C(\alpha, D) = \frac{\Gamma((1-\alpha)/2) \Gamma((D+\alpha)/2)}{2 \pi^{(D+1)/2}}$
+    * $D_{\theta}^\alpha$ is the Riemann-Liouville directional fractional derivative.
+    * $\theta$ is the differentiation direction vector.
+
+    The solution $u(x)$ is assumed to be identically zero in the boundary and 
+    exterior of the domain. When $D = 1$, the constant simplifies to: 
+    $$C(\alpha, D) = \frac{1}{2 \cos(\alpha \pi / 2)}$$
+
+    .. note::
+
+        This solver does not consider $C(\alpha, D)$ in the fractional Laplacian, 
+        and only discretizes $\int_{\|\theta\|=1} D_{\theta}^\alpha u(x) \, d\theta$. 
+        The derivative $D_{\theta}^\alpha$ is approximated by the 
+        **Grünwald–Letnikov** formula.
     """
-
     def __init__(
         self,
         geometry,
@@ -208,22 +212,30 @@ class FPDE(PDE):
 class TimeFPDE(FPDE):
     r"""Time-dependent fractional PDE solver.
 
-    D-dimensional fractional Laplacian of order alpha/2 (1 < alpha < 2) is defined as:
-    (-Delta)^(alpha/2) u(x) = C(alpha, D) \int_{||theta||=1} D_theta^alpha u(x) d theta,
-    where C(alpha, D) = gamma((1-alpha)/2) * gamma((D+alpha)/2) / (2 pi^((D+1)/2)),
-    D_theta^alpha is the Riemann-Liouville directional fractional derivative,
-    and theta is the differentiation direction vector.
-    The solution u(x) is assumed to be identically zero in the boundary and exterior of the domain.
-    When D = 1, C(alpha, D) = 1 / (2 cos(alpha * pi / 2)).
+    The $D$-dimensional fractional Laplacian of order $\alpha/2$ ($1 < \alpha < 2$) 
+    is defined as:
 
-    This solver does not consider C(alpha, D) in the fractional Laplacian,
-    and only discretizes \int_{||theta||=1} D_theta^alpha u(x) d theta.
-    D_theta^alpha is approximated by Grunwald-Letnikov formula.
+    $$(-\Delta)^{\alpha/2} u(x) = C(\alpha, D) \int_{\|\theta\|=1} D_{\theta}^\alpha u(x) \, d\theta$$
 
-    References:
-        `G. Pang, L. Lu, & G. E. Karniadakis. fPINNs: Fractional physics-informed neural
-        networks. SIAM Journal on Scientific Computing, 41(4), A2603--A2626, 2019
-        <https://doi.org/10.1137/18M1229845>`_.
+    where:
+
+    * $C(\alpha, D) = \frac{\Gamma((1-\alpha)/2) \Gamma((D+\alpha)/2)}{2 \pi^{(D+1)/2}}$
+    * $D_{\theta}^\alpha$ is the Riemann-Liouville directional fractional derivative.
+    * $\theta$ is the differentiation direction vector.
+    * The solution $u(x)$ is assumed to be identically zero in the boundary and 
+    exterior of the domain.
+
+    When $D = 1$, the constant simplifies to: 
+    $$C(\alpha, D) = \frac{1}{2 \cos(\alpha \pi / 2)}$$
+
+    .. note::
+
+        **Implementation Details:**
+        
+        * This solver **does not consider** $C(\alpha, D)$ in the fractional 
+        Laplacian calculation.
+        * It only discretizes the integral $\int_{\|\theta\|=1} D_{\theta}^\alpha u(x) \, d\theta$.
+        * The term $D_{\theta}^\alpha$ is approximated by the **Grünwald-Letnikov** formula.
     """
 
     def __init__(

--- a/deepxde/data/fpde.py
+++ b/deepxde/data/fpde.py
@@ -67,7 +67,7 @@ class FPDE(PDE):
         This solver does not consider $C(\alpha, D)$ in the fractional Laplacian, 
         and only discretizes $\int_{\|\theta\|=1} D_{\theta}^\alpha u(x) \, d\theta$. 
         The derivative $D_{\theta}^\alpha$ is approximated by the 
-        **Grünwald–Letnikov** formula.
+        Grünwald–Letnikov formula.
     """
     def __init__(
         self,
@@ -229,13 +229,9 @@ class TimeFPDE(FPDE):
     $$C(\alpha, D) = \frac{1}{2 \cos(\alpha \pi / 2)}$$
 
     .. note::
-
-        **Implementation Details:**
-        
-        * This solver **does not consider** $C(\alpha, D)$ in the fractional 
-        Laplacian calculation.
-        * It only discretizes the integral $\int_{\|\theta\|=1} D_{\theta}^\alpha u(x) \, d\theta$.
-        * The term $D_{\theta}^\alpha$ is approximated by the **Grünwald-Letnikov** formula.
+        This solver **does not consider** $C(\alpha, D)$ in the fractional 
+        Laplacian calculation. It only discretizes the integral $\int_{\|\theta\|=1} D_{\theta}^\alpha u(x) \, d\theta$, 
+        where $D_{\theta}^\alpha$ is approximated by the **Grünwald-Letnikov** formula.
     """
 
     def __init__(

--- a/deepxde/data/fpde.py
+++ b/deepxde/data/fpde.py
@@ -49,7 +49,7 @@ class FPDE(PDE):
 
     The $D$-dimensional fractional Laplacian of order $\alpha/2$ ($1 < \alpha < 2$) 
     is defined as
-    $$(-\Delta)^{\alpha/2} u(x) = C(\alpha, D) \int_{\|\theta\|=1} D_{\theta}^\alpha u(x) \, d\theta$$
+    $$(-\Delta)^{\alpha/2} u(x) = C(\alpha, D) \int_{\|\theta\|=1} D_{\theta}^\alpha u(x) \, d\theta,$$
     where
 
     * $C(\alpha, D) = \frac{\Gamma((1-\alpha)/2) \Gamma((D+\alpha)/2)}{2 \pi^{(D+1)/2}}$
@@ -58,7 +58,7 @@ class FPDE(PDE):
 
     The solution $u(x)$ is assumed to be identically zero in the boundary and 
     exterior of the domain. When $D = 1$, the constant simplifies to
-    $$C(\alpha, D) = \frac{1}{2 \cos(\alpha \pi / 2)}$$
+    $$C(\alpha, D) = \frac{1}{2 \cos(\alpha \pi / 2)}.$$
 
     .. note::
         This solver does not consider $C(\alpha, D)$ in the fractional Laplacian, 
@@ -66,6 +66,7 @@ class FPDE(PDE):
         The derivative $D_{\theta}^\alpha$ is approximated by the 
         Grünwald–Letnikov formula.
     """
+    
     def __init__(
         self,
         geometry,

--- a/deepxde/data/fpde.py
+++ b/deepxde/data/fpde.py
@@ -66,7 +66,7 @@ class FPDE(PDE):
         The derivative $D_{\theta}^\alpha$ is approximated by the 
         Grünwald–Letnikov formula.
     """
-    
+
     def __init__(
         self,
         geometry,
@@ -212,7 +212,7 @@ class TimeFPDE(FPDE):
 
     The $D$-dimensional fractional Laplacian of order $\alpha/2$ ($1 < \alpha < 2$) 
     is defined as
-    $$(-\Delta)^{\alpha/2} u(x) = C(\alpha, D) \int_{\|\theta\|=1} D_{\theta}^\alpha u(x) \, d\theta$$
+    $$(-\Delta)^{\alpha/2} u(x) = C(\alpha, D) \int_{\|\theta\|=1} D_{\theta}^\alpha u(x) \, d\theta,$$
     where
 
     * $C(\alpha, D) = \frac{\Gamma((1-\alpha)/2) \Gamma((D+\alpha)/2)}{2 \pi^{(D+1)/2}}$
@@ -222,7 +222,7 @@ class TimeFPDE(FPDE):
     exterior of the domain.
 
     When $D = 1$, the constant simplifies to
-    $$C(\alpha, D) = \frac{1}{2 \cos(\alpha \pi / 2)}$$
+    $$C(\alpha, D) = \frac{1}{2 \cos(\alpha \pi / 2)}.$$
 
     .. note::
         This solver **does not consider** $C(\alpha, D)$ in the fractional 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,8 +49,8 @@ mathjax3_config = {
     "tex": {
         "inlineMath": [["$", "$"], ["\\(", "\\)"]], # Enable $...$  and \(...)\for inline math
         "displayMath": [["$$", "$$"], ["\\[", "\\]"]], # Enable $$...$$ and \[...\] for display math
-        "processEscapes": True, # Allow the use of escape characters in math mode, for example $\$500 dollars$
-    }
+        "processEscapes": True # Allow the use of escape characters in math mode, for example $\$500 dollars$
+    },
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,6 @@ extensions = [
     "sphinx_math_dollar",  # Enabled dollar sign math support
 ]
 
-# Configure MathJax to recognize single dollar signs for inline math
 mathjax3_config = {
     "tex": {
         "inlineMath": [["$", "$"], ["\\(", "\\)"]], # Enable $...$  and \(...)\for inline math

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ mathjax3_config = {
         "inlineMath": [["$", "$"], ["\\(", "\\)"]], # Enable $...$  and \(...)\for inline math
         "displayMath": [["$$", "$$"], ["\\[", "\\]"]], # Enable $$...$$ and \[...\] for display math
         "processEscapes": True, # Allow the use of escape characters in math mode, for example $\$500 dollars$
-    },
+    }
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,13 +45,6 @@ extensions = [
     "sphinx_math_dollar",  # Enabled dollar sign math support
 ]
 
-mathjax3_config = {
-    "tex": {
-        "inlineMath": [["$", "$"], ["\\(", "\\)"]], # Enable $...$  and \(...)\for inline math
-        "displayMath": [["$$", "$$"], ["\\[", "\\]"]] # Enable $$...$$ and \[...\] for display math
-    },
-}
-
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 
@@ -164,3 +157,10 @@ texinfo_documents = [
 
 
 # -- Extension configuration -------------------------------------------------
+
+mathjax3_config = {
+    "tex": {
+        "inlineMath": [["$", "$"], ["\\(", "\\)"]], # Enable $...$  and \(...)\for inline math
+        "displayMath": [["$$", "$$"], ["\\[", "\\]"]] # Enable $$...$$ and \[...\] for display math
+    },
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,9 +48,9 @@ extensions = [
 # Configure MathJax to recognize single dollar signs for inline math
 mathjax3_config = {
     "tex": {
-        "inlineMath": [["$", "$"], ["\\(", "\\)"]], # Enable $...$ for inline math
-        "displayMath": [["$$", "$$"], ["\\[", "\\]"]], # Enable $$...$$ for display math
-        "processEscapes": True,
+        "inlineMath": [["$", "$"], ["\\(", "\\)"]], # Enable $...$  and \(...)\for inline math
+        "displayMath": [["$$", "$$"], ["\\[", "\\]"]], # Enable $$...$$ and \[...\] for display math
+        "processEscapes": True, # Allow the use of escape characters in math mode, for example $\$500 dollars$
     },
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,17 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "sphinx_copybutton",
+    "sphinx_math_dollar",  # Enabled dollar sign math support
 ]
+
+# Configure MathJax to recognize single dollar signs for inline math
+mathjax3_config = {
+    "tex": {
+        "inlineMath": [["$", "$"], ["\\(", "\\)"]], # Enable $...$ for inline math
+        "displayMath": [["$$", "$$"], ["\\[", "\\]"]], # Enable $$...$$ for display math
+        "processEscapes": True,
+    },
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,8 +48,7 @@ extensions = [
 mathjax3_config = {
     "tex": {
         "inlineMath": [["$", "$"], ["\\(", "\\)"]], # Enable $...$  and \(...)\for inline math
-        "displayMath": [["$$", "$$"], ["\\[", "\\]"]], # Enable $$...$$ and \[...\] for display math
-        "processEscapes": True # Allow the use of escape characters in math mode, for example $\$500 dollars$
+        "displayMath": [["$$", "$$"], ["\\[", "\\]"]] # Enable $$...$$ and \[...\] for display math
     },
 }
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -20,4 +20,5 @@ flax
 optax
 
 sphinx-copybutton
+sphinx-math-dollar
 sphinx-rtd-theme


### PR DESCRIPTION
New docstrings can use single dollar signs or double dollar signs to render math. 

This change is backwards-compatible for other docstrings, as long as they do not contain dollar signs.