### PR TITLE
Fix geometry dtype to respect config.real(np) for NumPy 2.x compatibility

### DIFF
--- a/deepxde/geometry/geometry_2d.py
+++ b/deepxde/geometry/geometry_2d.py
@@ -48,7 +48,7 @@ class Disk(Hypersphere):
         return self.radius * (np.sqrt(r) * np.vstack((x, y))).T + self.center
 
     def uniform_boundary_points(self, n):
-        theta = np.linspace(0, 2 * np.pi, num=n, endpoint=False)
+        theta = np.linspace(0, 2 * np.pi, num=n, endpoint=False, dtype=config.real(np))
         X = np.vstack((np.cos(theta), np.sin(theta))).T
         return self.radius * X + self.center
 
@@ -214,30 +214,34 @@ class Rectangle(Hypercube):
         nx, ny = np.ceil(n / self.perimeter * (self.xmax - self.xmin)).astype(int)
         xbot = np.hstack(
             (
-                np.linspace(self.xmin[0], self.xmax[0], num=nx, endpoint=False)[
+                np.linspace(self.xmin[0], self.xmax[0], num=nx, endpoint=False,
+                    dtype=config.real(np))[
                     :, None
                 ],
-                np.full([nx, 1], self.xmin[1]),
+                np.full([nx, 1], self.xmin[1], dtype=config.real(np)),
             )
         )
         yrig = np.hstack(
             (
-                np.full([ny, 1], self.xmax[0]),
-                np.linspace(self.xmin[1], self.xmax[1], num=ny, endpoint=False)[
+                np.full([ny, 1], self.xmax[0], dtype=config.real(np)),
+                np.linspace(self.xmin[1], self.xmax[1], num=ny, endpoint=False,
+                    dtype=config.real(np))[
                     :, None
                 ],
             )
         )
         xtop = np.hstack(
             (
-                np.linspace(self.xmin[0], self.xmax[0], num=nx + 1)[1:, None],
-                np.full([nx, 1], self.xmax[1]),
+                np.linspace(self.xmin[0], self.xmax[0], num=nx + 1,
+                    dtype=config.real(np))[1:, None],
+                np.full([nx, 1], self.xmax[1], dtype=config.real(np)),
             )
         )
         ylef = np.hstack(
             (
-                np.full([ny, 1], self.xmin[0]),
-                np.linspace(self.xmin[1], self.xmax[1], num=ny + 1)[1:, None],
+                np.full([ny, 1], self.xmin[0], dtype=config.real(np)),
+                np.linspace(self.xmin[1], self.xmax[1], num=ny + 1,
+                    dtype=config.real(np))[1:, None],
             )
         )
         x = np.vstack((xbot, yrig, xtop, ylef))
@@ -268,7 +272,7 @@ class Rectangle(Hypercube):
                 x.append([self.xmax[0] - l + l2, self.xmax[1]])
             else:
                 x.append([self.xmin[0], self.xmax[1] - l + l3])
-        return np.vstack(x)
+        return np.vstack(x).astype(config.real(np))
 
     def _boundary_constraint_factor_inside(
         self,
@@ -465,7 +469,7 @@ class StarShaped(Geometry):
 
     def _r_theta(self, theta):
         """Define the parametrization r(theta) at angles theta."""
-        result = self.radius * np.ones(theta.shape)
+        result = self.radius * np.ones(theta.shape, dtype=config.real(np))
         for i, (coeff_cos, coeff_sin) in enumerate(
             zip(self.coeffs_cos, self.coeffs_sin), start=1
         ):
@@ -474,7 +478,7 @@ class StarShaped(Geometry):
 
     def _dr_theta(self, theta):
         """Evalutate the polar derivative r'(theta) at angles theta"""
-        result = np.zeros(theta.shape)
+        result = np.zeros(theta.shape, dtype=config.real(np))
         for i, (coeff_cos, coeff_sin) in enumerate(
             zip(self.coeffs_cos, self.coeffs_sin), start=1
         ):
@@ -517,7 +521,7 @@ class StarShaped(Geometry):
         return x[:n]
 
     def uniform_boundary_points(self, n):
-        theta = np.linspace(0, 2 * np.pi, num=n, endpoint=False)
+        theta = np.linspace(0, 2 * np.pi, num=n, endpoint=False, dtype=config.real(np))
         r_theta = self._r_theta(theta)
         X = np.vstack((r_theta * np.cos(theta), r_theta * np.sin(theta))).T
         return X + self.center
@@ -635,21 +639,24 @@ class Triangle(Geometry):
     def uniform_boundary_points(self, n):
         density = n / self.perimeter
         x12 = (
-            np.linspace(0, 1, num=int(np.ceil(density * self.l12)), endpoint=False)[
+            np.linspace(0, 1, num=int(np.ceil(density * self.l12)), endpoint=False,
+                dtype=config.real(np))[
                 :, None
             ]
             * self.v12
             + self.x1
         )
         x23 = (
-            np.linspace(0, 1, num=int(np.ceil(density * self.l23)), endpoint=False)[
+            np.linspace(0, 1, num=int(np.ceil(density * self.l23)), endpoint=False,
+                dtype=config.real(np))[
                 :, None
             ]
             * self.v23
             + self.x2
         )
         x31 = (
-            np.linspace(0, 1, num=int(np.ceil(density * self.l31)), endpoint=False)[
+            np.linspace(0, 1, num=int(np.ceil(density * self.l31)), endpoint=False,
+                dtype=config.real(np))[
                 :, None
             ]
             * self.v31
@@ -891,6 +898,7 @@ class Polygon(Geometry):
                     1,
                     num=int(np.ceil(density * self.diagonals[i, i + 1])),
                     endpoint=False,
+                    dtype=config.real(np),
                 )[:, None]
                 * (self.vertices[i + 1] - self.vertices[i])
                 + self.vertices[i]
@@ -924,7 +932,7 @@ class Polygon(Geometry):
                 l0, l1 = l1, l1 + self.diagonals[i, i + 1]
                 v = (self.vertices[i + 1] - self.vertices[i]) / self.diagonals[i, i + 1]
             x.append((l - l0) * v + self.vertices[i])
-        return np.vstack(x)
+        return np.vstack(x).astype(config.real(np))
 
 
 def polygon_signed_area(vertices):

--- a/deepxde/geometry/geometry_3d.py
+++ b/deepxde/geometry/geometry_3d.py
@@ -6,6 +6,7 @@ import numpy as np
 from .geometry_2d import Rectangle
 from .geometry_nd import Hypercube, Hypersphere
 from .. import backend as bkd
+from .. import config
 
 
 class Cuboid(Hypercube):
@@ -26,15 +27,15 @@ class Cuboid(Hypercube):
         rect = Rectangle(self.xmin[:-1], self.xmax[:-1])
         for z in [self.xmin[-1], self.xmax[-1]]:
             u = rect.random_points(int(np.ceil(density * rect.area)), random=random)
-            pts.append(np.hstack((u, np.full((len(u), 1), z))))
+            pts.append(np.hstack((u, np.full((len(u), 1), z, dtype=config.real(np)))))
         rect = Rectangle(self.xmin[::2], self.xmax[::2])
         for y in [self.xmin[1], self.xmax[1]]:
             u = rect.random_points(int(np.ceil(density * rect.area)), random=random)
-            pts.append(np.hstack((u[:, 0:1], np.full((len(u), 1), y), u[:, 1:])))
+            pts.append(np.hstack((u[:, 0:1], np.full((len(u), 1), y, dtype=config.real(np)), u[:, 1:])))
         rect = Rectangle(self.xmin[1:], self.xmax[1:])
         for x in [self.xmin[0], self.xmax[0]]:
             u = rect.random_points(int(np.ceil(density * rect.area)), random=random)
-            pts.append(np.hstack((np.full((len(u), 1), x), u)))
+            pts.append(np.hstack((np.full((len(u), 1), x, dtype=config.real(np)), u)))
         pts = np.vstack(pts)
         if len(pts) > n:
             return pts[np.random.choice(len(pts), size=n, replace=False)]
@@ -43,22 +44,22 @@ class Cuboid(Hypercube):
     def uniform_boundary_points(self, n):
         h = (self.area / n) ** 0.5
         nx, ny, nz = np.ceil((self.xmax - self.xmin) / h).astype(int) + 1
-        x = np.linspace(self.xmin[0], self.xmax[0], num=nx)
-        y = np.linspace(self.xmin[1], self.xmax[1], num=ny)
-        z = np.linspace(self.xmin[2], self.xmax[2], num=nz)
+        x = np.linspace(self.xmin[0], self.xmax[0], num=nx, dtype=config.real(np))
+        y = np.linspace(self.xmin[1], self.xmax[1], num=ny, dtype=config.real(np))
+        z = np.linspace(self.xmin[2], self.xmax[2], num=nz, dtype=config.real(np))
 
         pts = []
         for v in [self.xmin[-1], self.xmax[-1]]:
             u = list(itertools.product(x, y))
-            pts.append(np.hstack((u, np.full((len(u), 1), v))))
+            pts.append(np.hstack((u, np.full((len(u), 1), v, dtype=config.real(np)))))
         if nz > 2:
             for v in [self.xmin[1], self.xmax[1]]:
                 u = np.array(list(itertools.product(x, z[1:-1])))
-                pts.append(np.hstack((u[:, 0:1], np.full((len(u), 1), v), u[:, 1:])))
+                pts.append(np.hstack((u[:, 0:1], np.full((len(u), 1), v, dtype=config.real(np)), u[:, 1:])))
         if ny > 2 and nz > 2:
             for v in [self.xmin[0], self.xmax[0]]:
                 u = list(itertools.product(y[1:-1], z[1:-1]))
-                pts.append(np.hstack((np.full((len(u), 1), v), u)))
+                pts.append(np.hstack((np.full((len(u), 1), v, dtype=config.real(np)), u)))
         pts = np.vstack(pts)
         if n != len(pts):
             print(

--- a/deepxde/geometry/timedomain.py
+++ b/deepxde/geometry/timedomain.py
@@ -34,7 +34,7 @@ class GeometryXTime:
 
     def boundary_normal(self, x):
         _n = self.geometry.boundary_normal(x[:, :-1])
-        return np.hstack([_n, np.zeros((len(_n), 1))])
+        return np.hstack([_n, np.zeros((len(_n), 1), dtype=config.real(np))])
 
     def uniform_points(self, n, boundary=True):
         """Uniform points on the spatio-temporal domain.
@@ -67,7 +67,7 @@ class GeometryXTime:
             )[:, None]
         xt = []
         for ti in t:
-            xt.append(np.hstack((x, np.full([nx, 1], ti[0]))))
+            xt.append(np.hstack((x, np.full([nx, 1], ti[0], dtype=config.real(np)))))
         xt = np.vstack(xt)
         if n != len(xt):
             print(
@@ -132,7 +132,7 @@ class GeometryXTime:
         )
         xt = []
         for ti in t:
-            xt.append(np.hstack((x, np.full([nx, 1], ti))))
+            xt.append(np.hstack((x, np.full([nx, 1], ti, dtype=config.real(np)))))
         xt = np.vstack(xt)
         if n != len(xt):
             print(


### PR DESCRIPTION
Several geometry subclasses (Rectangle, Disk, StarShaped, Triangle, Polygon, Cuboid, GeometryXTime) created NumPy arrays via np.linspace, np.full, np.zeros, np.ones without specifying dtype, defaulting to float64. This caused a dtype mismatch with the neural network (float32 by default), resulting in "mat1 and mat2 must have the same dtype, but got Double and Float" errors in PyTorch with NumPy >= 2.0.

Added dtype=config.real(np) to all affected array-creation calls, consistent with the existing pattern used in geometry_1d.py, geometry_nd.py, and sampler.py.