### PR TITLE
Fix L-BFGS options

### DIFF
--- a/deepxde/optimizers/config.py
+++ b/deepxde/optimizers/config.py
@@ -60,6 +60,16 @@ def set_LBFGS_options(
     LBFGS_options["maxfun"] = maxfun if maxfun is not None else int(maxiter * 1.25)
     LBFGS_options["maxls"] = maxls
 
+    # Backend-dependent options
+    if backend_name in ["pytorch", "paddle"]:
+        # number of iterations per optimization call
+        LBFGS_options["iter_per_step"] = min(1000, LBFGS_options["maxiter"])
+        LBFGS_options["fun_per_step"] = (
+            LBFGS_options["maxfun"]
+            * LBFGS_options["iter_per_step"]
+            // LBFGS_options["maxiter"]
+        )
+
 
 def set_NNCG_options(
     lr=1,
@@ -149,14 +159,3 @@ set_LBFGS_options()
 set_NNCG_options()
 if hvd is not None:
     set_hvd_opt_options()
-
-
-# Backend-dependent options
-if backend_name in ["pytorch", "paddle"]:
-    # number of iterations per optimization call
-    LBFGS_options["iter_per_step"] = min(1000, LBFGS_options["maxiter"])
-    LBFGS_options["fun_per_step"] = (
-        LBFGS_options["maxfun"]
-        * LBFGS_options["iter_per_step"]
-        // LBFGS_options["maxiter"]
-    )


### PR DESCRIPTION
This PR fixes `dde.optimizers.set_LBFGS_options` so that it correctly updates `iter_per_step` and `fun_per_step` used by L-BFGS in PyTorch/Paddle backends.

Before PR:
```
dde.optimizers.set_LBFGS_options(maxiter=123, maxfun=456)
print(dde.optimizers.LBFGS_options)
# {'maxcor': 100, 'ftol': 0, 'gtol': 1e-08, 'maxiter': 123, 'maxfun': 456, 'maxls': 50, 'iter_per_step': 1000, 'fun_per_step': 1250}
```

After PR:
```
dde.optimizers.set_LBFGS_options(maxiter=123, maxfun=456)
print(dde.optimizers.LBFGS_options)
# {'maxcor': 100, 'ftol': 0, 'gtol': 1e-08, 'maxiter': 123, 'maxfun': 456, 'maxls': 50, 'iter_per_step': 123, 'fun_per_step': 456}
```
