### PR TITLE
Raise a clear error when an IC/BC function expects auxiliary variables but none are defined

### DIFF
--- a/deepxde/icbc/boundary_conditions.py
+++ b/deepxde/icbc/boundary_conditions.py
@@ -371,6 +371,16 @@ class Interface2DBC:
         return left_values + right_values - values
 
 
+def _check_auxiliary_var(aux_var):
+    if aux_var is None:
+        raise ValueError(
+            "The function used for an IC/BC takes two arguments, so DeepXDE calls it "
+            "as func(X, aux_var), but this problem defines no auxiliary variables "
+            "(auxiliary_var_function in dde.data.PDE). If the function is not meant "
+            "to use auxiliary variables, define it with a single argument func(X)."
+        )
+
+
 def npfunc_range_autocache(func):
     """Call a NumPy function on a range of the input ndarray.
 
@@ -404,6 +414,7 @@ def npfunc_range_autocache(func):
 
     @wraps(func)
     def wrapper_nocache_auxiliary(X, beg, end, aux_var):
+        _check_auxiliary_var(aux_var)
         return func(X[beg:end], aux_var[beg:end])
 
     @wraps(func)
@@ -416,6 +427,7 @@ def npfunc_range_autocache(func):
     @wraps(func)
     def wrapper_cache_auxiliary(X, beg, end, aux_var):
         # Even if X is the same one, aux_var could be different
+        _check_auxiliary_var(aux_var)
         key = (id(X), beg, end)
         if key not in cache:
             cache[key] = func(X[beg:end], aux_var[beg:end])


### PR DESCRIPTION
DeepXDE interprets a two-argument IC/BC function as func(X, aux_var). When the problem defines no auxiliary variables, aux_var is None and npfunc_range_autocache fails on aux_var[beg:end] with:

TypeError: 'NoneType' object is not subscriptable

The traceback points at DeepXDE internals, not at the user's mistake, so this failure is hard to connect to its cause. #698 is an example: the reporter passed a two-argument source term to dde.icbc.IC instead of the one-argument IC function, hit this exact error, and closed the issue months later after finding the mistake on their own. Several other issues in the tracker show the same error text.

This PR adds a guard in the two auxiliary wrappers that raises a ValueError explaining the two-argument interpretation, naming auxiliary_var_function, and suggesting the fix:

ValueError: The function used for an IC/BC takes two arguments, so DeepXDE calls it as func(X, aux_var), but this problem defines no auxiliary variables (auxiliary_var_function in dde.data.PDE). If the function is not meant to use auxiliary variables, define it with a single argument func(X).

Tested with the tensorflow.compat.v1 backend:
- the program from #698 now raises the clear ValueError at compile time
- a two-argument function with auxiliary variables provided passes through unchanged
- a standard TimePDE program with one-argument IC/BC functions trains as before