### PR TITLE
Fix indexing in data sampling for training labels

### DIFF
--- a/deepxde/data/triple.py
+++ b/deepxde/data/triple.py
@@ -87,7 +87,7 @@ class TripleCartesianProd(Data):
         return (
             self.train_x[0][indices_branch],
             self.train_x[1][indices_trunk],
-        ), self.train_y[indices_branch, indices_trunk]
+        ), self.train_y[indices_branch[:, None], indices_trunk]
 
     def test(self):
         return self.test_x, self.test_y


### PR DESCRIPTION
Hi,

I noticed an issue in TripleCartesianProd.train_next_batch when using tuple batch_size (i.e., separate batch sizes for branch and trunk inputs).

Currently, the code uses:

```  self.train_y[indices_branch, indices_trunk] ```

However, this performs NumPy advanced indexing over paired indices instead of selecting the Cartesian product. As a result, it returns a 1D array of shape `(batch_size,)` instead of the expected 2D submatrix ` (len(indices_branch), len(indices_trunk)).`

Since `TripleCartesianProd `represents data in Cartesian product form (`y_train `with shape `(N1, N2)`), the batch selection should also preserve this structur

### Why this matters
This affects training when using:  
`batch_size = (branch_batch_size, trunk_batch_size)`  

and may lead to:
- incorrect target shapes,
- silent broadcasting issues,
- or mismatches between model outputs and labels.