### PR TITLE
Fix f-string in error message for invalid sampler

### DIFF
--- a/deepxde/geometry/sampler.py
+++ b/deepxde/geometry/sampler.py
@@ -20,7 +20,7 @@ def sample(n_samples, dimension, sampler="pseudo"):
         return pseudorandom(n_samples, dimension)
     if sampler in ["LHS", "Halton", "Hammersley", "Sobol"]:
         return quasirandom(n_samples, dimension, sampler)
-    raise ValueError("f{sampler} sampling is not available.")
+    raise ValueError(f"{sampler} sampling is not available.")
 
 
 def pseudorandom(n_samples, dimension):


### PR DESCRIPTION
Fixes #1305.

The ValueError raised for an unknown sampler in deepxde/geometry/sampler.py has the f prefix inside the quotes, so the message prints the literal text f{sampler} instead of the sampler name.

Verified: sample(10, 2, "bogus") now raises ValueError: bogus sampling is not available.