### PR TITLE
Use random sampling in the heat_resample example so PDEPointResampler resamples

### DIFF
--- a/deepxde/callbacks.py
+++ b/deepxde/callbacks.py
@@ -570,6 +570,11 @@ class MovieDumper(Callback):
 class PDEPointResampler(Callback):
     """Resample the training points for PDE and/or BC losses every given period.
 
+    Note:
+        Use together with random sampling, i.e., ``train_distribution="pseudo"``
+        in the data. Quasirandom distributions such as the default Hammersley are
+        deterministic, so resampling regenerates the same points.
+
     Args:
         period: How often to resample the training points (default is 100 iterations).
         pde_points: If True, resample the training points for PDE losses (default is

--- a/examples/pinn_forward/heat_resample.py
+++ b/examples/pinn_forward/heat_resample.py
@@ -90,6 +90,9 @@ data = dde.data.TimePDE(
     num_domain=2540,
     num_boundary=80,
     num_initial=160,
+    # Random sampling is required for PDEPointResampler to produce new points.
+    # Quasirandom distributions are deterministic and regenerate the same set.
+    train_distribution="pseudo",
     num_test=2540,
 )
 net = dde.nn.FNN([2] + [20] * 3 + [1], "tanh", "Glorot normal")


### PR DESCRIPTION
Fixes #1306.

The heat_resample example attaches PDEPointResampler but builds the data with the default quasirandom train distribution. Quasirandom sequences are deterministic, so resample_train_points regenerates exactly the same points and the example never actually resamples, as reported in #1306. You confirmed there that the resampler should be used together with random sampling and invited a PR.

Verified at the data level:

```python
data = dde.data.TimePDE(geomtime, pde, [], num_domain=100)                              # default
data.resample_train_points()   # train_x_all identical to before: True
data = dde.data.TimePDE(geomtime, pde, [], num_domain=100, train_distribution="pseudo")
data.resample_train_points()   # train_x_all identical to before: False
```

Changes:
- heat_resample.py passes train_distribution="pseudo", matching the diffusion_1d_resample example, with a short comment on why.
- PDEPointResampler docstring gains a note that it needs random sampling, so the requirement is documented at the API and not only inside examples.