### PR TITLE
Standardize shape validation for PointSetOperatorBC

### DIFF
--- a/deepxde/icbc/boundary_conditions.py
+++ b/deepxde/icbc/boundary_conditions.py
@@ -257,8 +257,17 @@ class PointSetOperatorBC:
 
     def __init__(self, points, values, func, batch_size=None, shuffle=True):
         self.points = np.array(points, dtype=config.real(np))
-        if not isinstance(values, numbers.Number) and values.shape[1] != 1:
-            raise RuntimeError("PointSetOperatorBC should output 1D values")
+        if not isinstance(values, numbers.Number):
+            values_arr = np.asarray(values)
+            if values_arr.ndim != 2 or values_arr.shape[1] != 1:
+                raise RuntimeError(
+                    f"PointSetOperatorBC received values of shape {values_arr.shape}, "
+                    f"expected 2D array of shape (N, 1)."
+                )
+            if values_arr.shape[0] != len(self.points):
+                raise RuntimeError(
+                    f"PointSetOperatorBC received {len(self.points)} points but {values_arr.shape[0]} values."
+                )
         self.values = bkd.as_tensor(values, dtype=config.real(bkd.lib))
         self.func = func
         self.batch_size = batch_size


### PR DESCRIPTION
Follow-up to PR #2101. 

### Problem
`PointSetOperatorBC.__init__` checks `values.shape[1] != 1` directly, without 
first confirming `values` is 2D. A 1D array (e.g. `np.ones(10)`, shape `(10,)`) 
raises an unrelated `IndexError: tuple index out of range` before the intended 
validation ever runs. There was also no check that `len(points) == len(values)`.

### Solution
Applied the same validation pattern from #2101 to `PointSetOperatorBC.__init__`:
- Converts `values` to a NumPy array via `np.asarray` before touching `.shape`.
- Validates non-scalar `values` are 2D with `shape == (N, 1)`.
- Validates point count alignment (`len(points) == values_arr.shape[0]`).
- Raises a descriptive `RuntimeError` in place of the previous `IndexError`.

### Testing
Verified locally across both PyTorch and TensorFlow backends:
- 1D input `(10,)` → `RuntimeError` with shape message.
- Column mismatch `(10, 2)` → `RuntimeError` with shape message.
- Point-count mismatch (10 points, 8 values) → `RuntimeError`.
- Valid input `(10, 1)` → passes cleanly, no error.

### Out of scope
`Interface2DBC.error()` has a related but structurally different gap, its 
shape check (`bkd.ndim(values) == 2 and bkd.shape(values)[1] != 1`) silently 
skips validation when `func` returns a 1D array, which can still hit the same 
class of silent-broadcast bug downstream. Not fixing here since it's a 
different constructor pattern (no static `values` array, goes through `bkd` 
tensor ops rather than raw NumPy). Flagging in case it's worth a separate PR.