### PR TITLE
Do not cache IC/BC function outputs on pytorch/paddle (stale in inverse problems) (#2074)

### DIFF
--- a/deepxde/icbc/boundary_conditions.py
+++ b/deepxde/icbc/boundary_conditions.py
@@ -427,7 +427,17 @@ def npfunc_range_autocache(func):
         if utils.get_num_args(func) == 2:
             return wrapper_nocache_auxiliary
     if backend_name in ["pytorch", "paddle"]:
+        # Issue #2074: the (id(X), beg, end) cache key omits the current value of
+        # any trainable variable that ``func`` may close over (e.g. an inverse
+        # problem IC/BC of the form ``func(x) = f(x; theta)`` with ``theta`` a
+        # trainable ``dde.Variable``). Because X (and its id) is fixed across
+        # training iterations, ``wrapper_cache`` returns the value evaluated at
+        # the *first* theta, going stale after every optimizer step. This is the
+        # same reason the 2-argument path below already uses ``wrapper_nocache_*``
+        # (aux_var can change even when X is fixed); a fixed X does NOT imply a
+        # fixed func output. Use the no-cache wrapper here too so the reported
+        # IC/BC value and its autograd graph always track the current parameter.
         if utils.get_num_args(func) == 1:
-            return wrapper_cache
+            return wrapper_nocache
         if utils.get_num_args(func) == 2:
             return wrapper_nocache_auxiliary


### PR DESCRIPTION
npfunc_range_autocache cached func(X[beg:end]) keyed on (id(X), beg, end) only. In an inverse problem func closes over a trainable dde.Variable while X is fixed, so the memo returns the value at the initial parameter and never updates, freezing the IC/BC loss and its autograd graph. Use wrapper_nocache on this path, consistent with the 2-argument path which already does so.

### Problem

On the `pytorch`/`paddle` backends, an IC/BC whose function closes over a
trainable `dde.Variable` (an inverse problem, `func(x) = f(x; theta)`) reports a
stale IC/BC loss: the value and its autograd graph are frozen at the initial
`theta` and never update as training proceeds. This is issue #2074: the boundary
condition is evaluated once and the optimizer then has no gradient signal from
it, so the inverse parameter never moves.

### Root cause

`deepxde/icbc/boundary_conditions.py`, `npfunc_range_autocache()`. For the
`pytorch`/`paddle` backend with a 1-argument `func`, the selector returns
`wrapper_cache`:

```python
@wraps(func)
def wrapper_cache(X, beg, end, _):
    key = (id(X), beg, end)
    if key not in cache:
        cache[key] = func(X[beg:end])
    return cache[key]
...
if backend_name in ["pytorch", "paddle"]:
    if utils.get_num_args(func) == 1:
        return wrapper_cache          # <-- caches on (id(X), beg, end) only
```

The cache key is `(id(X), beg, end)` only. The comment above the function states
the assumption behind it: *"IC/BC is only for dde.data.PDE, where the ndarray is
fixed. So we can simply use id of X as the key."* In an inverse problem the
collocation array `X` is indeed fixed across iterations, so `id(X)` never
changes and the memo is never invalidated — but `func` also depends on a
trainable `theta` that changes every optimizer step. A fixed `X` does **not**
imply a fixed `func` output. The wrapper therefore returns the value computed at
the first `theta` forever, and the cached tensor carries a stale autograd graph.

Notably, the 2-argument path on the same backend already avoids caching
(`wrapper_nocache_auxiliary`), precisely because "even if X is the same one,
aux_var could be different" (see `wrapper_cache_auxiliary`'s own comment). A
trainable variable in `func`'s closure is the identical hazard on the
1-argument path.

### Fix

Route the `pytorch`/`paddle` 1-argument path to the already-defined
`wrapper_nocache` (which simply returns `func(X[beg:end])`), removing the unsound
memo:

```python
if backend_name in ["pytorch", "paddle"]:
    if utils.get_num_args(func) == 1:
        return wrapper_nocache
    if utils.get_num_args(func) == 2:
        return wrapper_nocache_auxiliary
```

This is minimal and consistent with the existing 2-argument decision on the same
backend. It touches only the wrapper-selection branch — not `bc.error`,
`DirichletBC`, gradient plumbing, or any loss/reporting. `wrapper_nocache`
returns exactly `func(X[beg:end])`, the value the cache was meant to hold, so for
any forward problem where `func` is a pure function of `X` the numeric result is
unchanged (see the byte-identical control below). The only cost is recomputing
`func` on the boundary slice each iteration — a performance trade-off, not a
correctness change — which is the smallest price for removing the staleness
without introducing a heuristic to guess whether `func` closes over trainable
state. (The `tensorflow`/`jax` branch already uses `wrapper_nocache` here and is
unaffected.)

### Test evidence

Validated with a two-arm run on the same environment (deepxde 1.15.0,
torch 2.12.1+cpu, backend `pytorch`), differing only by this one-line change. The
oracle: after `theta` changes `1 → 2` with the same `X` object and same
`beg,end` (the every-iteration situation), the library's reported BC error must
match an independent, uncached recomputation of `func(X[beg:end])` at the current
`theta`.

| check | before (unpatched) | after (patched) |
|---|---|---|
| inverse: BC error after `theta` 1→2, same `X` (truth `[-2,-2]`) | `[-1,-1]` **stale** | `[-2,-2]` correct |
| forward control: pure-x BC (cache was already correct) | `[-0.3, -1.3, -0.29999992]` | `[-0.3, -1.3, -0.29999992]` |

The forward control is **byte-identical across both arms**
(`-3.0000001192e-01 -1.2999999523e+00 -2.9999992251e-01`): the change alters no
numeric result where the cache was already valid; it only removes the staleness.

### How to reproduce

```python
import numpy as np
import deepxde as dde
from deepxde.backend import backend_name  # ensure DDE_BACKEND=pytorch

theta = dde.Variable(1.0)

def func(x):                     # closes over the trainable theta
    return theta * np.ones((len(x), 1)) if False else theta * x[:, 0:1] * 0 + theta

geom = dde.geometry.Interval(0.0, 1.0)
bc = dde.icbc.DirichletBC(geom, func, lambda _, on: on)

# Build the same X, evaluate the wrapped BC func, change theta, evaluate again.
# On pytorch, the second evaluation returns the theta=1 value (stale) before the
# fix; after the fix it tracks theta=2.
```

A self-contained driver that asserts the `theta` 1→2 update is available in the
issue thread / this package (`driver.py`): before the fix it reports the stale
`[-1,-1]`, after the fix `[-2,-2]`.

---