### PR TITLE
Add physical context to examples, and use backend-agnostic functions

### DIFF
--- a/examples/pinn_forward/diffusion_1d.py
+++ b/examples/pinn_forward/diffusion_1d.py
@@ -27,7 +27,6 @@ def pde(x, y):
     source_term_val = dde.backend.exp(-x[:, 1:]) * (
         dde.backend.sin(np.pi * x[:, 0:1]) - np.pi**2 * dde.backend.sin(np.pi * x[:, 0:1])
     )
-    # Backend tensorflow.compat.v1 or tensorflow, pytorch, jax, paddle
     return (
         dy_t
         - dy_xx

--- a/examples/pinn_forward/diffusion_1d.py
+++ b/examples/pinn_forward/diffusion_1d.py
@@ -22,33 +22,12 @@ def pde(x, y):
     f = dde.backend.exp(-x[:, 1:]) * (
         dde.backend.sin(np.pi * x[:, 0:1]) - np.pi**2 * dde.backend.sin(np.pi * x[:, 0:1])
     )
-    # Backend tensorflow.compat.v1 or tensorflow
+    # Backend tensorflow.compat.v1 or tensorflow, pytorch, jax, paddle
     return (
         dy_t
         - dy_xx
         + f
     ) 
-    # Backend pytorch
-    # return (
-    #     dy_t
-    #     - dy_xx
-    #     + torch.exp(-x[:, 1:])
-    #     * (torch.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * torch.sin(np.pi * x[:, 0:1]))
-    # )  
-    # Backend jax
-    # return (
-    #     dy_t
-    #     - dy_xx
-    #     + jnp.exp(-x[:, 1:])
-    #     * (jnp.sin(np.pi * x[..., 0:1]) - np.pi ** 2 * jnp.sin(np.pi * x[..., 0:1]))
-    # ) 
-    # Backend paddle
-    # return (
-    #     dy_t
-    #     - dy_xx
-    #     + paddle.exp(-x[:, 1:])
-    #     * (paddle.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * paddle.sin(np.pi * x[:, 0:1]))
-    # )
 
 
 def func(x):

--- a/examples/pinn_forward/diffusion_1d.py
+++ b/examples/pinn_forward/diffusion_1d.py
@@ -1,4 +1,14 @@
-"""Backend supported: tensorflow.compat.v1, tensorflow, pytorch, jax, paddle"""
+"""
+Backend supported: tensorflow.compat.v1, tensorflow, pytorch, jax, paddle
+1D Diffusion Equation with a Time-Dependent Source Term.
+
+This example solves the heat equation:
+∂y/∂t - ∂²y/∂x² = f(x, t)
+where the source term f(x, t) is chosen such that the analytical solution is y = e^(-t) * sin(πx).
+
+Physical context: This represents a 1D rod with a decaying heat source, where the ends are kept at zero temperature (Dirichlet Boundary Conditions).
+"""
+
 import deepxde as dde
 import numpy as np
 # Backend tensorflow.compat.v1 or tensorflow
@@ -18,13 +28,18 @@ def pde(x, y):
     # Backend jax
     # dy_t, _ = dde.grad.jacobian(y, x, j=1)
     # dy_xx, _ = dde.grad.hessian(y, x, j=0)
-    # Backend tensorflow.compat.v1 or tensorflow
+    
+    # Physics Note: The following term is the forced heat source f(x, t)
+    # required to satisfy the analytical solution y = e^(-t)sin(πx).
+    source_term_val = tf.exp(-x[:, 1:]) * (tf.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * tf.sin(np.pi * x[:, 0:1]))
+   
+   # Backend tensorflow.compat.v1 or tensorflow
     return (
         dy_t
         - dy_xx
-        + tf.exp(-x[:, 1:])
-        * (tf.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * tf.sin(np.pi * x[:, 0:1]))
+        + source_term_val
     )
+    
     # Backend pytorch
     # return (
     #     dy_t
@@ -32,6 +47,7 @@ def pde(x, y):
     #     + torch.exp(-x[:, 1:])
     #     * (torch.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * torch.sin(np.pi * x[:, 0:1]))
     # )
+    
     # Backend jax
     # return (
     #     dy_t
@@ -39,6 +55,7 @@ def pde(x, y):
     #     + jnp.exp(-x[:, 1:])
     #     * (jnp.sin(np.pi * x[..., 0:1]) - np.pi ** 2 * jnp.sin(np.pi * x[..., 0:1]))
     # )
+    
     # Backend paddle
     # return (
     #     dy_t

--- a/examples/pinn_forward/diffusion_1d.py
+++ b/examples/pinn_forward/diffusion_1d.py
@@ -1,14 +1,4 @@
-"""
-Backend supported: tensorflow.compat.v1, tensorflow, pytorch, jax, paddle
-1D Diffusion Equation with a Time-Dependent Source Term.
-
-This example solves the heat equation:
-∂y/∂t - ∂²y/∂x² = f(x, t)
-where the source term f(x, t) is chosen such that the analytical solution is y = e^(-t) * sin(πx).
-
-Physical context: This represents a 1D rod with a decaying heat source, where the ends are kept at zero temperature (Dirichlet Boundary Conditions).
-"""
-
+"""Backend supported: tensorflow.compat.v1, tensorflow, pytorch, jax, paddle"""
 import deepxde as dde
 import numpy as np
 # Backend tensorflow.compat.v1 or tensorflow
@@ -28,34 +18,30 @@ def pde(x, y):
     # Backend jax
     # dy_t, _ = dde.grad.jacobian(y, x, j=1)
     # dy_xx, _ = dde.grad.hessian(y, x, j=0)
-    
-    # Physics Note: The following term is the forced heat source f(x, t)
-    # required to satisfy the analytical solution y = e^(-t)sin(πx).
-    source_term_val = tf.exp(-x[:, 1:]) * (tf.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * tf.sin(np.pi * x[:, 0:1]))
-   
-   # Backend tensorflow.compat.v1 or tensorflow
+    # Cross-backend source term
+    f = dde.backend.exp(-x[:, 1:]) * (
+        dde.backend.sin(np.pi * x[:, 0:1]) - np.pi**2 * dde.backend.sin(np.pi * x[:, 0:1])
+    )
+    # Backend tensorflow.compat.v1 or tensorflow
     return (
         dy_t
         - dy_xx
-        + source_term_val
-    )
-    
+        + f
+    ) 
     # Backend pytorch
     # return (
     #     dy_t
     #     - dy_xx
     #     + torch.exp(-x[:, 1:])
     #     * (torch.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * torch.sin(np.pi * x[:, 0:1]))
-    # )
-    
+    # )  
     # Backend jax
     # return (
     #     dy_t
     #     - dy_xx
     #     + jnp.exp(-x[:, 1:])
     #     * (jnp.sin(np.pi * x[..., 0:1]) - np.pi ** 2 * jnp.sin(np.pi * x[..., 0:1]))
-    # )
-    
+    # ) 
     # Backend paddle
     # return (
     #     dy_t

--- a/examples/pinn_forward/diffusion_1d.py
+++ b/examples/pinn_forward/diffusion_1d.py
@@ -1,4 +1,10 @@
-"""Backend supported: tensorflow.compat.v1, tensorflow, pytorch, jax, paddle"""
+"""Backend supported: tensorflow.compat.v1, tensorflow, pytorch, jax, paddle
+1D Diffusion Equation with a Time-Dependent Source Term.
+
+This example solves the heat equation:
+∂y/∂t - ∂²y/∂x² = f(x, t)
+where the source term f(x, t) is chosen such that the analytical solution is y = e^(-t) * sin(πx).
+"""
 import deepxde as dde
 import numpy as np
 # Backend tensorflow.compat.v1 or tensorflow
@@ -15,18 +21,17 @@ def pde(x, y):
     # Most backends
     dy_t = dde.grad.jacobian(y, x, j=1)
     dy_xx = dde.grad.hessian(y, x, j=0)
-    # Backend jax
-    # dy_t, _ = dde.grad.jacobian(y, x, j=1)
-    # dy_xx, _ = dde.grad.hessian(y, x, j=0)
-    # Cross-backend source term
-    f = dde.backend.exp(-x[:, 1:]) * (
+   
+    # Physics Note: The following term is the forced heat source f(x, t)
+    # required to satisfy the analytical solution y = e^(-t)sin(πx).
+    source_term_val = dde.backend.exp(-x[:, 1:]) * (
         dde.backend.sin(np.pi * x[:, 0:1]) - np.pi**2 * dde.backend.sin(np.pi * x[:, 0:1])
     )
     # Backend tensorflow.compat.v1 or tensorflow, pytorch, jax, paddle
     return (
         dy_t
         - dy_xx
-        + f
+        + source_term_val
     ) 
 
 

--- a/examples/pinn_forward/diffusion_1d_exactBC.py
+++ b/examples/pinn_forward/diffusion_1d_exactBC.py
@@ -18,34 +18,16 @@ def pde(x, y):
     # Backend jax
     # dy_t, _ = dde.grad.jacobian(y, x, i=0, j=1)
     # dy_xx, _ = dde.grad.hessian(y, x, i=0, j=0)
-    # Backend tensorflow.compat.v1 or tensorflow
+    # Cross-backend source term
+    f = dde.backend.exp(-x[:, 1:]) * (
+        dde.backend.sin(np.pi * x[:, 0:1]) - np.pi**2 * dde.backend.sin(np.pi * x[:, 0:1])
+    )
+    # Backend tensorflow.compat.v1 or tensorflow, pytorch, jax, paddle
     return (
         dy_t
         - dy_xx
-        + tf.exp(-x[:, 1:])
-        * (tf.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * tf.sin(np.pi * x[:, 0:1]))
+        + f
     )
-    # Backend pytorch
-    # return (
-    #     dy_t
-    #     - dy_xx
-    #     + torch.exp(-x[:, 1:])
-    #     * (torch.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * torch.sin(np.pi * x[:, 0:1]))
-    # )
-    # Backend jax
-    # return (
-    #     dy_t
-    #     - dy_xx
-    #     + jnp.exp(-x[:, 1:])
-    #     * (jnp.sin(np.pi * x[..., 0:1]) - np.pi ** 2 * jnp.sin(np.pi * x[..., 0:1]))
-    # )
-    # Backend paddle
-    # return (
-    #     dy_t
-    #     - dy_xx
-    #     + paddle.exp(-x[:, 1:])
-    #     * (paddle.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * paddle.sin(np.pi * x[:, 0:1]))
-    # )
 
 
 def func(x):
@@ -63,14 +45,8 @@ activation = "tanh"
 initializer = "Glorot uniform"
 net = dde.nn.FNN(layer_size, activation, initializer)
 net.apply_output_transform(
-    # Backend tensorflow.compat.v1 or tensorflow
-    lambda x, y: x[:, 1:2] * (1 - x[:, 0:1] ** 2) * y + tf.sin(np.pi * x[:, 0:1])
-    # Backend pytorch
-    # lambda x, y: x[:, 1:2] * (1 - x[:, 0:1] ** 2) * y + torch.sin(np.pi * x[:, 0:1])
-    # Backend jax
-    # lambda x, y: x[..., 1:2] * (1 - x[..., 0:1] ** 2) * y + jnp.sin(np.pi * x[..., 0:1])
-    # Backend paddle
-    # lambda x, y: x[:, 1:2] * (1 - x[:, 0:1] ** 2) * y + paddle.sin(np.pi * x[:, 0:1])
+    # This single line now works for TensorFlow, PyTorch, JAX, and Paddle
+    lambda x, y: x[:, 1:2] * (1 - x[:, 0:1] ** 2) * y + dde.backend.sin(np.pi * x[:, 0:1])
 )
 
 model = dde.Model(data, net)

--- a/examples/pinn_forward/diffusion_1d_exactBC.py
+++ b/examples/pinn_forward/diffusion_1d_exactBC.py
@@ -1,4 +1,10 @@
-"""Backend supported: tensorflow.compat.v1, tensorflow, pytorch, jax, paddle"""
+"""Backend supported: tensorflow.compat.v1, tensorflow, pytorch, jax, paddle
+1D Diffusion Equation with a Time-Dependent Source Term.
+
+This example solves the heat equation:
+∂y/∂t - ∂²y/∂x² = f(x, t)
+where the source term f(x, t) is chosen such that the analytical solution is y = e^(-t) * sin(πx).
+"""
 import deepxde as dde
 import numpy as np
 # Backend tensorflow.compat.v1 or tensorflow
@@ -15,18 +21,17 @@ def pde(x, y):
     # Most backends
     dy_t = dde.grad.jacobian(y, x, i=0, j=1)
     dy_xx = dde.grad.hessian(y, x, i=0, j=0)
-    # Backend jax
-    # dy_t, _ = dde.grad.jacobian(y, x, i=0, j=1)
-    # dy_xx, _ = dde.grad.hessian(y, x, i=0, j=0)
-    # Cross-backend source term
-    f = dde.backend.exp(-x[:, 1:]) * (
+   
+    # Physics Note: The following term is the forced heat source f(x, t)
+    # required to satisfy the analytical solution y = e^(-t)sin(πx).
+    source_term_val = dde.backend.exp(-x[:, 1:]) * (
         dde.backend.sin(np.pi * x[:, 0:1]) - np.pi**2 * dde.backend.sin(np.pi * x[:, 0:1])
     )
     # Backend tensorflow.compat.v1 or tensorflow, pytorch, jax, paddle
     return (
         dy_t
         - dy_xx
-        + f
+        + source_term_val
     )
 
 
@@ -45,7 +50,7 @@ activation = "tanh"
 initializer = "Glorot uniform"
 net = dde.nn.FNN(layer_size, activation, initializer)
 net.apply_output_transform(
-    # This single line now works for TensorFlow, PyTorch, JAX, and Paddle
+    # This works for TensorFlow, PyTorch, JAX, and Paddle
     lambda x, y: x[:, 1:2] * (1 - x[:, 0:1] ** 2) * y + dde.backend.sin(np.pi * x[:, 0:1])
 )
 

--- a/examples/pinn_forward/diffusion_1d_exactBC.py
+++ b/examples/pinn_forward/diffusion_1d_exactBC.py
@@ -27,7 +27,6 @@ def pde(x, y):
     source_term_val = dde.backend.exp(-x[:, 1:]) * (
         dde.backend.sin(np.pi * x[:, 0:1]) - np.pi**2 * dde.backend.sin(np.pi * x[:, 0:1])
     )
-    # Backend tensorflow.compat.v1 or tensorflow, pytorch, jax, paddle
     return (
         dy_t
         - dy_xx
@@ -50,7 +49,6 @@ activation = "tanh"
 initializer = "Glorot uniform"
 net = dde.nn.FNN(layer_size, activation, initializer)
 net.apply_output_transform(
-    # This works for TensorFlow, PyTorch, JAX, and Paddle
     lambda x, y: x[:, 1:2] * (1 - x[:, 0:1] ** 2) * y + dde.backend.sin(np.pi * x[:, 0:1])
 )
 

--- a/examples/pinn_forward/diffusion_1d_resample.py
+++ b/examples/pinn_forward/diffusion_1d_resample.py
@@ -18,36 +18,18 @@ def pde(x, y):
     # Backend jax
     # dy_t, _ = dde.grad.jacobian(y, x, i=0, j=1)
     # dy_xx, _ = dde.grad.hessian(y, x, i=0, j=0)
-    # Backend tensorflow.compat.v1 or tensorflow
+    # Cross-backend source term
+    f = dde.backend.exp(-x[:, 1:]) * (
+        dde.backend.sin(np.pi * x[:, 0:1]) - np.pi**2 * dde.backend.sin(np.pi * x[:, 0:1])
+    )
+    # Backend tensorflow.compat.v1 or tensorflow, pytorch, jax, paddle
     return (
         dy_t
         - dy_xx
-        + tf.exp(-x[:, 1:])
-        * (tf.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * tf.sin(np.pi * x[:, 0:1]))
+        + f
     )
-    # Backend pytorch
-    # return (
-    #     dy_t
-    #     - dy_xx
-    #     + torch.exp(-x[:, 1:])
-    #     * (torch.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * torch.sin(np.pi * x[:, 0:1]))
-    # )
-    # Backend jax
-    # return (
-    #     dy_t
-    #     - dy_xx
-    #     + jnp.exp(-x[:, 1:])
-    #     * (jnp.sin(np.pi * x[..., 0:1]) - np.pi ** 2 * jnp.sin(np.pi * x[..., 0:1]))
-    # )
-    # Backend paddle
-    # return (
-    #     dy_t
-    #     - dy_xx
-    #     + paddle.exp(-x[:, 1:])
-    #     * (paddle.sin(np.pi * x[:, 0:1]) - np.pi ** 2 * paddle.sin(np.pi * x[:, 0:1]))
-    # )
-
-
+    
+    
 def func(x):
     return np.sin(np.pi * x[:, 0:1]) * np.exp(-x[:, 1:])
 

--- a/examples/pinn_forward/diffusion_1d_resample.py
+++ b/examples/pinn_forward/diffusion_1d_resample.py
@@ -27,7 +27,6 @@ def pde(x, y):
     source_term_val = dde.backend.exp(-x[:, 1:]) * (
         dde.backend.sin(np.pi * x[:, 0:1]) - np.pi**2 * dde.backend.sin(np.pi * x[:, 0:1])
     )
-    # Backend tensorflow.compat.v1 or tensorflow, pytorch, jax, paddle
     return (
         dy_t
         - dy_xx

--- a/examples/pinn_forward/diffusion_1d_resample.py
+++ b/examples/pinn_forward/diffusion_1d_resample.py
@@ -1,4 +1,10 @@
-"""Backend supported: tensorflow.compat.v1, tensorflow, pytorch, jax, paddle"""
+"""Backend supported: tensorflow.compat.v1, tensorflow, pytorch, jax, paddle
+1D Diffusion Equation with Adaptive Point Resampling.
+
+This example solves the heat equation using the PDEPointResampler callback:
+∂y/∂t - ∂²y/∂x² = f(x, t)
+Analytical solution: y = e^(-t) * sin(πx).
+"""
 import deepxde as dde
 import numpy as np
 # Backend tensorflow.compat.v1 or tensorflow
@@ -15,18 +21,17 @@ def pde(x, y):
     # Most backends
     dy_t = dde.grad.jacobian(y, x, i=0, j=1)
     dy_xx = dde.grad.hessian(y, x, i=0, j=0)
-    # Backend jax
-    # dy_t, _ = dde.grad.jacobian(y, x, i=0, j=1)
-    # dy_xx, _ = dde.grad.hessian(y, x, i=0, j=0)
-    # Cross-backend source term
-    f = dde.backend.exp(-x[:, 1:]) * (
+    
+    # Physics Note: The following term is the forced heat source f(x, t)
+    # required to satisfy the analytical solution y = e^(-t)sin(πx).
+    source_term_val = dde.backend.exp(-x[:, 1:]) * (
         dde.backend.sin(np.pi * x[:, 0:1]) - np.pi**2 * dde.backend.sin(np.pi * x[:, 0:1])
     )
     # Backend tensorflow.compat.v1 or tensorflow, pytorch, jax, paddle
     return (
         dy_t
         - dy_xx
-        + f
+        + source_term_val
     )
     
     
@@ -59,7 +64,11 @@ net = dde.nn.FNN(layer_size, activation, initializer)
 
 model = dde.Model(data, net)
 
+# Adaptive Resampling Callback
+# Period=100 means every 100 iterations, the model redistributes 
+# the domain points to where the PDE residual is highest.
 resampler = dde.callbacks.PDEPointResampler(period=100)
+
 model.compile("adam", lr=0.001, metrics=["l2 relative error"])
 losshistory, train_state = model.train(iterations=2000, callbacks=[resampler])
 


### PR DESCRIPTION
As a physicist working with PINNs, I noticed that the 1D diffusion example lacked a physical description of the source term. 

I have : 
1. Added a detailed **Module Docstring** explaining the 1D Heat Equation context. 
2. Refactored the `pde` function to clearly identify the forcing term $f(x, t)$. 
3. Ensured that the source term is derived to satisfy the analytical solution $y = e^{-t} \sin(\pi x)$.

This makes the example more accessible for students and researchers using **DeepXDE** for scientific modeling. 