### PR TITLE
Pytorch backend: add orthogonal initializer

### DIFF
--- a/deepxde/nn/initializers.py
+++ b/deepxde/nn/initializers.py
@@ -135,6 +135,7 @@ def initializer_dict_torch():
         "Glorot uniform": torch.nn.init.xavier_uniform_,
         "He normal": torch.nn.init.kaiming_normal_,
         "He uniform": torch.nn.init.kaiming_uniform_,
+        "Orthogonal": torch.nn.init.orthogonal_,
         "zeros": torch.nn.init.zeros_,
     }
 


### PR DESCRIPTION
This PR adds support for the orthogonal kernel initializer for PyTorch backend.