### PR TITLE
Make basic BC/IC classes correctly trainable

### DIFF
--- a/deepxde/icbc/boundary_conditions.py
+++ b/deepxde/icbc/boundary_conditions.py
@@ -48,6 +48,9 @@ class BC(ABC):
             depends_on_trainable_variables = False
         self.depends_on_trainable_variables = depends_on_trainable_variables
 
+        # If learnable geometry is introduced, the boundary normal caching must be disabled
+        # if the "geometry depends on trainable variables" flag of `self.geom` is True,
+        # similar to `self.func` here.
         self.boundary_normal = npfunc_range_autocache(
             utils.return_tensor(self.geom.boundary_normal)
         )
@@ -107,6 +110,8 @@ class RobinBC(BC):
         # with other BC/IC functions with `func`
         # and in case in future caching is added here, too.
         super().__init__(geom, on_boundary, component, depends_on_trainable_variables)
+        # If for some reason caching of `func` is added here in future,
+        # it must be disabled if `self.depends_on_trainable_variables` is True.
         self.func = func
 
     def error(self, X, inputs, outputs, beg, end, aux_var=None):
@@ -169,6 +174,8 @@ class OperatorBC(BC):
         # with other BC/IC functions with `func`
         # and in case in future caching is added here, too.
         super().__init__(geom, on_boundary, 0, depends_on_trainable_variables)
+        # If for some reason caching of `func` is added here in future,
+        # it must be disabled if `self.depends_on_trainable_variables` is True.
         self.func = func
 
     def error(self, X, inputs, outputs, beg, end, aux_var=None):
@@ -283,6 +290,8 @@ class PointSetOperatorBC:
             depends_on_trainable_variables = False
         self.depends_on_trainable_variables = depends_on_trainable_variables
 
+        # If for some reason caching of `func` is added here in future,
+        # it must be disabled if `self.depends_on_trainable_variables` is True
         self.func = func
         self.batch_size = batch_size
 
@@ -354,6 +363,9 @@ class Interface2DBC:
         )
         self.direction = direction
 
+        # If learnable geometry is introduced, the boundary normal caching must be disabled
+        # if the "geometry depends on trainable variables" flag of `self.geom` is True,
+        # similar to `self.func` here.
         self.boundary_normal = npfunc_range_autocache(
             utils.return_tensor(self.geom.boundary_normal)
         )

--- a/deepxde/icbc/boundary_conditions.py
+++ b/deepxde/icbc/boundary_conditions.py
@@ -33,8 +33,7 @@ class BC(ABC):
         geom: A ``deepxde.geometry.Geometry`` instance.
         on_boundary: A function: (x, Geometry.on_boundary(x)) -> True/False.
         component: The output component satisfying this BC.
-        depends_on_trainable_variables: Whether this BC depends on any trainable variable
-            and must have cache disabled, or not.
+        depends_on_trainable_variables: Whether this BC depends on any trainable variable or not.
     """
 
     def __init__(self, geom, on_boundary, component, depends_on_trainable_variables=False):
@@ -151,8 +150,7 @@ class OperatorBC(BC):
             `inputs` and `outputs` are the network input and output tensors,
             respectively; `X` are the NumPy array of the `inputs`.
         on_boundary: (x, Geometry.on_boundary(x)) -> True/False.
-        depends_on_trainable_variables: Whether this BC depends on any trainable variable
-            and must have cache disabled, or not.
+        depends_on_trainable_variables: Whether this BC depends on any trainable variable or not.
 
     Warning:
         If you use `X` in `func`, then do not set ``num_test`` when you define
@@ -264,8 +262,7 @@ class PointSetOperatorBC:
             Note, If you want to use batch size here, you should also set callback
             'dde.callbacks.PDEPointResampler(bc_points=True)' in training.
         shuffle: Randomize the order on each pass through the data when batching.
-        depends_on_trainable_variables: Whether this BC depends on any trainable variable
-            and must have cache disabled, or not.
+        depends_on_trainable_variables: Whether this BC depends on any trainable variable or not.
     """
 
     def __init__(self, points, values, func, batch_size=None, shuffle=True, depends_on_trainable_variables=False):
@@ -330,8 +327,7 @@ class Interface2DBC:
         on_boundary1: First edge func. (x, Geometry.on_boundary(x)) -> True/False.
         on_boundary2: Second edge func. (x, Geometry.on_boundary(x)) -> True/False.
         direction (string): "normal" or "tangent".
-        depends_on_trainable_variables: Whether this BC depends on any trainable variable
-            and must have cache disabled, or not.
+        depends_on_trainable_variables: Whether this BC depends on any trainable variable or not.
     """
 
     def __init__(self, geom, func, on_boundary1, on_boundary2, direction="normal", depends_on_trainable_variables=False):

--- a/deepxde/icbc/boundary_conditions.py
+++ b/deepxde/icbc/boundary_conditions.py
@@ -36,12 +36,16 @@ class BC(ABC):
         depends_on_trainable_variables: Whether this BC depends on any trainable variable or not.
     """
 
-    def __init__(self, geom, on_boundary, component, depends_on_trainable_variables=False):
+    def __init__(self, geom, on_boundary, component, depends_on_trainable_variables=None):
         self.geom = geom
         self.on_boundary = lambda x, on: np.array(
             [on_boundary(x[i], on[i]) for i in range(len(x))]
         )
         self.component = component
+
+        if depends_on_trainable_variables is None:
+            _warn_dependance_on_trainable_variables()
+            depends_on_trainable_variables = False
         self.depends_on_trainable_variables = depends_on_trainable_variables
 
         self.boundary_normal = npfunc_range_autocache(
@@ -69,7 +73,7 @@ class BC(ABC):
 class DirichletBC(BC):
     """Dirichlet boundary conditions: y(x) = func(x)."""
 
-    def __init__(self, geom, func, on_boundary, component=0, depends_on_trainable_variables=False):
+    def __init__(self, geom, func, on_boundary, component=0, depends_on_trainable_variables=None):
         super().__init__(geom, on_boundary, component, depends_on_trainable_variables)
         self.func = npfunc_range_autocache(utils.return_tensor(func), self.depends_on_trainable_variables)
 
@@ -86,7 +90,7 @@ class DirichletBC(BC):
 class NeumannBC(BC):
     """Neumann boundary conditions: dy/dn(x) = func(x)."""
 
-    def __init__(self, geom, func, on_boundary, component=0, depends_on_trainable_variables=False):
+    def __init__(self, geom, func, on_boundary, component=0, depends_on_trainable_variables=None):
         super().__init__(geom, on_boundary, component, depends_on_trainable_variables)
         self.func = npfunc_range_autocache(utils.return_tensor(func), self.depends_on_trainable_variables)
 
@@ -98,7 +102,7 @@ class NeumannBC(BC):
 class RobinBC(BC):
     """Robin boundary conditions: dy/dn(x) = func(x, y)."""
 
-    def __init__(self, geom, func, on_boundary, component=0, depends_on_trainable_variables=False):
+    def __init__(self, geom, func, on_boundary, component=0, depends_on_trainable_variables=None):
         # `depends_on_trainable_variables` is here in order to be consistent
         # with other BC/IC functions with `func`
         # and in case in future caching is added here, too.
@@ -160,7 +164,7 @@ class OperatorBC(BC):
         which cannot be fixed in an easy way for all backends.
     """
 
-    def __init__(self, geom, func, on_boundary, depends_on_trainable_variables=False):
+    def __init__(self, geom, func, on_boundary, depends_on_trainable_variables=None):
         # `depends_on_trainable_variables` is here in order to be consistent
         # with other BC/IC functions with `func`
         # and in case in future caching is added here, too.
@@ -265,7 +269,7 @@ class PointSetOperatorBC:
         depends_on_trainable_variables: Whether this BC depends on any trainable variable or not.
     """
 
-    def __init__(self, points, values, func, batch_size=None, shuffle=True, depends_on_trainable_variables=False):
+    def __init__(self, points, values, func, batch_size=None, shuffle=True, depends_on_trainable_variables=None):
         self.points = np.array(points, dtype=config.real(np))
         if not isinstance(values, numbers.Number) and values.shape[1] != 1:
             raise RuntimeError("PointSetOperatorBC should output 1D values")
@@ -274,6 +278,9 @@ class PointSetOperatorBC:
         # `depends_on_trainable_variables` is here in order to be consistent
         # with other BC/IC functions with `func`
         # and in case in future caching is added here, too.
+        if depends_on_trainable_variables is None:
+            _warn_dependance_on_trainable_variables()
+            depends_on_trainable_variables = False
         self.depends_on_trainable_variables = depends_on_trainable_variables
 
         self.func = func
@@ -330,8 +337,12 @@ class Interface2DBC:
         depends_on_trainable_variables: Whether this BC depends on any trainable variable or not.
     """
 
-    def __init__(self, geom, func, on_boundary1, on_boundary2, direction="normal", depends_on_trainable_variables=False):
+    def __init__(self, geom, func, on_boundary1, on_boundary2, direction="normal", depends_on_trainable_variables=None):
         self.geom = geom
+
+        if depends_on_trainable_variables is None:
+            _warn_dependance_on_trainable_variables()
+            depends_on_trainable_variables = False
         self.depends_on_trainable_variables = depends_on_trainable_variables
 
         self.func = npfunc_range_autocache(utils.return_tensor(func), self.depends_on_trainable_variables)
@@ -441,7 +452,7 @@ def npfunc_range_autocache(func, disable_caching=False):
             cache[key] = func(X[beg:end], aux_var[beg:end])
         return cache[key]
 
-    if backend_name in ["tensorflow.compat.v1", "tensorflow", "jax"] or disable_caching:
+    if (backend_name in ["tensorflow.compat.v1", "tensorflow", "jax"]) or disable_caching:
         if utils.get_num_args(func) == 1:
             return wrapper_nocache
         elif utils.get_num_args(func) == 2:
@@ -451,3 +462,12 @@ def npfunc_range_autocache(func, disable_caching=False):
             return wrapper_cache
         elif utils.get_num_args(func) == 2:
             return wrapper_nocache_auxiliary
+
+
+def _warn_dependance_on_trainable_variables():
+    print(
+        "Warning: The BC/IC instance initialization parameter `depends_on_trainable_variables` "
+        "must be explicitly set to either True or False for all BC and IC objects, or else "
+        "the gradients of the loss function with respect to the external trainable variables "
+        "in inverse problems may become wrong."
+    )

--- a/deepxde/icbc/boundary_conditions.py
+++ b/deepxde/icbc/boundary_conditions.py
@@ -41,11 +41,6 @@ class BC(ABC):
             [on_boundary(x[i], on[i]) for i in range(len(x))]
         )
         self.component = component
-
-        if not isinstance(depends_on_trainable_variables, bool):
-            raise ValueError(
-                "`depends_on_trainable_variables` must be boolean (True or False)."
-            )
         self.depends_on_trainable_variables = depends_on_trainable_variables
 
         self.boundary_normal = npfunc_range_autocache(
@@ -73,7 +68,7 @@ class BC(ABC):
 class DirichletBC(BC):
     """Dirichlet boundary conditions: y(x) = func(x)."""
 
-    def __init__(self, geom, func, on_boundary, component=0, depends_on_trainable_variables=None):
+    def __init__(self, geom, func, on_boundary, component=0, depends_on_trainable_variables=False):
         super().__init__(geom, on_boundary, component, depends_on_trainable_variables)
         self.func = npfunc_range_autocache(utils.return_tensor(func), self.depends_on_trainable_variables)
 
@@ -90,7 +85,7 @@ class DirichletBC(BC):
 class NeumannBC(BC):
     """Neumann boundary conditions: dy/dn(x) = func(x)."""
 
-    def __init__(self, geom, func, on_boundary, component=0, depends_on_trainable_variables=None):
+    def __init__(self, geom, func, on_boundary, component=0, depends_on_trainable_variables=False):
         super().__init__(geom, on_boundary, component, depends_on_trainable_variables)
         self.func = npfunc_range_autocache(utils.return_tensor(func), self.depends_on_trainable_variables)
 
@@ -102,7 +97,7 @@ class NeumannBC(BC):
 class RobinBC(BC):
     """Robin boundary conditions: dy/dn(x) = func(x, y)."""
 
-    def __init__(self, geom, func, on_boundary, component=0, depends_on_trainable_variables=None):
+    def __init__(self, geom, func, on_boundary, component=0, depends_on_trainable_variables=False):
         # `depends_on_trainable_variables` is here in order to be consistent
         # with other BC/IC functions with `func`
         # and in case in future caching is added here, too.
@@ -163,7 +158,7 @@ class OperatorBC(BC):
         which cannot be fixed in an easy way for all backends.
     """
 
-    def __init__(self, geom, func, on_boundary, depends_on_trainable_variables=None):
+    def __init__(self, geom, func, on_boundary, depends_on_trainable_variables=False):
         # `depends_on_trainable_variables` is here in order to be consistent
         # with other BC/IC functions with `func`
         # and in case in future caching is added here, too.
@@ -267,19 +262,15 @@ class PointSetOperatorBC:
         shuffle: Randomize the order on each pass through the data when batching.
     """
 
-    def __init__(self, points, values, func, batch_size=None, shuffle=True, depends_on_trainable_variables=None):
+    def __init__(self, points, values, func, batch_size=None, shuffle=True, depends_on_trainable_variables=False):
         self.points = np.array(points, dtype=config.real(np))
         if not isinstance(values, numbers.Number) and values.shape[1] != 1:
             raise RuntimeError("PointSetOperatorBC should output 1D values")
         self.values = bkd.as_tensor(values, dtype=config.real(bkd.lib))
 
-        # This is here in order to be consistent
+        # `depends_on_trainable_variables` is here in order to be consistent
         # with other BC/IC functions with `func`
         # and in case in future caching is added here, too.
-        if not isinstance(depends_on_trainable_variables, bool):
-            raise ValueError(
-                "`depends_on_trainable_variables` must be boolean (True or False)."
-            )
         self.depends_on_trainable_variables = depends_on_trainable_variables
 
         self.func = func
@@ -335,13 +326,8 @@ class Interface2DBC:
         direction (string): "normal" or "tangent".
     """
 
-    def __init__(self, geom, func, on_boundary1, on_boundary2, direction="normal", depends_on_trainable_variables=None):
+    def __init__(self, geom, func, on_boundary1, on_boundary2, direction="normal", depends_on_trainable_variables=False):
         self.geom = geom
-
-        if not isinstance(depends_on_trainable_variables, bool):
-            raise ValueError(
-                "`depends_on_trainable_variables` must be boolean (True or False)."
-            )
         self.depends_on_trainable_variables = depends_on_trainable_variables
 
         self.func = npfunc_range_autocache(utils.return_tensor(func), self.depends_on_trainable_variables)

--- a/deepxde/icbc/boundary_conditions.py
+++ b/deepxde/icbc/boundary_conditions.py
@@ -33,6 +33,8 @@ class BC(ABC):
         geom: A ``deepxde.geometry.Geometry`` instance.
         on_boundary: A function: (x, Geometry.on_boundary(x)) -> True/False.
         component: The output component satisfying this BC.
+        depends_on_trainable_variables: Whether this BC depends on any trainable variable
+            and must have cache disabled, or not.
     """
 
     def __init__(self, geom, on_boundary, component, depends_on_trainable_variables=False):
@@ -149,6 +151,8 @@ class OperatorBC(BC):
             `inputs` and `outputs` are the network input and output tensors,
             respectively; `X` are the NumPy array of the `inputs`.
         on_boundary: (x, Geometry.on_boundary(x)) -> True/False.
+        depends_on_trainable_variables: Whether this BC depends on any trainable variable
+            and must have cache disabled, or not.
 
     Warning:
         If you use `X` in `func`, then do not set ``num_test`` when you define
@@ -260,6 +264,8 @@ class PointSetOperatorBC:
             Note, If you want to use batch size here, you should also set callback
             'dde.callbacks.PDEPointResampler(bc_points=True)' in training.
         shuffle: Randomize the order on each pass through the data when batching.
+        depends_on_trainable_variables: Whether this BC depends on any trainable variable
+            and must have cache disabled, or not.
     """
 
     def __init__(self, points, values, func, batch_size=None, shuffle=True, depends_on_trainable_variables=False):
@@ -324,6 +330,8 @@ class Interface2DBC:
         on_boundary1: First edge func. (x, Geometry.on_boundary(x)) -> True/False.
         on_boundary2: Second edge func. (x, Geometry.on_boundary(x)) -> True/False.
         direction (string): "normal" or "tangent".
+        depends_on_trainable_variables: Whether this BC depends on any trainable variable
+            and must have cache disabled, or not.
     """
 
     def __init__(self, geom, func, on_boundary1, on_boundary2, direction="normal", depends_on_trainable_variables=False):
@@ -390,6 +398,7 @@ def npfunc_range_autocache(func, disable_caching=False):
     """Call a NumPy function on a range of the input ndarray.
 
     If the backend is pytorch, the results are cached based on the id of X.
+    For BC/IC objects that depend on trainable variables caching must be disabled.
     """
     # For some BCs, we need to call self.func(X[beg:end]) in BC.error(). For backend
     # tensorflow.compat.v1/tensorflow, self.func() is only called once in graph mode,

--- a/deepxde/icbc/boundary_conditions.py
+++ b/deepxde/icbc/boundary_conditions.py
@@ -35,12 +35,18 @@ class BC(ABC):
         component: The output component satisfying this BC.
     """
 
-    def __init__(self, geom, on_boundary, component):
+    def __init__(self, geom, on_boundary, component, depends_on_trainable_variables):
         self.geom = geom
         self.on_boundary = lambda x, on: np.array(
             [on_boundary(x[i], on[i]) for i in range(len(x))]
         )
         self.component = component
+
+        if not isinstance(depends_on_trainable_variables, bool):
+            raise ValueError(
+                "`depends_on_trainable_variables` must be boolean (True or False)."
+            )
+        self.depends_on_trainable_variables = depends_on_trainable_variables
 
         self.boundary_normal = npfunc_range_autocache(
             utils.return_tensor(self.geom.boundary_normal)
@@ -67,9 +73,9 @@ class BC(ABC):
 class DirichletBC(BC):
     """Dirichlet boundary conditions: y(x) = func(x)."""
 
-    def __init__(self, geom, func, on_boundary, component=0):
-        super().__init__(geom, on_boundary, component)
-        self.func = npfunc_range_autocache(utils.return_tensor(func))
+    def __init__(self, geom, func, on_boundary, component=0, depends_on_trainable_variables=None):
+        super().__init__(geom, on_boundary, component, depends_on_trainable_variables)
+        self.func = npfunc_range_autocache(utils.return_tensor(func), self.depends_on_trainable_variables)
 
     def error(self, X, inputs, outputs, beg, end, aux_var=None):
         values = self.func(X, beg, end, aux_var)
@@ -84,9 +90,9 @@ class DirichletBC(BC):
 class NeumannBC(BC):
     """Neumann boundary conditions: dy/dn(x) = func(x)."""
 
-    def __init__(self, geom, func, on_boundary, component=0):
-        super().__init__(geom, on_boundary, component)
-        self.func = npfunc_range_autocache(utils.return_tensor(func))
+    def __init__(self, geom, func, on_boundary, component=0, depends_on_trainable_variables=None):
+        super().__init__(geom, on_boundary, component, depends_on_trainable_variables)
+        self.func = npfunc_range_autocache(utils.return_tensor(func), self.depends_on_trainable_variables)
 
     def error(self, X, inputs, outputs, beg, end, aux_var=None):
         values = self.func(X, beg, end, aux_var)
@@ -96,8 +102,11 @@ class NeumannBC(BC):
 class RobinBC(BC):
     """Robin boundary conditions: dy/dn(x) = func(x, y)."""
 
-    def __init__(self, geom, func, on_boundary, component=0):
-        super().__init__(geom, on_boundary, component)
+    def __init__(self, geom, func, on_boundary, component=0, depends_on_trainable_variables=None):
+        # `depends_on_trainable_variables` is here in order to be consistent
+        # with other BC/IC functions with `func`
+        # and in case in future caching is added here, too.
+        super().__init__(geom, on_boundary, component, depends_on_trainable_variables)
         self.func = func
 
     def error(self, X, inputs, outputs, beg, end, aux_var=None):
@@ -110,7 +119,7 @@ class PeriodicBC(BC):
     """Periodic boundary conditions on component_x."""
 
     def __init__(self, geom, component_x, on_boundary, derivative_order=0, component=0):
-        super().__init__(geom, on_boundary, component)
+        super().__init__(geom, on_boundary, component, False)
         self.component_x = component_x
         self.derivative_order = derivative_order
         if derivative_order > 1:
@@ -154,8 +163,11 @@ class OperatorBC(BC):
         which cannot be fixed in an easy way for all backends.
     """
 
-    def __init__(self, geom, func, on_boundary):
-        super().__init__(geom, on_boundary, 0)
+    def __init__(self, geom, func, on_boundary, depends_on_trainable_variables=None):
+        # `depends_on_trainable_variables` is here in order to be consistent
+        # with other BC/IC functions with `func`
+        # and in case in future caching is added here, too.
+        super().__init__(geom, on_boundary, 0, depends_on_trainable_variables)
         self.func = func
 
     def error(self, X, inputs, outputs, beg, end, aux_var=None):
@@ -255,11 +267,21 @@ class PointSetOperatorBC:
         shuffle: Randomize the order on each pass through the data when batching.
     """
 
-    def __init__(self, points, values, func, batch_size=None, shuffle=True):
+    def __init__(self, points, values, func, batch_size=None, shuffle=True, depends_on_trainable_variables=None):
         self.points = np.array(points, dtype=config.real(np))
         if not isinstance(values, numbers.Number) and values.shape[1] != 1:
             raise RuntimeError("PointSetOperatorBC should output 1D values")
         self.values = bkd.as_tensor(values, dtype=config.real(bkd.lib))
+
+        # This is here in order to be consistent
+        # with other BC/IC functions with `func`
+        # and in case in future caching is added here, too.
+        if not isinstance(depends_on_trainable_variables, bool):
+            raise ValueError(
+                "`depends_on_trainable_variables` must be boolean (True or False)."
+            )
+        self.depends_on_trainable_variables = depends_on_trainable_variables
+
         self.func = func
         self.batch_size = batch_size
 
@@ -313,9 +335,16 @@ class Interface2DBC:
         direction (string): "normal" or "tangent".
     """
 
-    def __init__(self, geom, func, on_boundary1, on_boundary2, direction="normal"):
+    def __init__(self, geom, func, on_boundary1, on_boundary2, direction="normal", depends_on_trainable_variables=None):
         self.geom = geom
-        self.func = npfunc_range_autocache(utils.return_tensor(func))
+
+        if not isinstance(depends_on_trainable_variables, bool):
+            raise ValueError(
+                "`depends_on_trainable_variables` must be boolean (True or False)."
+            )
+        self.depends_on_trainable_variables = depends_on_trainable_variables
+
+        self.func = npfunc_range_autocache(utils.return_tensor(func), self.depends_on_trainable_variables)
         self.on_boundary1 = lambda x, on: np.array(
             [on_boundary1(x[i], on[i]) for i in range(len(x))]
         )
@@ -371,7 +400,7 @@ class Interface2DBC:
         return left_values + right_values - values
 
 
-def npfunc_range_autocache(func):
+def npfunc_range_autocache(func, disable_caching=False):
     """Call a NumPy function on a range of the input ndarray.
 
     If the backend is pytorch, the results are cached based on the id of X.
@@ -421,13 +450,13 @@ def npfunc_range_autocache(func):
             cache[key] = func(X[beg:end], aux_var[beg:end])
         return cache[key]
 
-    if backend_name in ["tensorflow.compat.v1", "tensorflow", "jax"]:
+    if backend_name in ["tensorflow.compat.v1", "tensorflow", "jax"] or disable_caching:
         if utils.get_num_args(func) == 1:
             return wrapper_nocache
-        if utils.get_num_args(func) == 2:
+        elif utils.get_num_args(func) == 2:
             return wrapper_nocache_auxiliary
-    if backend_name in ["pytorch", "paddle"]:
+    elif backend_name in ["pytorch", "paddle"]:
         if utils.get_num_args(func) == 1:
             return wrapper_cache
-        if utils.get_num_args(func) == 2:
+        elif utils.get_num_args(func) == 2:
             return wrapper_nocache_auxiliary

--- a/deepxde/icbc/boundary_conditions.py
+++ b/deepxde/icbc/boundary_conditions.py
@@ -35,7 +35,7 @@ class BC(ABC):
         component: The output component satisfying this BC.
     """
 
-    def __init__(self, geom, on_boundary, component, depends_on_trainable_variables):
+    def __init__(self, geom, on_boundary, component, depends_on_trainable_variables=False):
         self.geom = geom
         self.on_boundary = lambda x, on: np.array(
             [on_boundary(x[i], on[i]) for i in range(len(x))]

--- a/deepxde/icbc/boundary_conditions.py
+++ b/deepxde/icbc/boundary_conditions.py
@@ -14,7 +14,7 @@ __all__ = [
 
 import numbers
 from abc import ABC, abstractmethod
-from functools import wraps
+from functools import wraps, lru_cache
 
 import numpy as np
 
@@ -464,7 +464,12 @@ def npfunc_range_autocache(func, disable_caching=False):
             return wrapper_nocache_auxiliary
 
 
+@lru_cache(maxsize=1)
 def _warn_dependance_on_trainable_variables():
+    """Print the warning that must contain the same message in constructors of various BC and IC classes.
+    The warning will be shown only once, which is achieved by using `lru_cache(maxsize=1)`
+    for a function with no arguments.
+    """
     print(
         "Warning: The BC/IC instance initialization parameter `depends_on_trainable_variables` "
         "must be explicitly set to either True or False for all BC and IC objects, or else "

--- a/deepxde/icbc/initial_conditions.py
+++ b/deepxde/icbc/initial_conditions.py
@@ -4,7 +4,7 @@ __all__ = ["IC"]
 
 import numpy as np
 
-from .boundary_conditions import npfunc_range_autocache
+from .boundary_conditions import npfunc_range_autocache, _warn_dependance_on_trainable_variables
 from .. import backend as bkd
 from .. import utils
 
@@ -23,8 +23,12 @@ class IC:
         depends_on_trainable_variables: Whether this IC depends on any trainable variable or not.
     """
 
-    def __init__(self, geom, func, on_initial, component=0, depends_on_trainable_variables=False):
+    def __init__(self, geom, func, on_initial, component=0, depends_on_trainable_variables=None):
         self.geom = geom
+
+        if depends_on_trainable_variables is None:
+            _warn_dependance_on_trainable_variables()
+            depends_on_trainable_variables = False
         self.depends_on_trainable_variables = depends_on_trainable_variables
 
         self.func = npfunc_range_autocache(utils.return_tensor(func), self.depends_on_trainable_variables)

--- a/deepxde/icbc/initial_conditions.py
+++ b/deepxde/icbc/initial_conditions.py
@@ -10,7 +10,19 @@ from .. import utils
 
 
 class IC:
-    """Initial conditions: y([x, t0]) = func([x, t0])."""
+    """Initial conditions: y([x, t0]) = func([x, t0]).
+
+    Args:
+        geom: A ``deepxde.geometry.Geometry`` instance.
+        func: A function takes arguments (`inputs`, `outputs`)
+            and outputs a tensor of size `N x 1`, where `N` is the length of `inputs`.
+            `inputs` and `outputs` are the network input and output tensors,
+            respectively.
+        on_initial: A function: (x, Geometry.on_initial(x)) -> True/False.
+        component: The output component satisfying this IC.
+        depends_on_trainable_variables: Whether this IC depends on any trainable variable
+            and must have cache disabled, or not.
+    """
 
     def __init__(self, geom, func, on_initial, component=0, depends_on_trainable_variables=False):
         self.geom = geom

--- a/deepxde/icbc/initial_conditions.py
+++ b/deepxde/icbc/initial_conditions.py
@@ -12,13 +12,8 @@ from .. import utils
 class IC:
     """Initial conditions: y([x, t0]) = func([x, t0])."""
 
-    def __init__(self, geom, func, on_initial, component=0, depends_on_trainable_variables=None):
+    def __init__(self, geom, func, on_initial, component=0, depends_on_trainable_variables=False):
         self.geom = geom
-
-        if not isinstance(depends_on_trainable_variables, bool):
-            raise ValueError(
-                "`depends_on_trainable_variables` must be boolean (True or False)."
-            )
         self.depends_on_trainable_variables = depends_on_trainable_variables
 
         self.func = npfunc_range_autocache(utils.return_tensor(func), self.depends_on_trainable_variables)

--- a/deepxde/icbc/initial_conditions.py
+++ b/deepxde/icbc/initial_conditions.py
@@ -20,8 +20,7 @@ class IC:
             respectively.
         on_initial: A function: (x, Geometry.on_initial(x)) -> True/False.
         component: The output component satisfying this IC.
-        depends_on_trainable_variables: Whether this IC depends on any trainable variable
-            and must have cache disabled, or not.
+        depends_on_trainable_variables: Whether this IC depends on any trainable variable or not.
     """
 
     def __init__(self, geom, func, on_initial, component=0, depends_on_trainable_variables=False):

--- a/deepxde/icbc/initial_conditions.py
+++ b/deepxde/icbc/initial_conditions.py
@@ -12,9 +12,16 @@ from .. import utils
 class IC:
     """Initial conditions: y([x, t0]) = func([x, t0])."""
 
-    def __init__(self, geom, func, on_initial, component=0):
+    def __init__(self, geom, func, on_initial, component=0, depends_on_trainable_variables=None):
         self.geom = geom
-        self.func = npfunc_range_autocache(utils.return_tensor(func))
+
+        if not isinstance(depends_on_trainable_variables, bool):
+            raise ValueError(
+                "`depends_on_trainable_variables` must be boolean (True or False)."
+            )
+        self.depends_on_trainable_variables = depends_on_trainable_variables
+
+        self.func = npfunc_range_autocache(utils.return_tensor(func), self.depends_on_trainable_variables)
         self.on_initial = lambda x, on: np.array(
             [on_initial(x[i], on[i]) for i in range(len(x))]
         )


### PR DESCRIPTION
Hello.

In relation to the issue #2074.

Now it is possible to include trainable variables into BC/IC for inverse problems only by using `OperatorBC` (_at least for the main types of BC/IC_), but it did not manage to find an explicit statement about this in the documentation or FAQ. Now, if one tries to use `DirichletBC`, `NeumannBC`, `IC` etc. that depends on trainable variables, the function values are cached and the trainable variable gradients are incorrect, which leads to terrible convergence behavior.

This PR proposes to require from the basic BC/IC classes to specify whether they depend on trainable variables (this disables function caching for them) or not. It is done independently for each BC/IC to protect the performance.

I have put the new argument at the end of the class signatures in order to preserve backward compatibility for scripts with positional arguments. But the default value is None, which will cause an exception saying that the user need to set it correctly.

The alternative to these or different code changes is to add a warning to the documentation (_at least the BC, IC and inverse problems examples sections_) saying that for inverse problems with trainable variables in BC/IC one must use `OperatorBC`.