### PR TITLE
fix: add seed support to TensorFlow initializers

### DIFF
--- a/deepxde/config.py
+++ b/deepxde/config.py
@@ -161,6 +161,15 @@ def set_random_seed(seed):
     random_seed = seed
 
 
+def get_random_seed():
+    """Get the current random seed.
+
+    Returns:
+        int: The current random seed, or None if not set.
+    """
+    return random_seed
+
+
 def enable_xla_jit(mode=True):
     """Enables just-in-time compilation with XLA.
 

--- a/deepxde/config.py
+++ b/deepxde/config.py
@@ -159,7 +159,11 @@ def set_random_seed(seed):
         paddle.seed(seed)
     global random_seed
     random_seed = seed
-
+    
+ # Reload initializer dict to update to the new seed
+    from .nn.initializers import reset_initializer_dict
+    reset_initializer_dict()
+    
 
 def get_random_seed():
     """Get the current random seed.

--- a/deepxde/nn/initializers.py
+++ b/deepxde/nn/initializers.py
@@ -128,6 +128,8 @@ def initializer_dict_tf():
         "stacked LeCun normal": VarianceScalingStacked(),
         "stacked LeCun uniform": VarianceScalingStacked(distribution="uniform"),
     }
+
+
 def initializer_dict_torch():
     return {
         "Glorot normal": torch.nn.init.xavier_normal_,
@@ -160,14 +162,26 @@ def initializer_dict_paddle():
     }
 
 
-if backend_name in ["tensorflow.compat.v1", "tensorflow"]:
-    INITIALIZER_DICT = initializer_dict_tf()
-elif backend_name == "pytorch":
-    INITIALIZER_DICT = initializer_dict_torch()
-elif backend_name == "jax":
-    INITIALIZER_DICT = initializer_dict_jax()
-elif backend_name == "paddle":
-    INITIALIZER_DICT = initializer_dict_paddle()
+# NEW: Function to get initializer dict dynamically
+def get_initializer_dict():
+    if backend_name in ["tensorflow.compat.v1", "tensorflow"]:
+        return initializer_dict_tf()
+    elif backend_name == "pytorch":
+        return initializer_dict_torch()
+    elif backend_name == "jax":
+        return initializer_dict_jax()
+    elif backend_name == "paddle":
+        return initializer_dict_paddle()
+
+
+# Initialize once at module load
+INITIALIZER_DICT = get_initializer_dict()
+
+
+# NEW: Function to reset initializer dict (call when seed changes)
+def reset_initializer_dict():
+    global INITIALIZER_DICT
+    INITIALIZER_DICT = get_initializer_dict()
 
 
 def get(identifier):

--- a/deepxde/nn/initializers.py
+++ b/deepxde/nn/initializers.py
@@ -112,26 +112,17 @@ def _compute_fans_stacked(shape):
 
 
 def initializer_dict_tf():
-    # Get the random seed from config
+    # Get the random seed from config (will be None if not set)
     seed = config.get_random_seed()
     
-    # Create initializers with seed if provided
-    if seed is not None:
-        glorot_uniform = tf.keras.initializers.GlorotUniform(seed=seed)
-        glorot_normal = tf.keras.initializers.GlorotNormal(seed=seed)
-        he_normal = tf.keras.initializers.HeNormal(seed=seed)
-        he_uniform = tf.keras.initializers.HeUniform(seed=seed)
-        lecun_normal = tf.keras.initializers.LecunNormal(seed=seed)
-        lecun_uniform = tf.keras.initializers.LecunUniform(seed=seed)
-        orthogonal = tf.keras.initializers.Orthogonal(seed=seed)
-    else:
-        glorot_uniform = tf.keras.initializers.GlorotUniform()
-        glorot_normal = tf.keras.initializers.GlorotNormal()
-        he_normal = tf.keras.initializers.HeNormal()
-        he_uniform = tf.keras.initializers.HeUniform()
-        lecun_normal = tf.keras.initializers.LecunNormal()
-        lecun_uniform = tf.keras.initializers.LecunUniform()
-        orthogonal = tf.keras.initializers.Orthogonal()
+    # Create initializers - GlorotUniform and others accept seed=None by default
+    glorot_uniform = tf.keras.initializers.GlorotUniform(seed=seed)
+    glorot_normal = tf.keras.initializers.GlorotNormal(seed=seed)
+    he_normal = tf.keras.initializers.HeNormal(seed=seed)
+    he_uniform = tf.keras.initializers.HeUniform(seed=seed)
+    lecun_normal = tf.keras.initializers.LecunNormal(seed=seed)
+    lecun_uniform = tf.keras.initializers.LecunUniform(seed=seed)
+    orthogonal = tf.keras.initializers.Orthogonal(seed=seed)
     
     return {
         "Glorot normal": glorot_normal,

--- a/deepxde/nn/initializers.py
+++ b/deepxde/nn/initializers.py
@@ -112,26 +112,16 @@ def _compute_fans_stacked(shape):
 
 
 def initializer_dict_tf():
-    # Get the random seed from config (will be None if not set)
     seed = config.get_random_seed()
     
-    # Create initializers - GlorotUniform and others accept seed=None by default
-    glorot_uniform = tf.keras.initializers.GlorotUniform(seed=seed)
-    glorot_normal = tf.keras.initializers.GlorotNormal(seed=seed)
-    he_normal = tf.keras.initializers.HeNormal(seed=seed)
-    he_uniform = tf.keras.initializers.HeUniform(seed=seed)
-    lecun_normal = tf.keras.initializers.LecunNormal(seed=seed)
-    lecun_uniform = tf.keras.initializers.LecunUniform(seed=seed)
-    orthogonal = tf.keras.initializers.Orthogonal(seed=seed)
-    
     return {
-        "Glorot normal": glorot_normal,
-        "Glorot uniform": glorot_uniform,
-        "He normal": he_normal,
-        "He uniform": he_uniform,
-        "LeCun normal": lecun_normal,
-        "LeCun uniform": lecun_uniform,
-        "Orthogonal": orthogonal,
+        "Glorot normal": tf.keras.initializers.GlorotNormal(seed=seed),
+        "Glorot uniform": tf.keras.initializers.GlorotUniform(seed=seed),
+        "He normal": tf.keras.initializers.HeNormal(seed=seed),
+        "He uniform": tf.keras.initializers.HeUniform(seed=seed),
+        "LeCun normal": tf.keras.initializers.LecunNormal(seed=seed),
+        "LeCun uniform": tf.keras.initializers.LecunUniform(seed=seed),
+        "Orthogonal": tf.keras.initializers.Orthogonal(seed=seed),
         "zeros": tf.zeros_initializer(),
         # Initializers of stacked DeepONet
         "stacked He normal": VarianceScalingStacked(scale=2.0),
@@ -139,7 +129,6 @@ def initializer_dict_tf():
         "stacked LeCun normal": VarianceScalingStacked(),
         "stacked LeCun uniform": VarianceScalingStacked(distribution="uniform"),
     }
-
 
 def initializer_dict_torch():
     return {

--- a/deepxde/nn/initializers.py
+++ b/deepxde/nn/initializers.py
@@ -114,27 +114,20 @@ def _compute_fans_stacked(shape):
 def initializer_dict_tf():
     seed = config.get_random_seed()
     
-    # Lowercase functions work with both TF 1.x and 2.x
-    if seed is not None:
-        init = lambda f: f(seed=seed)
-    else:
-        init = lambda f: f()
-    
     return {
-        "Glorot normal": init(tf.keras.initializers.glorot_normal),
-        "Glorot uniform": init(tf.keras.initializers.glorot_uniform),
-        "He normal": init(tf.keras.initializers.he_normal),
-        "He uniform": init(tf.keras.initializers.he_uniform),
-        "LeCun normal": init(tf.keras.initializers.lecun_normal),
-        "LeCun uniform": init(tf.keras.initializers.lecun_uniform),
-        "Orthogonal": init(tf.keras.initializers.Orthogonal),
+        "Glorot normal": tf.keras.initializers.glorot_normal(seed=seed),
+        "Glorot uniform": tf.keras.initializers.glorot_uniform(seed=seed),
+        "He normal": tf.keras.initializers.he_normal(seed=seed),
+        "He uniform": tf.keras.initializers.he_uniform(seed=seed),
+        "LeCun normal": tf.keras.initializers.lecun_normal(seed=seed),
+        "LeCun uniform": tf.keras.initializers.lecun_uniform(seed=seed),
+        "Orthogonal": tf.keras.initializers.Orthogonal(seed=seed),
         "zeros": tf.zeros_initializer(),
         "stacked He normal": VarianceScalingStacked(scale=2.0),
         "stacked He uniform": VarianceScalingStacked(scale=2.0, distribution="uniform"),
         "stacked LeCun normal": VarianceScalingStacked(),
         "stacked LeCun uniform": VarianceScalingStacked(distribution="uniform"),
     }
-
 def initializer_dict_torch():
     return {
         "Glorot normal": torch.nn.init.xavier_normal_,

--- a/deepxde/nn/initializers.py
+++ b/deepxde/nn/initializers.py
@@ -114,16 +114,21 @@ def _compute_fans_stacked(shape):
 def initializer_dict_tf():
     seed = config.get_random_seed()
     
+    # Lowercase functions work with both TF 1.x and 2.x
+    if seed is not None:
+        init = lambda f: f(seed=seed)
+    else:
+        init = lambda f: f()
+    
     return {
-        "Glorot normal": tf.keras.initializers.GlorotNormal(seed=seed),
-        "Glorot uniform": tf.keras.initializers.GlorotUniform(seed=seed),
-        "He normal": tf.keras.initializers.HeNormal(seed=seed),
-        "He uniform": tf.keras.initializers.HeUniform(seed=seed),
-        "LeCun normal": tf.keras.initializers.LecunNormal(seed=seed),
-        "LeCun uniform": tf.keras.initializers.LecunUniform(seed=seed),
-        "Orthogonal": tf.keras.initializers.Orthogonal(seed=seed),
+        "Glorot normal": init(tf.keras.initializers.glorot_normal),
+        "Glorot uniform": init(tf.keras.initializers.glorot_uniform),
+        "He normal": init(tf.keras.initializers.he_normal),
+        "He uniform": init(tf.keras.initializers.he_uniform),
+        "LeCun normal": init(tf.keras.initializers.lecun_normal),
+        "LeCun uniform": init(tf.keras.initializers.lecun_uniform),
+        "Orthogonal": init(tf.keras.initializers.Orthogonal),
         "zeros": tf.zeros_initializer(),
-        # Initializers of stacked DeepONet
         "stacked He normal": VarianceScalingStacked(scale=2.0),
         "stacked He uniform": VarianceScalingStacked(scale=2.0, distribution="uniform"),
         "stacked LeCun normal": VarianceScalingStacked(),

--- a/deepxde/nn/initializers.py
+++ b/deepxde/nn/initializers.py
@@ -112,14 +112,35 @@ def _compute_fans_stacked(shape):
 
 
 def initializer_dict_tf():
+    # Get the random seed from config
+    seed = config.get_random_seed()
+    
+    # Create initializers with seed if provided
+    if seed is not None:
+        glorot_uniform = tf.keras.initializers.GlorotUniform(seed=seed)
+        glorot_normal = tf.keras.initializers.GlorotNormal(seed=seed)
+        he_normal = tf.keras.initializers.HeNormal(seed=seed)
+        he_uniform = tf.keras.initializers.HeUniform(seed=seed)
+        lecun_normal = tf.keras.initializers.LecunNormal(seed=seed)
+        lecun_uniform = tf.keras.initializers.LecunUniform(seed=seed)
+        orthogonal = tf.keras.initializers.Orthogonal(seed=seed)
+    else:
+        glorot_uniform = tf.keras.initializers.GlorotUniform()
+        glorot_normal = tf.keras.initializers.GlorotNormal()
+        he_normal = tf.keras.initializers.HeNormal()
+        he_uniform = tf.keras.initializers.HeUniform()
+        lecun_normal = tf.keras.initializers.LecunNormal()
+        lecun_uniform = tf.keras.initializers.LecunUniform()
+        orthogonal = tf.keras.initializers.Orthogonal()
+    
     return {
-        "Glorot normal": tf.keras.initializers.glorot_normal(),
-        "Glorot uniform": tf.keras.initializers.glorot_uniform(),
-        "He normal": tf.keras.initializers.he_normal(),
-        "He uniform": tf.keras.initializers.he_uniform(),
-        "LeCun normal": tf.keras.initializers.lecun_normal(),
-        "LeCun uniform": tf.keras.initializers.lecun_uniform(),
-        "Orthogonal": tf.keras.initializers.Orthogonal(),
+        "Glorot normal": glorot_normal,
+        "Glorot uniform": glorot_uniform,
+        "He normal": he_normal,
+        "He uniform": he_uniform,
+        "LeCun normal": lecun_normal,
+        "LeCun uniform": lecun_uniform,
+        "Orthogonal": orthogonal,
         "zeros": tf.zeros_initializer(),
         # Initializers of stacked DeepONet
         "stacked He normal": VarianceScalingStacked(scale=2.0),


### PR DESCRIPTION
### Purpose / Description

Fixes the unseeded initializer warning by adding seed support to TensorFlow initializers.

### Fixes

Fixes #2086

### Approach

- Modified `initializer_dict_tf()` to read seed from `config.get_random_seed()`
- Creates initializers with seed when available, without seed when not
- Applied to all TensorFlow initializers: Glorot, He, LeCun, Orthogonal

### How Has This Been Tested?

Tested locally with:
```python
import deepxde as dde
dde.config.set_random_seed(42)
# Model initialization now uses the seed, no more warning