### PR TITLE
Add Union data classes for combining multiple Data objects

### DIFF
--- a/deepxde/data/__init__.py
+++ b/deepxde/data/__init__.py
@@ -23,6 +23,9 @@ __all__ = [
     "TimePDE",
     "Triple",
     "TripleCartesianProd",
+    "Union",
+    "UnionMerge",
+    "UnionRoundRobin",
     "wasserstein2",
 ]
 
@@ -40,3 +43,4 @@ from .pde_operator import PDEOperator, PDEOperatorCartesianProd
 from .quadruple import Quadruple, QuadrupleCartesianProd
 from .sampler import BatchSampler
 from .triple import Triple, TripleCartesianProd
+from .union import Union, UnionMerge, UnionRoundRobin

--- a/deepxde/data/union.py
+++ b/deepxde/data/union.py
@@ -1,0 +1,185 @@
+import numpy as np
+
+from .data import Data
+from .pde import PDE
+from .pde_operator import PDEOperator, PDEOperatorCartesianProd
+
+
+class Union(Data):
+    """Base class for combining multiple ``Data`` objects.
+
+    Args:
+        data_objects: A list of ``Data`` instances.
+        loss: A shared loss function, or a list of per-data loss functions.
+    """
+
+    def __init__(self, data_objects, loss=None):
+        self.data_objects = list(data_objects)
+        self.loss = loss
+
+        if isinstance(self.loss, (list, tuple)) and len(self.loss) != len(
+            self.data_objects
+        ):
+            raise ValueError("loss list must match number of data objects")
+
+    def _get_loss(self, i, default_loss):
+        if self.loss is None:
+            return default_loss
+        if isinstance(self.loss, (list, tuple)):
+            return self.loss[i]
+        return self.loss
+
+
+class UnionRoundRobin(Union):
+    """Combines multiple ``Data`` objects by cycling through them in round-robin order."""
+
+    def __init__(self, data_objects, loss=None):
+        super().__init__(data_objects, loss)
+        self._train_idx = 0
+        self._test_idx = 0
+
+    def train_next_batch(self, batch_size=None):
+        return self.data_objects[self._train_idx].train_next_batch(batch_size)
+
+    def losses_train(self, targets, outputs, loss_fn, inputs, model, aux=None):
+        i = self._train_idx
+        self._train_idx = (self._train_idx + 1) % len(self.data_objects)
+        return self.data_objects[i].losses_train(
+            targets, outputs, self._get_loss(i, loss_fn), inputs, model, aux=aux
+        )
+
+    def test(self):
+        return self.data_objects[self._test_idx].test()
+
+    def losses_test(self, targets, outputs, loss_fn, inputs, model, aux=None):
+        i = self._test_idx
+        self._test_idx = (self._test_idx + 1) % len(self.data_objects)
+        return self.data_objects[i].losses_test(
+            targets, outputs, self._get_loss(i, loss_fn), inputs, model, aux=aux
+        )
+
+
+class UnionMerge(Union):
+    """Combines multiple ``Data`` objects into one merged forward pass per step.
+
+    Incompatible with PDE-based ``Data`` objects (``PDE``, ``PDEOperator``, etc.);
+    use ``UnionRoundRobin`` for those.
+    """
+
+    def __init__(self, data_objects, loss=None):
+        _incompatible = (PDE, PDEOperator, PDEOperatorCartesianProd)
+        for obj in data_objects:
+            if isinstance(obj, _incompatible):
+                raise TypeError(
+                    f"{type(obj).__name__} is incompatible with UnionMerge. "
+                    "Use UnionRoundRobin instead."
+                )
+
+        super().__init__(data_objects, loss)
+        self._train_slices = None
+        self._test_slices = None
+
+    def train_next_batch(self, batch_size=None):
+        batch_sizes = self._split_batch_size(batch_size)
+        batches = [
+            data.train_next_batch(bs)
+            for data, bs in zip(self.data_objects, batch_sizes)
+        ]
+        *merged, self._train_slices = self._merge_batches(batches)
+        return tuple(merged)
+
+    def test(self):
+        batches = [data.test() for data in self.data_objects]
+        *merged, self._test_slices = self._merge_batches(batches)
+        return tuple(merged)
+
+    def losses_train(self, targets, outputs, loss_fn, inputs, model, aux=None):
+        if self._train_slices is None:
+            raise RuntimeError(
+                "train_next_batch() must be called before losses_train()."
+            )
+        return self._losses(
+            targets,
+            outputs,
+            loss_fn,
+            inputs,
+            model,
+            aux,
+            self._train_slices,
+            train=True,
+        )
+
+    def losses_test(self, targets, outputs, loss_fn, inputs, model, aux=None):
+        if self._test_slices is None:
+            raise RuntimeError("test() must be called before losses_test().")
+        return self._losses(
+            targets,
+            outputs,
+            loss_fn,
+            inputs,
+            model,
+            aux,
+            self._test_slices,
+            train=False,
+        )
+
+    def _losses(self, targets, outputs, loss_fn, inputs, model, aux, slices, train):
+        losses = []
+        for i, (data, sl) in enumerate(zip(self.data_objects, slices)):
+            x_i = self._slice_inputs(inputs, sl)
+            y_i = None if targets is None else targets[sl]
+            out_i = outputs[sl]
+            loss_i_fn = self._get_loss(i, loss_fn)
+            if train:
+                loss_i = data.losses_train(y_i, out_i, loss_i_fn, x_i, model, aux=aux)
+            else:
+                loss_i = data.losses_test(y_i, out_i, loss_i_fn, x_i, model, aux=aux)
+            if not isinstance(loss_i, list):
+                loss_i = [loss_i]
+            losses.extend(loss_i)
+        return losses
+
+    def _split_batch_size(self, batch_size):
+        if isinstance(batch_size, (list, tuple)):
+            if len(batch_size) != len(self.data_objects):
+                raise ValueError("batch_size list must match number of data objects")
+            return list(batch_size)
+        if batch_size is None:
+            return [None] * len(self.data_objects)
+        q, r = divmod(batch_size, len(self.data_objects))
+        return [q + int(i < r) for i in range(len(self.data_objects))]
+
+    @staticmethod
+    def _merge_batches(batches):
+        parts = list(zip(*batches))
+        xs = parts[0]
+        sizes = [UnionMerge._batch_size(x) for x in xs]
+        slices, start = [], 0
+        for n in sizes:
+            slices.append(slice(start, start + n))
+            start += n
+        merged = [UnionMerge._concat_inputs(xs)]
+        for group in parts[1:]:
+            val = (
+                None if all(g is None for g in group) else np.concatenate(group, axis=0)
+            )
+            merged.append(val)
+        return (*merged, slices)
+
+    @staticmethod
+    def _batch_size(x):
+        return x[0].shape[0] if isinstance(x, tuple) else x.shape[0]
+
+    @staticmethod
+    def _concat_inputs(xs):
+        if isinstance(xs[0], tuple):
+            return tuple(
+                np.concatenate([x[i] for x in xs], axis=0) for i in range(len(xs[0]))
+            )
+        return np.concatenate(xs, axis=0)
+
+    @staticmethod
+    def _slice_inputs(x, sl):
+        if isinstance(x, tuple):
+            return tuple(xi[sl] for xi in x)
+        return x[sl]


### PR DESCRIPTION
Introduces `UnionRoundRobin` and `UnionMerge`, two strategies for training a single model on multiple data objects simultaneously.

- `UnionRoundRobin` cycles through data objects one at a time, using one data object per training step.
- `UnionMerge` concatenates batches from all data objects into a single forward pass per training step. Note: this strategy is not compatible with `PDE`, `PDEOperator`, or other PDE-based `Data` objects.

Both strategies support per-data loss functions via the `loss` argument when it is defined; otherwise, the loss from `model.compile()` is used.

Example: training an FNN to fit two different functions, *x sin(5x)* and *x cos(2.5x)*, on the same geometry using `UnionMerge`:

```
import deepxde as dde
import matplotlib.pyplot as plt
import numpy as np


def func_1(x):
    return x * np.sin(5 * x)


def func_2(x):
    return x * np.cos(2.5 * x)


geom = dde.geometry.Interval(-1, 1)
num_train = 16
num_test = 100

data_1 = dde.data.Function(geom, func_1, num_train, num_test)
data_2 = dde.data.Function(geom, func_2, num_train, num_test)

data = dde.data.UnionMerge(
    data_objects=[data_1, data_2]
)

activation = "tanh"
initializer = "Glorot uniform"
net = dde.nn.FNN([1] + [20] * 3 + [1], activation, initializer)
model = dde.Model(data, net)
model.compile(
    "adam",
    lr=0.0001,
)
model.train(iterations=10000)

x_plot = np.linspace(-1, 1, 500)[:, None]
y_pred = model.predict(x_plot)
y_true_1 = func_1(x_plot)
y_true_2 = func_2(x_plot)
plt.figure()
plt.plot(x_plot[:, 0], y_true_1[:, 0], "--", label="func_1")
plt.plot(x_plot[:, 0], y_true_2[:, 0], "--", label="func_2")
plt.plot(x_plot[:, 0], y_pred[:, 0], label="prediction", c="black", linewidth=2.0)
plt.xlabel("x")
plt.ylabel("y")
plt.legend()
plt.grid(True)
plt.show()
```

<img width="640" height="480" alt="union" src="https://github.com/user-attachments/assets/50334276-ca26-4da0-84d8-9739fb95ea95" />